### PR TITLE
chore: harden repo with dependabot + SECURITY policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: America/Sao_Paulo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - gradle
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+      junit:
+        patterns:
+          - "org.junit*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: America/Sao_Paulo
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "chore(ci)"
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ secrets.properties
 # Claude Code working files
 # ================================
 .claude/scheduled_tasks.lock
-.claude/handover-*.md
 handoff-prompt-*.txt
 research-prompts-*.txt
 

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ secrets.properties
 # Claude Code working files
 # ================================
 .claude/scheduled_tasks.lock
+.claude/handover-*.md
 handoff-prompt-*.txt
 research-prompts-*.txt
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security policy
+
+## Reporting a vulnerability
+
+If you believe you have found a security issue in `kmp-targets`, please **do not** open a public issue. Instead, report it privately via GitHub's security advisory flow:
+
+- <https://github.com/rsicarelli/kmp-targets/security/advisories/new>
+
+I will acknowledge receipt within 7 days and work with you on a coordinated fix. Once a patch is available, the advisory will be published with credit (unless you prefer to remain anonymous).
+
+## Supported versions
+
+The project is in early pre-release (`0.x`). Only the latest published version is supported. Once `1.0.0` ships, this section will be updated with a versioning policy.
+
+## Scope
+
+Security-relevant areas of this repository:
+
+- The Gradle plugin code under `gradle-plugin/` — anything that could affect a consumer's build (e.g. arbitrary code execution during plugin apply, classpath leakage, malicious task wiring).
+- GitHub Actions workflows under `.github/workflows/` — particularly write-permission grants, secret usage, or third-party action references.
+
+Out of scope:
+
+- Vulnerabilities in upstream dependencies (Gradle, Kotlin, etc.) — report those to the respective project. We will track and bump versions via Dependabot.
+- Issues only reproducible by an authenticated maintainer (e.g. settings misconfiguration).
+
+Thanks for helping keep `kmp-targets` and its consumers safe.


### PR DESCRIPTION
## Summary

First pass at repo hardening. Two new files; everything else (settings, workflow token scope, tag ruleset) is already live via the GitHub API.

## Changes

### Files (this PR)
- **`.github/dependabot.yml`** — weekly gradle + github-actions updates, grouped (kotlin, junit, actions), PR-limited (5 gradle, 3 actions), commits prefixed `chore(deps)` / `chore(ci)`, runs Mondays 08:00 BRT.
- **`SECURITY.md`** — private vulnerability reporting flow (GitHub security advisories), scope statement, supported-versions note.

### Applied via API (no diff)
- Repo settings: `allow_auto_merge`, `allow_update_branch`, squash uses PR title/body for commit subject, wiki off, discussions on.
- Workflow `GITHUB_TOKEN` default permission restricted to `read`.
- New tag ruleset on `refs/tags/v*` blocking delete / update / non-fast-forward push.

## Test plan

- [x] `task ci` passes locally — no code touched, but worth confirming.
- [x] Branch protection ruleset will block merge until `Build, test, sample` is green here.
- [ ] After merge: first Dependabot run on Monday should open grouped PRs for any pending bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)