### PR TITLE
feat: implement property-driven KMP target selector

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# kmp-targets — pre-commit hook
+#
+# Runs the same DOD gate as `task dod` but treats `fmt` as a check (read-only)
+# rather than a rewrite, so an unformatted commit is rejected with a clear hint
+# instead of silently modifying the working tree mid-commit.
+#
+# Enable: task hooks:install     (sets core.hooksPath to .githooks)
+# Skip once: git commit --no-verify
+
+set -euo pipefail
+
+if ! command -v task >/dev/null 2>&1; then
+    echo "pre-commit: 'task' is not installed (see .mise.toml). Skipping DOD checks." >&2
+    exit 0
+fi
+
+echo "→ ktfmt check"
+if ! task fmt:check >/dev/null 2>&1; then
+    echo ""
+    echo "✗ Kotlin sources are not formatted." >&2
+    echo "  Run: task fmt && git add -u" >&2
+    exit 1
+fi
+
+echo "→ build"
+task build >/dev/null
+
+echo "→ test"
+task test >/dev/null
+
+echo "✓ DOD checks passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: ./gradlew :gradle-plugin:publishPluginMavenPublicationToMavenLocal :gradle-plugin:publishKmpTargetsPluginMarkerMavenPublicationToMavenLocal
 
       - name: Build sample (hello-world)
-        run: ./gradlew -p samples/hello-world build kmpTargetsHello
+        run: ./gradlew -p samples/hello-world build

--- a/README.md
+++ b/README.md
@@ -2,38 +2,68 @@
 
 > Dynamically select which Kotlin Multiplatform targets to build.
 
-**Status:** bootstrap (pre-release) — the foundation is here; the selector logic ships in the next release.
+**Status:** alpha (pre-1.0). The core selector is implemented and exercised by the sample; per-module configuration and helper APIs (`applyHierarchyTemplate`, XCFramework) are roadmap items.
 
 `kmp-targets` is a Gradle plugin for Kotlin Multiplatform projects that lets each developer (and each CI runner) choose which KMP targets to build, via a single Gradle property:
 
 ```properties
-# local.properties or -P
-KMP_TARGETS=android,iosArm64
+# local.properties, gradle.properties, or -P
+KMP_TARGETS=jvm,iosArm64
 ```
 
-Targets you don't select are never registered with KGP, so their compile/link/KSP/publish tasks never run — cutting Gradle sync and build times dramatically when you only need a subset.
+Targets you don't select are never registered with KGP, so their compile/link/KSP/publish tasks never run — cutting Gradle sync and build times when you only need a subset.
 
-## Intended usage (not yet implemented)
+## Usage
 
 ```kotlin
 // build.gradle.kts
 plugins {
+    kotlin("multiplatform") version "2.3.21"
     id("com.rsicarelli.kmptargets") version "<version>"
-    kotlin("multiplatform")
 }
 ```
 
+Set the selection via any of these sources (priority order, highest first):
+
+1. `-PKMP_TARGETS=...` on the CLI
+2. `ORG_GRADLE_PROJECT_KMP_TARGETS` environment variable
+3. `gradle.properties` (project, then root)
+4. `local.properties` (per-developer, gitignored)
+5. Plugin default — every target the plugin currently knows about
+
+### Selection grammar
+
 ```properties
-# Set in local.properties, as -P flag, or as env var
-KMP_TARGETS=android              # → android + jvm (pairing rule)
-KMP_TARGETS=iosAll               # → all iOS targets (sugar)
-KMP_TARGETS=jvm,iosArm64         # → JVM + iOS device only
-# (absent / blank)               # → all targets (default, no behavior change)
+KMP_TARGETS=android,iosArm64        # explicit list
+KMP_TARGETS=appleMobile             # preset (iosArm64 + iosSimulatorArm64)
+KMP_TARGETS=appleMobile,-iosArm64   # preset minus a leaf
+KMP_TARGETS=apple,+android          # preset plus an addition
+KMP_TARGETS=ANDROID, ios-arm64      # aliases + case-insensitive
 ```
+
+Available presets: `all`, `apple`, `appleMobile`, `appleDesktop`, `web`, `jvmFamily`.
+
+Unknown tokens fail the build at configuration time with a "did you mean ...?" suggestion — silently dropping a misspelled target in CI is the worst failure mode, so the parser is strict.
+
+### Supported targets
+
+This release ships leaves for the most-used target families. Other branches (`watchOS`, `tvOS`, `linux`, `mingw`, `androidNative`) exist as sealed scaffolding and land their leaves in follow-up releases.
+
+| Family | Targets |
+|---|---|
+| JVM | `androidTarget` (alias `android`), `jvm` (alias `desktop`) |
+| iOS | `iosArm64`, `iosSimulatorArm64` |
+| macOS | `macosArm64`, `macosX64` |
+| Web | `js`, `wasmJs`, `wasmWasi` |
 
 ## Installation
 
-Coming soon — see **Status** above. The plugin is not yet published to the Gradle Plugin Portal or Maven Central. Track progress in the issues / releases.
+The plugin is not yet published to the Gradle Plugin Portal or Maven Central. Track progress in the issues / releases. Locally:
+
+```bash
+task publish-local           # publishes :gradle-plugin to mavenLocal
+task sample                  # smoke test against samples/hello-world
+```
 
 ## Development
 
@@ -42,6 +72,8 @@ Requirements: [mise](https://mise.jdx.dev) (pins JDK 23) and [Task](https://task
 ```bash
 mise install        # provisions Temurin 23.0.2+7
 task ci             # build + test + sample
+task dod            # Definition of Done — fmt + build + test (run before committing)
+task hooks:install  # enable the version-controlled .githooks/ pre-commit gate
 ```
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development guide.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,10 +30,10 @@ tasks:
       - "{{.GRADLE}} :gradle-plugin:publishPluginMavenPublicationToMavenLocal :gradle-plugin:publishKmpTargetsPluginMarkerMavenPublicationToMavenLocal"
 
   sample:
-    desc: Run the hello-world sample (depends on publish-local)
+    desc: Quick smoke — plugin applies and registers KMP targets (depends on publish-local)
     deps: [publish-local]
     cmds:
-      - "{{.GRADLE}} -p samples/hello-world kmpTargetsHello"
+      - "{{.GRADLE}} -p samples/hello-world help"
 
   sample:build:
     desc: Build the hello-world sample (depends on publish-local)
@@ -48,6 +48,25 @@ tasks:
       - task: sample
       - task: sample:build
 
+  dod:
+    desc: Definition of Done — fmt + build + test (run before committing)
+    cmds:
+      - task: fmt
+      - task: build
+      - task: test
+
+  hooks:install:
+    desc: Enable the version-controlled .githooks/ directory (pre-commit DOD gate)
+    cmds:
+      - git config core.hooksPath .githooks
+      - echo "✓ git hooks enabled (.githooks/). Skip once with 'git commit --no-verify'."
+
+  hooks:uninstall:
+    desc: Restore Git's default .git/hooks/ directory
+    cmds:
+      - git config --unset core.hooksPath
+      - echo "✓ git hooks disabled (back to .git/hooks/)."
+
   clean:
     desc: Clean root build + sample build artifacts
     cmds:
@@ -55,6 +74,11 @@ tasks:
       - rm -rf samples/hello-world/build samples/hello-world/.gradle
 
   fmt:
-    desc: Format code (placeholder — spotless wired in next PR)
+    desc: Format Kotlin sources with ktfmt (kotlinlang style)
     cmds:
-      - 'echo "fmt: not yet wired — coming next PR"'
+      - "{{.GRADLE}} :gradle-plugin:ktfmtFormat"
+
+  fmt:check:
+    desc: Verify Kotlin sources are ktfmt-formatted (run by `task check`)
+    cmds:
+      - "{{.GRADLE}} :gradle-plugin:ktfmtCheck"

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,17 +1,19 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ktfmt)
     `java-gradle-plugin`
     `maven-publish`
 }
 
-kotlin {
-    jvmToolchain(23)
-}
+kotlin { jvmToolchain(23) }
+
+ktfmt { kotlinLangStyle() }
 
 dependencies {
     compileOnly(libs.kotlin.gradlePlugin)
 
     testImplementation(gradleTestKit())
+    testImplementation(libs.kotlin.gradlePlugin)
     testImplementation(libs.junit.jupiter)
     testImplementation(kotlin("test-junit5"))
 }
@@ -24,7 +26,8 @@ gradlePlugin {
             id = "com.rsicarelli.kmptargets"
             implementationClass = "com.rsicarelli.kmptargets.KmpTargetsPlugin"
             displayName = "KMP Targets"
-            description = "Dynamically select which Kotlin Multiplatform targets to build via the KMP_TARGETS Gradle property."
+            description =
+                "Dynamically select which Kotlin Multiplatform targets to build via the KMP_TARGETS Gradle property."
             tags.set(listOf("kotlin", "kmp", "multiplatform", "build", "ios", "android"))
         }
     }
@@ -38,6 +41,6 @@ publishing {
     }
 }
 
-tasks.test {
-    useJUnitPlatform()
-}
+tasks.test { useJUnitPlatform() }
+
+tasks.named("check") { dependsOn("ktfmtCheck") }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -1,0 +1,41 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import org.gradle.api.provider.Property
+
+/**
+ * Public DSL surface exposed by the plugin as the `kmpTargets` extension.
+ *
+ * [selection] is the resolved target set the plugin will register with KGP. The plugin sets a
+ * convention on it (parsed from the `KMP_TARGETS` property, falling back to [fallback]), and the
+ * user can override it explicitly via [selection.set], or via the [only] / [exclude] helpers for
+ * common cases.
+ *
+ * [fallback] is consulted only when `KMP_TARGETS` is absent. Convention: [KmpTargetSet.all].
+ *
+ * Both properties hold immutable `KmpTargetSet` values composed of `data object` leaves, so the
+ * extension itself is configuration-cache safe — no `Project` or mutable state is captured.
+ */
+public abstract class KmpTargetsExtension {
+
+    public abstract val selection: Property<KmpTargetSet>
+
+    public abstract val fallback: Property<KmpTargetSet>
+
+    /** Replaces the current selection with exactly [targets]. Last write wins. */
+    public fun only(vararg targets: KmpTarget) {
+        selection.set(KmpTargetSet.of(*targets))
+    }
+
+    /**
+     * Removes [targets] from the current selection. Resolves the current value eagerly against
+     * [selection] (which may carry a convention from the plugin) and falls back to [fallback] or
+     * [KmpTargetSet.empty] if neither is set.
+     */
+    public fun exclude(vararg targets: KmpTarget) {
+        val excluded = KmpTargetSet.of(*targets)
+        val current = selection.orNull ?: fallback.orNull ?: KmpTargetSet.empty
+        selection.set(current - excluded)
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -1,17 +1,85 @@
 package com.rsicarelli.kmptargets
 
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import com.rsicarelli.kmptargets.parser.ParseResult
+import com.rsicarelli.kmptargets.parser.parseKmpTargets
+import com.rsicarelli.kmptargets.source.EnvironmentVariableSource
+import com.rsicarelli.kmptargets.source.GradlePropertySource
+import com.rsicarelli.kmptargets.source.LocalPropertyValueSource
+import com.rsicarelli.kmptargets.source.SelectionSource
+import com.rsicarelli.kmptargets.source.composeSelectionSources
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 public class KmpTargetsPlugin : Plugin<Project> {
+
     override fun apply(target: Project) {
-        val projectPath = target.path
-        target.tasks.register("kmpTargetsHello") { task ->
-            task.group = "kmp-targets"
-            task.description = "Prints a hello message — bootstrap placeholder until the real selector lands."
-            task.doLast {
-                println("kmp-targets plugin applied to $projectPath")
-            }
+        val ext = target.extensions.create("kmpTargets", KmpTargetsExtension::class.java)
+        ext.fallback.convention(KmpTargetSet.all)
+
+        val sources =
+            composeSelectionSources(
+                GradlePropertySource(target.providers, PROPERTY_NAME),
+                EnvironmentVariableSource(target.providers, PROPERTY_NAME),
+                localPropertiesSource(target),
+            )
+
+        val raw: String? = sources.read()
+        val parsedFromProperty: KmpTargetSet? = raw?.let { parseOrThrow(it) }
+
+        if (parsedFromProperty != null && parsedFromProperty.isNotEmpty()) {
+            ext.selection.convention(parsedFromProperty)
+        } else {
+            ext.selection.convention(ext.fallback)
         }
+
+        target.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+            val kotlin = target.extensions.getByType(KotlinMultiplatformExtension::class.java)
+            ext.selection.get().forEach { kmp -> registerTarget(kotlin, kmp) }
+        }
+    }
+
+    private fun localPropertiesSource(target: Project): SelectionSource {
+        val provider =
+            target.providers.of(LocalPropertyValueSource::class.java) {
+                it.parameters.rootDir.set(target.rootDir)
+                it.parameters.propertyName.set(PROPERTY_NAME)
+            }
+        return SelectionSource { provider.orNull }
+    }
+
+    private fun parseOrThrow(raw: String): KmpTargetSet =
+        when (val r = parseKmpTargets(raw)) {
+            is ParseResult.Ok -> r.set
+            is ParseResult.Err -> throw GradleException(r.message)
+        }
+
+    private fun registerTarget(kotlin: KotlinMultiplatformExtension, target: KmpTarget) {
+        when (target) {
+            KmpTarget.Jvm.Android -> kotlin.androidTarget()
+            KmpTarget.Jvm.Desktop -> kotlin.jvm()
+            KmpTarget.Native.Apple.Ios.Arm64 -> kotlin.iosArm64()
+            KmpTarget.Native.Apple.Ios.SimulatorArm64 -> kotlin.iosSimulatorArm64()
+            KmpTarget.Native.Apple.Macos.Arm64 -> kotlin.macosArm64()
+            KmpTarget.Native.Apple.Macos.X64 -> kotlin.macosX64()
+            KmpTarget.Web.Js ->
+                kotlin.js {
+                    browser()
+                    nodejs()
+                }
+            KmpTarget.Web.WasmJs ->
+                kotlin.wasmJs {
+                    browser()
+                    nodejs()
+                }
+            KmpTarget.Web.WasmWasi -> kotlin.wasmWasi { nodejs() }
+        }
+    }
+
+    private companion object {
+        const val PROPERTY_NAME: String = "KMP_TARGETS"
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTarget.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTarget.kt
@@ -1,0 +1,111 @@
+package com.rsicarelli.kmptargets.model
+
+/**
+ * Every Kotlin Multiplatform target the plugin knows about is a leaf in this sealed hierarchy.
+ *
+ * Branches ([Jvm], [Native], [Native.Apple], [Native.Apple.Ios], [Web], ...) are themselves sealed,
+ * so a `when` over a branch type is exhaustive — adding a new leaf to a branch forces every call
+ * site that pattern-matches on that branch to handle it.
+ *
+ * [id] is the canonical KGP preset name (e.g. `iosArm64`, `androidTarget`) and is the single source
+ * of truth for property strings, target registration, and serialization.
+ *
+ * [aliases] are case-insensitive alternate spellings accepted by the property parser. They must
+ * never collide with another leaf's [id].
+ */
+public sealed interface KmpTarget {
+
+    public val id: String
+
+    public val aliases: Set<String>
+
+    public sealed interface Jvm : KmpTarget {
+
+        public data object Android : Jvm {
+            override val id: String = "androidTarget"
+            override val aliases: Set<String> = setOf("android")
+        }
+
+        public data object Desktop : Jvm {
+            override val id: String = "jvm"
+            override val aliases: Set<String> = setOf("desktop")
+        }
+    }
+
+    public sealed interface Native : KmpTarget {
+
+        public sealed interface Apple : Native {
+
+            public sealed interface Ios : Apple {
+
+                public data object Arm64 : Ios {
+                    override val id: String = "iosArm64"
+                    override val aliases: Set<String> = setOf("ios-arm64")
+                }
+
+                public data object SimulatorArm64 : Ios {
+                    override val id: String = "iosSimulatorArm64"
+                    override val aliases: Set<String> =
+                        setOf("ios-sim-arm64", "ios-simulator-arm64")
+                }
+            }
+
+            public sealed interface Macos : Apple {
+
+                public data object Arm64 : Macos {
+                    override val id: String = "macosArm64"
+                    override val aliases: Set<String> = setOf("macos-arm64")
+                }
+
+                public data object X64 : Macos {
+                    override val id: String = "macosX64"
+                    override val aliases: Set<String> = setOf("macos-x64")
+                }
+            }
+
+            public sealed interface Watchos : Apple
+
+            public sealed interface Tvos : Apple
+        }
+
+        public sealed interface Linux : Native
+
+        public sealed interface Mingw : Native
+
+        public sealed interface AndroidNative : Native
+    }
+
+    public sealed interface Web : KmpTarget {
+
+        public data object Js : Web {
+            override val id: String = "js"
+            override val aliases: Set<String> = emptySet()
+        }
+
+        public data object WasmJs : Web {
+            override val id: String = "wasmJs"
+            override val aliases: Set<String> = setOf("wasm-js")
+        }
+
+        public data object WasmWasi : Web {
+            override val id: String = "wasmWasi"
+            override val aliases: Set<String> = setOf("wasm-wasi")
+        }
+    }
+
+    public companion object {
+
+        public val all: Set<KmpTarget> =
+            setOf(
+                Jvm.Android,
+                Jvm.Desktop,
+                Native.Apple.Ios.Arm64,
+                Native.Apple.Ios.SimulatorArm64,
+                Native.Apple.Macos.Arm64,
+                Native.Apple.Macos.X64,
+                Web.Js,
+                Web.WasmJs,
+                Web.WasmWasi,
+            )
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSet.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSet.kt
@@ -1,0 +1,67 @@
+package com.rsicarelli.kmptargets.model
+
+/**
+ * Immutable, value-typed selection of [KmpTarget]s.
+ *
+ * Behaves like a [Set] via interface delegation, so `in`, `size`, iteration and collection
+ * extensions all work directly. All algebraic operations ([plus], [minus]) return new instances —
+ * instances are never mutated.
+ *
+ * Members of this set are `data object` singletons, which makes the value Serializable as-is and
+ * therefore safe to capture in Gradle's configuration cache without further work.
+ */
+@JvmInline
+public value class KmpTargetSet private constructor(public val members: Set<KmpTarget>) :
+    Iterable<KmpTarget> {
+
+    public val size: Int
+        get() = members.size
+
+    public fun isEmpty(): Boolean = members.isEmpty()
+
+    public fun isNotEmpty(): Boolean = members.isNotEmpty()
+
+    public operator fun contains(target: KmpTarget): Boolean = target in members
+
+    override fun iterator(): Iterator<KmpTarget> = members.iterator()
+
+    public operator fun plus(other: KmpTarget): KmpTargetSet = KmpTargetSet(members + other)
+
+    public operator fun plus(other: KmpTargetSet): KmpTargetSet =
+        KmpTargetSet(members + other.members)
+
+    public operator fun minus(other: KmpTarget): KmpTargetSet = KmpTargetSet(members - other)
+
+    public operator fun minus(other: KmpTargetSet): KmpTargetSet =
+        KmpTargetSet(members - other.members)
+
+    override fun toString(): String =
+        members.joinToString(prefix = "KmpTargetSet(", postfix = ")") { it.id }
+
+    public companion object {
+
+        public val empty: KmpTargetSet = KmpTargetSet(emptySet())
+
+        public val all: KmpTargetSet = KmpTargetSet(KmpTarget.all)
+
+        public val appleMobile: KmpTargetSet =
+            KmpTargetSet(
+                setOf(KmpTarget.Native.Apple.Ios.Arm64, KmpTarget.Native.Apple.Ios.SimulatorArm64)
+            )
+
+        public val appleDesktop: KmpTargetSet =
+            KmpTargetSet(
+                setOf(KmpTarget.Native.Apple.Macos.Arm64, KmpTarget.Native.Apple.Macos.X64)
+            )
+
+        public val apple: KmpTargetSet = KmpTargetSet(appleMobile.members + appleDesktop.members)
+
+        public val web: KmpTargetSet =
+            KmpTargetSet(setOf(KmpTarget.Web.Js, KmpTarget.Web.WasmJs, KmpTarget.Web.WasmWasi))
+
+        public val jvmFamily: KmpTargetSet =
+            KmpTargetSet(setOf(KmpTarget.Jvm.Android, KmpTarget.Jvm.Desktop))
+
+        public fun of(vararg targets: KmpTarget): KmpTargetSet = KmpTargetSet(targets.toSet())
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/DidYouMean.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/DidYouMean.kt
@@ -1,0 +1,62 @@
+package com.rsicarelli.kmptargets.parser
+
+/**
+ * Returns the candidate string closest to [input] by Levenshtein edit distance, or `null` if no
+ * candidate is within [maxDistance] edits.
+ *
+ * If [input] matches a candidate exactly (case-sensitive), returns `null` — the caller already had
+ * a hit and a suggestion would be noise. If [input] matches case-insensitively but with different
+ * casing, the canonical-cased candidate is returned (so users learn the preferred form).
+ *
+ * Ties are broken by shorter candidate (a short canonical name is a better suggestion than a longer
+ * one when they're equally distant).
+ */
+internal fun didYouMean(
+    input: String,
+    candidates: Collection<String>,
+    maxDistance: Int = 2,
+): String? {
+    if (input.isEmpty() || candidates.isEmpty()) return null
+    if (input in candidates) return null
+
+    val caseInsensitive = candidates.firstOrNull { it.equals(input, ignoreCase = true) }
+    if (caseInsensitive != null) return caseInsensitive
+
+    val normalized = input.lowercase()
+    var best: String? = null
+    var bestDistance = Int.MAX_VALUE
+
+    for (candidate in candidates) {
+        val distance = levenshtein(normalized, candidate.lowercase())
+        if (distance > maxDistance) continue
+        val isBetter =
+            distance < bestDistance ||
+                (distance == bestDistance && best != null && candidate.length < best.length)
+        if (isBetter) {
+            best = candidate
+            bestDistance = distance
+        }
+    }
+    return best
+}
+
+private fun levenshtein(a: String, b: String): Int {
+    if (a == b) return 0
+    if (a.isEmpty()) return b.length
+    if (b.isEmpty()) return a.length
+
+    var prev = IntArray(b.length + 1) { it }
+    var curr = IntArray(b.length + 1)
+
+    for (i in 1..a.length) {
+        curr[0] = i
+        for (j in 1..b.length) {
+            val cost = if (a[i - 1] == b[j - 1]) 0 else 1
+            curr[j] = minOf(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost)
+        }
+        val swap = prev
+        prev = curr
+        curr = swap
+    }
+    return prev[b.length]
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParser.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParser.kt
@@ -1,0 +1,127 @@
+package com.rsicarelli.kmptargets.parser
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+
+/**
+ * Parses a `KMP_TARGETS` value into a [KmpTargetSet].
+ *
+ * Grammar (informal):
+ * ```
+ * expr   := atom (',' atom)*
+ * atom   := ('+' | '-')? token
+ * token  := <leaf-id> | <leaf-alias> | <preset-name>
+ * preset := "all" | "appleMobile" | "appleDesktop" | "apple" | "web" | "jvmFamily"
+ * ```
+ *
+ * Resolution is a left-to-right fold. The first token may omit a sign (defaults to additive).
+ * Tokens are trimmed and matched case-insensitively against canonical ids, aliases, and preset
+ * names.
+ *
+ * - Unknown tokens fail strictly, with a did-you-mean suggestion if a known token is within edit
+ *   distance 2.
+ * - Bare family names ([FAMILY_HINTS]) fail with a hint pointing at the relevant preset or leaf.
+ * - Empty input (or input containing only separators) returns [ParseResult.Ok] with
+ *   [KmpTargetSet.empty] and a warning; the plugin then falls back to its configured default
+ *   selection.
+ */
+public fun parseKmpTargets(raw: String, registry: Set<KmpTarget> = KmpTarget.all): ParseResult {
+    val tokens = raw.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+    if (tokens.isEmpty()) {
+        return ParseResult.Ok(
+            KmpTargetSet.empty,
+            warnings = listOf("KMP_TARGETS is empty; using fallback selection"),
+        )
+    }
+
+    val byCanonical: Map<String, KmpTarget> = registry.associateBy { it.id.lowercase() }
+    val byAlias: Map<String, KmpTarget> = buildMap {
+        registry.forEach { target ->
+            target.aliases.forEach { alias -> put(alias.lowercase(), target) }
+        }
+    }
+    val presets: Map<String, KmpTargetSet> = PRESETS
+
+    val knownNames: Set<String> = byCanonical.keys + byAlias.keys + presets.keys
+
+    var accumulator = KmpTargetSet.empty
+    for (rawToken in tokens) {
+        val (sign, name) = splitSign(rawToken)
+        if (name.isEmpty()) {
+            return ParseResult.Err(
+                message = "KMP_TARGETS token '$rawToken' has a sign but no target name",
+                offendingToken = rawToken,
+            )
+        }
+        val lower = name.lowercase()
+        val resolved: KmpTargetSet =
+            byCanonical[lower]?.let { KmpTargetSet.of(it) }
+                ?: byAlias[lower]?.let { KmpTargetSet.of(it) }
+                ?: presets[lower]
+                ?: return ParseResult.Err(
+                    message = unknownTokenMessage(name, lower, knownNames),
+                    offendingToken = name,
+                )
+        accumulator =
+            when (sign) {
+                '+' -> accumulator + resolved
+                '-' -> accumulator - resolved
+                else -> error("unreachable sign: $sign")
+            }
+    }
+    return ParseResult.Ok(accumulator)
+}
+
+private val PRESETS: Map<String, KmpTargetSet> =
+    mapOf(
+        "all" to KmpTargetSet.all,
+        "applemobile" to KmpTargetSet.appleMobile,
+        "appledesktop" to KmpTargetSet.appleDesktop,
+        "apple" to KmpTargetSet.apple,
+        "web" to KmpTargetSet.web,
+        "jvmfamily" to KmpTargetSet.jvmFamily,
+    )
+
+/**
+ * Lowercase family names users commonly try to use as selectors. None of them resolve to a leaf,
+ * alias, or preset — but they're close enough to user intent to deserve a tailored error rather
+ * than a generic did-you-mean.
+ */
+private val FAMILY_HINTS: Map<String, String> =
+    mapOf(
+        "ios" to
+            "use a specific leaf like 'iosArm64' or 'iosSimulatorArm64', or the 'appleMobile' preset",
+        "macos" to
+            "use a specific leaf like 'macosArm64' or 'macosX64', or the 'appleDesktop' preset",
+        "watchos" to "no watchOS leaves are shipped yet — track the roadmap for support",
+        "tvos" to "no tvOS leaves are shipped yet — track the roadmap for support",
+        "linux" to "no Linux leaves are shipped yet — track the roadmap for support",
+        "mingw" to "no MinGW leaves are shipped yet — track the roadmap for support",
+        "androidnative" to
+            "no Android Native leaves are shipped yet — track the roadmap for support",
+        "native" to
+            "'native' covers many platforms — use a specific leaf or a family preset like 'apple'",
+    )
+
+private fun splitSign(token: String): Pair<Char, String> =
+    when {
+        token.startsWith('+') -> '+' to token.substring(1).trim()
+        token.startsWith('-') -> '-' to token.substring(1).trim()
+        else -> '+' to token
+    }
+
+private fun unknownTokenMessage(
+    original: String,
+    lowered: String,
+    knownNames: Set<String>,
+): String {
+    FAMILY_HINTS[lowered]?.let { hint ->
+        return "KMP_TARGETS: '$original' is a target family, not a selectable target — $hint"
+    }
+    val suggestion = didYouMean(lowered, knownNames)
+    return if (suggestion != null) {
+        "KMP_TARGETS: unknown target '$original' — did you mean '$suggestion'?"
+    } else {
+        "KMP_TARGETS: unknown target '$original'"
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/ParseResult.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/ParseResult.kt
@@ -1,0 +1,18 @@
+package com.rsicarelli.kmptargets.parser
+
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+
+/**
+ * Outcome of parsing a `KMP_TARGETS` string into a [KmpTargetSet].
+ *
+ * [Ok] carries the resolved selection plus any non-fatal warnings (empty input, redundant tokens,
+ * etc). [Err] carries a human-readable message and the offending token (when applicable) so the
+ * plugin can fail the build with a precise diagnostic.
+ */
+public sealed interface ParseResult {
+
+    public data class Ok(val set: KmpTargetSet, val warnings: List<String> = emptyList()) :
+        ParseResult
+
+    public data class Err(val message: String, val offendingToken: String?) : ParseResult
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/LocalPropertyValueSource.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/LocalPropertyValueSource.kt
@@ -1,0 +1,29 @@
+package com.rsicarelli.kmptargets.source
+
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+
+/**
+ * Gradle [ValueSource] wrapper around [LocalPropertiesSource] so the plugin's read of
+ * `local.properties` is tracked as a configuration-cache input. Direct file reads at configuration
+ * time would otherwise bypass the cache fingerprint.
+ *
+ * Used internally by the plugin; tests exercise the underlying [LocalPropertiesSource] directly.
+ */
+internal abstract class LocalPropertyValueSource :
+    ValueSource<String, LocalPropertyValueSource.Params> {
+
+    interface Params : ValueSourceParameters {
+        val rootDir: DirectoryProperty
+        val propertyName: Property<String>
+    }
+
+    override fun obtain(): String? =
+        LocalPropertiesSource(
+                rootDir = parameters.rootDir.asFile.get(),
+                propertyName = parameters.propertyName.get(),
+            )
+            .read()
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/SelectionSource.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/SelectionSource.kt
@@ -1,0 +1,18 @@
+package com.rsicarelli.kmptargets.source
+
+/**
+ * A source that can produce a raw `KMP_TARGETS` string (e.g. from a Gradle property, an environment
+ * variable, or a `local.properties` file).
+ *
+ * Implementations return `null` to mean **absent**; an empty string means **present but blank**
+ * (the parser will treat that as "use the fallback selection" and emit a warning). The distinction
+ * matters for composition: a `null` source defers to the next source in priority order; an explicit
+ * empty does not.
+ *
+ * This is the isolation point for future YAML/TOML/JSON sources — add a new implementation and
+ * compose it with [composeSelectionSources].
+ */
+public fun interface SelectionSource {
+
+    public fun read(): String?
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/SelectionSources.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/SelectionSources.kt
@@ -1,0 +1,60 @@
+package com.rsicarelli.kmptargets.source
+
+import java.io.File
+import java.util.Properties
+import org.gradle.api.provider.ProviderFactory
+
+/**
+ * Returns a [SelectionSource] that delegates to each [sources] in order and yields the first
+ * non-null result. An empty composition (no sources) reads as `null`.
+ */
+public fun composeSelectionSources(vararg sources: SelectionSource): SelectionSource =
+    SelectionSource {
+        sources.firstNotNullOfOrNull { it.read() }
+    }
+
+/**
+ * Reads `KMP_TARGETS` from a Gradle property (`-P<name>=...` or `gradle.properties`).
+ *
+ * The [providers] reference is captured at construction and the property value is fetched lazily on
+ * each [read] call, so the Gradle configuration cache treats the property as a tracked input via
+ * the normal `ProviderFactory` mechanism.
+ */
+public class GradlePropertySource(
+    private val providers: ProviderFactory,
+    private val name: String,
+) : SelectionSource {
+
+    override fun read(): String? = providers.gradleProperty(name).orNull
+}
+
+/**
+ * Reads `KMP_TARGETS` from an environment variable. Same configuration-cache contract as
+ * [GradlePropertySource].
+ */
+public class EnvironmentVariableSource(
+    private val providers: ProviderFactory,
+    private val name: String,
+) : SelectionSource {
+
+    override fun read(): String? = providers.environmentVariable(name).orNull
+}
+
+/**
+ * Reads `KMP_TARGETS` from a `local.properties` file in [rootDir].
+ *
+ * This implementation reads the file directly; the plugin wraps it in a Gradle `ValueSource` so the
+ * file is tracked as a configuration-cache input. Used directly (without that wrapper) only in
+ * tests.
+ */
+public class LocalPropertiesSource(private val rootDir: File, private val propertyName: String) :
+    SelectionSource {
+
+    override fun read(): String? {
+        val file = rootDir.resolve("local.properties")
+        if (!file.exists()) return null
+        val properties = Properties()
+        file.inputStream().use(properties::load)
+        return properties.getProperty(propertyName)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
@@ -1,0 +1,87 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+class KmpTargetsExtensionTest {
+
+    @Test
+    fun `given extension created when selection accessed then property is present and unset`() {
+        val ext = newExtension()
+        assertFalse(ext.selection.isPresent)
+    }
+
+    @Test
+    fun `given extension created when fallback accessed then property is present and unset`() {
+        val ext = newExtension()
+        assertFalse(ext.fallback.isPresent)
+    }
+
+    @Test
+    fun `given only when called then selection contains exactly those targets`() {
+        val ext = newExtension()
+        ext.only(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64)
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64),
+            ext.selection.get(),
+        )
+    }
+
+    @Test
+    fun `given only called with no targets when invoked then selection is empty`() {
+        val ext = newExtension()
+        ext.only()
+        assertEquals(KmpTargetSet.empty, ext.selection.get())
+    }
+
+    @Test
+    fun `given convention set when exclude is called then selection is convention minus excluded`() {
+        val ext = newExtension()
+        ext.selection.convention(KmpTargetSet.appleMobile)
+        ext.exclude(KmpTarget.Native.Apple.Ios.SimulatorArm64)
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.selection.get())
+    }
+
+    @Test
+    fun `given fallback set and no selection when exclude is called then exclude resolves against fallback`() {
+        val ext = newExtension()
+        ext.fallback.set(KmpTargetSet.appleMobile)
+        ext.exclude(KmpTarget.Native.Apple.Ios.SimulatorArm64)
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.selection.get())
+    }
+
+    @Test
+    fun `given neither selection nor fallback when exclude is called then selection is empty`() {
+        val ext = newExtension()
+        ext.exclude(KmpTarget.Jvm.Android)
+        assertEquals(KmpTargetSet.empty, ext.selection.get())
+    }
+
+    @Test
+    fun `given only then exclude when invoked then exclude applies to the only-set value`() {
+        val ext = newExtension()
+        ext.only(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64)
+        ext.exclude(KmpTarget.Jvm.Android)
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.selection.get())
+    }
+
+    @Test
+    fun `given fallback set when selection is read then selection still empty until convention applied`() {
+        val ext = newExtension()
+        ext.fallback.set(KmpTargetSet.web)
+        // Setting fallback doesn't auto-populate selection — that's the plugin's job
+        assertFalse(ext.selection.isPresent)
+        assertTrue(ext.fallback.isPresent)
+        assertEquals(KmpTargetSet.web, ext.fallback.get())
+    }
+
+    private fun newExtension(): KmpTargetsExtension {
+        val project = ProjectBuilder.builder().build()
+        return project.extensions.create("kmpTargets", KmpTargetsExtension::class.java)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
@@ -1,57 +1,153 @@
 package com.rsicarelli.kmptargets
 
-import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.TempDir
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
 import java.nio.file.Path
 import kotlin.io.path.writeText
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 
 class KmpTargetsPluginTest {
 
     @Test
-    fun `given plugin applied when running kmpTargetsHello then prints message`(@TempDir projectDir: Path) {
-        writeProject(projectDir)
+    fun `given plugin applied to project when extension is queried then KmpTargetsExtension is registered`(
+        @TempDir dir: Path
+    ) {
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.findByType(KmpTargetsExtension::class.java)
+        assertNotNull(ext)
+    }
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir.toFile())
-            .withPluginClasspath()
-            .withArguments("kmpTargetsHello", "--stacktrace")
-            .build()
+    @Test
+    fun `given plugin applied without any property when selection is read then equals fallback default KmpTargetSet all`(
+        @TempDir dir: Path
+    ) {
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(KmpTargetSet.all, ext.selection.get())
+    }
 
-        assertEquals(TaskOutcome.SUCCESS, result.task(":kmpTargetsHello")?.outcome)
-        assertTrue(
-            result.output.contains("kmp-targets plugin applied to :"),
-            "Expected hello message in output, got:\n${result.output}",
+    @Test
+    fun `given KMP_TARGETS gradle property is set when selection is read then it reflects the parsed value`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=android,iosArm64\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64),
+            ext.selection.get(),
         )
     }
 
     @Test
-    fun `given plugin applied when listing tasks then kmpTargetsHello appears under kmp-targets group`(@TempDir projectDir: Path) {
-        writeProject(projectDir)
+    fun `given KMP_TARGETS gradle property is appleMobile when selection is read then it equals KmpTargetSet appleMobile`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=appleMobile\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(KmpTargetSet.appleMobile, ext.selection.get())
+    }
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir.toFile())
-            .withPluginClasspath()
-            .withArguments("tasks", "--group", "kmp-targets")
-            .build()
+    @Test
+    fun `given user fallback override when plugin applied without property then selection equals that fallback`(
+        @TempDir dir: Path
+    ) {
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        ext.fallback.set(KmpTargetSet.web)
+        assertEquals(KmpTargetSet.web, ext.selection.get())
+    }
 
+    @Test
+    fun `given user only override when plugin applied with property set then user value wins`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=android\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        ext.only(KmpTarget.Native.Apple.Ios.Arm64)
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.selection.get())
+    }
+
+    @Test
+    fun `given KMP_TARGETS is invalid when plugin is applied then a GradleException surfaces in the failure chain`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=invalidToken\n")
+        val project = newProject(dir)
+        val ex =
+            assertFailsWith<Exception> { project.pluginManager.apply("com.rsicarelli.kmptargets") }
+        // Apply wraps the GradleException; walk the chain to find the one carrying the parser's
+        // message.
+        val rootCause =
+            generateSequence(ex as Throwable?) { it.cause }
+                .firstOrNull { it.message?.contains("KMP_TARGETS") == true }
+        assertNotNull(rootCause, "expected KMP_TARGETS-tagged cause in chain, root: ${ex.message}")
         assertTrue(
-            result.output.contains("kmpTargetsHello"),
-            "Expected kmpTargetsHello task listed, got:\n${result.output}",
+            rootCause.message!!.contains("invalidToken"),
+            "expected message to include offending token, got: ${rootCause.message}",
         )
     }
 
-    private fun writeProject(projectDir: Path) {
-        projectDir.resolve("settings.gradle.kts").writeText("rootProject.name = \"under-test\"\n")
-        projectDir.resolve("build.gradle.kts").writeText(
-            """
-            plugins {
-                id("com.rsicarelli.kmptargets")
-            }
-            """.trimIndent(),
-        )
+    @Test
+    fun `given KMP_TARGETS in local properties when plugin applied then selection reflects that value`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("local.properties").writeText("KMP_TARGETS=android\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Android), ext.selection.get())
     }
+
+    @Test
+    fun `given KMP_TARGETS in both gradle properties and local properties when plugin applied then gradle property wins`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=iosArm64\n")
+        dir.resolve("local.properties").writeText("KMP_TARGETS=android\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.selection.get())
+    }
+
+    @Test
+    fun `given KMP_TARGETS is blank when plugin applied then selection falls back to default`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        // A blank property is not "I want zero targets" — it's "I'm not overriding"; fallback wins.
+        assertEquals(KmpTargetSet.all, ext.selection.get())
+    }
+
+    @Test
+    fun `given the legacy placeholder task name when listed then it does not exist`(
+        @TempDir dir: Path
+    ) {
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        // The bootstrap placeholder task has been replaced with the real selector wiring.
+        assertEquals(null, project.tasks.findByName("kmpTargetsHello"))
+    }
+
+    private fun newProject(dir: Path): Project =
+        ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
 }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSetTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSetTest.kt
@@ -1,0 +1,134 @@
+package com.rsicarelli.kmptargets.model
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class KmpTargetSetTest {
+
+    @Test
+    fun `given empty preset when accessed then has zero members`() {
+        assertEquals(0, KmpTargetSet.empty.size)
+        assertTrue(KmpTargetSet.empty.isEmpty())
+    }
+
+    @Test
+    fun `given all preset when accessed then equals KmpTarget all`() {
+        assertEquals(KmpTarget.all, KmpTargetSet.all.members)
+    }
+
+    @Test
+    fun `given appleMobile preset when accessed then contains exactly the iOS leaves`() {
+        val expected =
+            setOf<KmpTarget>(
+                KmpTarget.Native.Apple.Ios.Arm64,
+                KmpTarget.Native.Apple.Ios.SimulatorArm64,
+            )
+        assertEquals(expected, KmpTargetSet.appleMobile.members)
+    }
+
+    @Test
+    fun `given appleDesktop preset when accessed then contains exactly the macOS leaves`() {
+        val expected =
+            setOf<KmpTarget>(KmpTarget.Native.Apple.Macos.Arm64, KmpTarget.Native.Apple.Macos.X64)
+        assertEquals(expected, KmpTargetSet.appleDesktop.members)
+    }
+
+    @Test
+    fun `given apple preset when accessed then equals appleMobile plus appleDesktop`() {
+        val expected = KmpTargetSet.appleMobile.members + KmpTargetSet.appleDesktop.members
+        assertEquals(expected, KmpTargetSet.apple.members)
+    }
+
+    @Test
+    fun `given web preset when accessed then contains exactly Js WasmJs WasmWasi`() {
+        val expected =
+            setOf<KmpTarget>(KmpTarget.Web.Js, KmpTarget.Web.WasmJs, KmpTarget.Web.WasmWasi)
+        assertEquals(expected, KmpTargetSet.web.members)
+    }
+
+    @Test
+    fun `given jvmFamily preset when accessed then contains Android and Desktop`() {
+        val expected = setOf<KmpTarget>(KmpTarget.Jvm.Android, KmpTarget.Jvm.Desktop)
+        assertEquals(expected, KmpTargetSet.jvmFamily.members)
+    }
+
+    @Test
+    fun `given of with varargs when constructed then contains every passed target`() {
+        val set = KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Web.Js)
+        assertEquals(setOf<KmpTarget>(KmpTarget.Jvm.Android, KmpTarget.Web.Js), set.members)
+    }
+
+    @Test
+    fun `given of with duplicates when constructed then duplicates are collapsed`() {
+        val set = KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Jvm.Android)
+        assertEquals(1, set.size)
+    }
+
+    @Test
+    fun `given a set when adding a target then result includes that target`() {
+        val base = KmpTargetSet.of(KmpTarget.Jvm.Android)
+        val result = base + KmpTarget.Web.Js
+        assertEquals(setOf<KmpTarget>(KmpTarget.Jvm.Android, KmpTarget.Web.Js), result.members)
+    }
+
+    @Test
+    fun `given a set when adding another set then result is the union`() {
+        val a = KmpTargetSet.of(KmpTarget.Jvm.Android)
+        val b = KmpTargetSet.of(KmpTarget.Web.Js, KmpTarget.Web.WasmJs)
+        val result = a + b
+        assertEquals(
+            setOf<KmpTarget>(KmpTarget.Jvm.Android, KmpTarget.Web.Js, KmpTarget.Web.WasmJs),
+            result.members,
+        )
+    }
+
+    @Test
+    fun `given a set when removing a target then result excludes that target`() {
+        val base = KmpTargetSet.appleMobile
+        val result = base - KmpTarget.Native.Apple.Ios.SimulatorArm64
+        assertFalse(KmpTarget.Native.Apple.Ios.SimulatorArm64 in result)
+        assertTrue(KmpTarget.Native.Apple.Ios.Arm64 in result)
+    }
+
+    @Test
+    fun `given a set when removing another set then result is the difference`() {
+        val base = KmpTargetSet.apple
+        val result = base - KmpTargetSet.appleDesktop
+        assertEquals(KmpTargetSet.appleMobile.members, result.members)
+    }
+
+    @Test
+    fun `given a set when iterated then yields its members`() {
+        val set = KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Web.Js)
+        val collected = set.toList()
+        assertEquals(2, collected.size)
+        assertTrue(KmpTarget.Jvm.Android in collected)
+        assertTrue(KmpTarget.Web.Js in collected)
+    }
+
+    @Test
+    fun `given a set when contains is called then identity matching works on data objects`() {
+        val set = KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64)
+        assertTrue(KmpTarget.Native.Apple.Ios.Arm64 in set)
+        assertFalse(KmpTarget.Native.Apple.Ios.SimulatorArm64 in set)
+    }
+
+    @Test
+    fun `given plus minus chain when applied then operations compose left-to-right`() {
+        val result =
+            KmpTargetSet.appleMobile + KmpTarget.Jvm.Android -
+                KmpTarget.Native.Apple.Ios.SimulatorArm64
+        val expected = setOf<KmpTarget>(KmpTarget.Native.Apple.Ios.Arm64, KmpTarget.Jvm.Android)
+        assertEquals(expected, result.members)
+    }
+
+    @Test
+    fun `given two equal sets when compared then they are equal and have equal hashCode`() {
+        val a = KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Web.Js)
+        val b = KmpTargetSet.of(KmpTarget.Web.Js, KmpTarget.Jvm.Android)
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/model/KmpTargetTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/model/KmpTargetTest.kt
@@ -1,0 +1,120 @@
+package com.rsicarelli.kmptargets.model
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class KmpTargetTest {
+
+    @Test
+    fun `given KmpTarget Jvm Android when accessing id then returns androidTarget`() {
+        assertEquals("androidTarget", KmpTarget.Jvm.Android.id)
+    }
+
+    @Test
+    fun `given KmpTarget Jvm Desktop when accessing id then returns jvm`() {
+        assertEquals("jvm", KmpTarget.Jvm.Desktop.id)
+    }
+
+    @Test
+    fun `given KmpTarget Native Apple Ios leaves when accessing id then returns canonical KGP name`() {
+        assertEquals("iosArm64", KmpTarget.Native.Apple.Ios.Arm64.id)
+        assertEquals("iosSimulatorArm64", KmpTarget.Native.Apple.Ios.SimulatorArm64.id)
+    }
+
+    @Test
+    fun `given KmpTarget Native Apple Macos leaves when accessing id then returns canonical KGP name`() {
+        assertEquals("macosArm64", KmpTarget.Native.Apple.Macos.Arm64.id)
+        assertEquals("macosX64", KmpTarget.Native.Apple.Macos.X64.id)
+    }
+
+    @Test
+    fun `given KmpTarget Web leaves when accessing id then returns canonical KGP name`() {
+        assertEquals("js", KmpTarget.Web.Js.id)
+        assertEquals("wasmJs", KmpTarget.Web.WasmJs.id)
+        assertEquals("wasmWasi", KmpTarget.Web.WasmWasi.id)
+    }
+
+    @Test
+    fun `given KmpTarget Jvm Android when checking aliases then contains user-friendly android`() {
+        assertTrue("android" in KmpTarget.Jvm.Android.aliases)
+    }
+
+    @Test
+    fun `given KmpTarget Jvm Desktop when checking aliases then contains desktop`() {
+        assertTrue("desktop" in KmpTarget.Jvm.Desktop.aliases)
+    }
+
+    @Test
+    fun `given KmpTarget all when enumerated then contains every shipped leaf exactly once`() {
+        val expected =
+            setOf<KmpTarget>(
+                KmpTarget.Jvm.Android,
+                KmpTarget.Jvm.Desktop,
+                KmpTarget.Native.Apple.Ios.Arm64,
+                KmpTarget.Native.Apple.Ios.SimulatorArm64,
+                KmpTarget.Native.Apple.Macos.Arm64,
+                KmpTarget.Native.Apple.Macos.X64,
+                KmpTarget.Web.Js,
+                KmpTarget.Web.WasmJs,
+                KmpTarget.Web.WasmWasi,
+            )
+        assertEquals(expected, KmpTarget.all)
+    }
+
+    @Test
+    fun `given KmpTarget all when checked for unique ids then no duplicates`() {
+        val ids = KmpTarget.all.map { it.id }
+        assertEquals(ids.size, ids.toSet().size, "duplicate ids in registry: $ids")
+    }
+
+    @Test
+    fun `given KmpTarget all when checking aliases then no alias collides with a different leaf's id`() {
+        KmpTarget.all.forEach { target ->
+            target.aliases.forEach { alias ->
+                val collidingLeaf = KmpTarget.all.firstOrNull { it.id == alias }
+                if (collidingLeaf != null) {
+                    assertEquals(
+                        target,
+                        collidingLeaf,
+                        "alias '$alias' on ${target.id} collides with leaf id of ${collidingLeaf.id}",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `given Ios leaf when checked then it belongs to Apple and Native branches`() {
+        val arm64: KmpTarget = KmpTarget.Native.Apple.Ios.Arm64
+        assertTrue(arm64 is KmpTarget.Native)
+        assertTrue(arm64 is KmpTarget.Native.Apple)
+        assertTrue(arm64 is KmpTarget.Native.Apple.Ios)
+    }
+
+    @Test
+    fun `given Macos leaf when checked then it belongs to Apple and Native branches`() {
+        val macos: KmpTarget = KmpTarget.Native.Apple.Macos.Arm64
+        assertTrue(macos is KmpTarget.Native)
+        assertTrue(macos is KmpTarget.Native.Apple)
+        assertTrue(macos is KmpTarget.Native.Apple.Macos)
+    }
+
+    @Test
+    fun `given Js leaf when checked then it belongs to Web branch`() {
+        val js: KmpTarget = KmpTarget.Web.Js
+        assertTrue(js is KmpTarget.Web)
+    }
+
+    @Test
+    fun `given KmpTarget leaves when used in exhaustive when over Web then compiler accepts without else`() {
+        val target: KmpTarget.Web = KmpTarget.Web.WasmJs
+        val name: String =
+            when (target) {
+                KmpTarget.Web.Js -> "js"
+                KmpTarget.Web.WasmJs -> "wasmJs"
+                KmpTarget.Web.WasmWasi -> "wasmWasi"
+            }
+        assertEquals("wasmJs", name)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/parser/DidYouMeanTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/parser/DidYouMeanTest.kt
@@ -1,0 +1,88 @@
+package com.rsicarelli.kmptargets.parser
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+class DidYouMeanTest {
+
+    private val sampleCandidates: Set<String> =
+        setOf(
+            "android",
+            "androidTarget",
+            "iosArm64",
+            "iosSimulatorArm64",
+            "jvm",
+            "macosArm64",
+            "appleMobile",
+            "wasmJs",
+        )
+
+    @Test
+    fun `given exact match in candidates when invoked then returns null`() {
+        assertNull(didYouMean("iosArm64", sampleCandidates))
+    }
+
+    @Test
+    fun `given single-character typo when invoked then returns the close candidate`() {
+        assertEquals("iosArm64", didYouMean("iosArm46", sampleCandidates))
+    }
+
+    @Test
+    fun `given character omission when invoked then returns the close candidate`() {
+        assertEquals("android", didYouMean("androi", sampleCandidates))
+    }
+
+    @Test
+    fun `given character insertion when invoked then returns the close candidate`() {
+        assertEquals("jvm", didYouMean("jvmm", sampleCandidates))
+    }
+
+    @Test
+    fun `given case-mismatched input when invoked then returns the canonical candidate`() {
+        assertEquals("appleMobile", didYouMean("APPLEMOBILE", sampleCandidates))
+    }
+
+    @Test
+    fun `given wildly different input when invoked then returns null`() {
+        assertNull(didYouMean("xboxOne", sampleCandidates))
+    }
+
+    @Test
+    fun `given input beyond default distance when invoked then returns null`() {
+        // "andriot" is 3 edits away from "android" — beyond default maxDistance of 2
+        assertNull(didYouMean("andriot", sampleCandidates))
+    }
+
+    @Test
+    fun `given empty input when invoked then returns null`() {
+        assertNull(didYouMean("", sampleCandidates))
+    }
+
+    @Test
+    fun `given empty candidates when invoked then returns null`() {
+        assertNull(didYouMean("anything", emptySet()))
+    }
+
+    @Test
+    fun `given two candidates equally close when invoked then returns the shortest`() {
+        // "iosArm64x" has distance 1 to "iosArm64" (length 8) — should suggest that one.
+        val candidates = setOf("iosArm64", "iosSimulatorArm64")
+        assertEquals("iosArm64", didYouMean("iosArm64x", candidates))
+    }
+
+    @Test
+    fun `given custom maxDistance when invoked then respects the threshold`() {
+        // "androids" is 1 edit from "android" — within both default and custom.
+        assertEquals("android", didYouMean("androids", sampleCandidates, maxDistance = 1))
+        // "andro" is 2 edits — within default but not maxDistance=1.
+        assertEquals("android", didYouMean("andro", sampleCandidates, maxDistance = 2))
+        assertNull(didYouMean("andro", sampleCandidates, maxDistance = 1))
+    }
+
+    @Test
+    fun `given longer candidate matches when invoked then prefers closer match by edit distance`() {
+        // "ioArm64" is closer to "iosArm64" (1 edit) than to "iosSimulatorArm64" (10+ edits).
+        assertEquals("iosArm64", didYouMean("ioArm64", sampleCandidates))
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParserTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParserTest.kt
@@ -1,0 +1,219 @@
+package com.rsicarelli.kmptargets.parser
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class KmpTargetsParserTest {
+
+    @Test
+    fun `given empty string when parsed then result is Ok empty with warning`() {
+        val result = parseKmpTargets("")
+        assertTrue(result is ParseResult.Ok, "expected Ok, got $result")
+        assertEquals(KmpTargetSet.empty, result.set)
+        assertTrue(result.warnings.isNotEmpty(), "expected at least one warning, got none")
+    }
+
+    @Test
+    fun `given whitespace-only string when parsed then result is Ok empty with warning`() {
+        val result = parseKmpTargets("   \t  ")
+        assertTrue(result is ParseResult.Ok, "expected Ok, got $result")
+        assertEquals(KmpTargetSet.empty, result.set)
+        assertTrue(result.warnings.isNotEmpty())
+    }
+
+    @Test
+    fun `given a single canonical id when parsed then result contains exactly that leaf`() {
+        val result = parseKmpTargets("iosArm64")
+        assertTrue(result is ParseResult.Ok, "got $result")
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), result.set)
+        assertTrue(result.warnings.isEmpty())
+    }
+
+    @Test
+    fun `given a user-friendly alias when parsed then result resolves to canonical leaf`() {
+        val result = parseKmpTargets("android")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Android), result.set)
+    }
+
+    @Test
+    fun `given the all preset when parsed then result equals KmpTargetSet all`() {
+        val result = parseKmpTargets("all")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.all, result.set)
+    }
+
+    @Test
+    fun `given the appleMobile preset when parsed then result equals KmpTargetSet appleMobile`() {
+        val result = parseKmpTargets("appleMobile")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.appleMobile, result.set)
+    }
+
+    @Test
+    fun `given the apple preset when parsed then result equals KmpTargetSet apple`() {
+        val result = parseKmpTargets("apple")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.apple, result.set)
+    }
+
+    @Test
+    fun `given the web preset when parsed then result equals KmpTargetSet web`() {
+        val result = parseKmpTargets("web")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.web, result.set)
+    }
+
+    @Test
+    fun `given multiple comma-separated leaves when parsed then result contains the union`() {
+        val result = parseKmpTargets("android,iosArm64")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64),
+            result.set,
+        )
+    }
+
+    @Test
+    fun `given a token with plus prefix when parsed then it is added to the running set`() {
+        val result = parseKmpTargets("appleMobile,+android")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.appleMobile + KmpTarget.Jvm.Android, result.set)
+    }
+
+    @Test
+    fun `given a token with minus prefix when parsed then it is removed from the running set`() {
+        val result = parseKmpTargets("appleMobile,-iosSimulatorArm64")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), result.set)
+    }
+
+    @Test
+    fun `given mixed-case input when parsed then matching is case-insensitive`() {
+        val result = parseKmpTargets("ANDROID,IOSARM64")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64),
+            result.set,
+        )
+    }
+
+    @Test
+    fun `given whitespace around tokens when parsed then whitespace is trimmed`() {
+        val result = parseKmpTargets("  android  ,  iosArm64  ")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64),
+            result.set,
+        )
+    }
+
+    @Test
+    fun `given duplicate tokens when parsed then duplicates collapse`() {
+        val result = parseKmpTargets("android,android")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Android), result.set)
+    }
+
+    @Test
+    fun `given unknown token close to a known one when parsed then Err includes did-you-mean suggestion`() {
+        val result = parseKmpTargets("androd")
+        assertTrue(result is ParseResult.Err, "expected Err, got $result")
+        assertEquals("androd", result.offendingToken)
+        assertTrue(
+            result.message.contains("android", ignoreCase = true),
+            "expected did-you-mean to suggest 'android', got: ${result.message}",
+        )
+    }
+
+    @Test
+    fun `given unknown token with no close match when parsed then result is Err without suggestion`() {
+        val result = parseKmpTargets("xboxOne")
+        assertTrue(result is ParseResult.Err)
+        assertEquals("xboxOne", result.offendingToken)
+    }
+
+    @Test
+    fun `given bare family name when parsed then result is Err with helpful family hint`() {
+        val result = parseKmpTargets("ios")
+        assertTrue(result is ParseResult.Err, "expected Err for bare family name, got $result")
+        assertNotNull(result.offendingToken)
+        assertTrue(
+            result.message.contains("appleMobile", ignoreCase = true) ||
+                result.message.contains("iosArm64") ||
+                result.message.contains("family", ignoreCase = true),
+            "expected family hint, got: ${result.message}",
+        )
+    }
+
+    @Test
+    fun `given subtraction that empties a preset when parsed then result is Ok empty`() {
+        val result = parseKmpTargets("appleMobile,-iosArm64,-iosSimulatorArm64")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.empty, result.set)
+    }
+
+    @Test
+    fun `given preset and addition and subtraction when parsed then operations compose left-to-right`() {
+        val result = parseKmpTargets("appleMobile,+android,-iosSimulatorArm64")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64, KmpTarget.Jvm.Android),
+            result.set,
+        )
+    }
+
+    @Test
+    fun `given hyphenated alias when parsed then result resolves to canonical leaf`() {
+        val result = parseKmpTargets("ios-arm64")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), result.set)
+    }
+
+    @Test
+    fun `given a sign with no name when parsed then result is Err`() {
+        val result = parseKmpTargets("android,+")
+        assertTrue(result is ParseResult.Err, "expected Err for dangling sign, got $result")
+    }
+
+    @Test
+    fun `given a leading minus when parsed then subtraction starts from empty as a no-op`() {
+        val result = parseKmpTargets("-iosArm64")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.empty, result.set)
+    }
+
+    @Test
+    fun `given comma-separated empties between tokens when parsed then empties are skipped`() {
+        val result = parseKmpTargets("android,,iosArm64,")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64),
+            result.set,
+        )
+    }
+
+    @Test
+    fun `given input with only separators when parsed then result is Ok empty with warning`() {
+        val result = parseKmpTargets(",,,")
+        assertTrue(result is ParseResult.Ok)
+        assertEquals(KmpTargetSet.empty, result.set)
+        assertTrue(result.warnings.isNotEmpty())
+    }
+
+    @Test
+    fun `given custom registry without a target when parsed then that target id is unknown`() {
+        // Custom registry that excludes iosArm64
+        val customRegistry: Set<KmpTarget> = KmpTarget.all - KmpTarget.Native.Apple.Ios.Arm64
+        val result = parseKmpTargets("iosArm64", customRegistry)
+        assertTrue(
+            result is ParseResult.Err,
+            "expected Err when token not in registry, got $result",
+        )
+        assertEquals("iosArm64", result.offendingToken)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/source/LocalPropertiesSourceTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/source/LocalPropertiesSourceTest.kt
@@ -1,0 +1,90 @@
+package com.rsicarelli.kmptargets.source
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class LocalPropertiesSourceTest {
+
+    @Test
+    fun `given local properties with the key when read then returns the value`(@TempDir dir: Path) {
+        dir.resolve("local.properties").writeText("KMP_TARGETS=android,iosArm64\n")
+        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        assertEquals("android,iosArm64", source.read())
+    }
+
+    @Test
+    fun `given local properties without the key when read then returns null`(@TempDir dir: Path) {
+        dir.resolve("local.properties").writeText("OTHER_KEY=value\n")
+        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        assertNull(source.read())
+    }
+
+    @Test
+    fun `given no local properties file when read then returns null`(@TempDir dir: Path) {
+        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        assertNull(source.read())
+    }
+
+    @Test
+    fun `given local properties with leading whitespace around value when read then leading is stripped`(
+        @TempDir dir: Path
+    ) {
+        // java.util.Properties strips leading whitespace from values but keeps trailing
+        dir.resolve("local.properties").writeText("KMP_TARGETS=  android\n")
+        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        assertEquals("android", source.read())
+    }
+
+    @Test
+    fun `given local properties with empty value when read then returns empty string`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("local.properties").writeText("KMP_TARGETS=\n")
+        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        assertEquals("", source.read())
+    }
+
+    @Test
+    fun `given local properties with comments when read then comments are ignored`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("local.properties")
+            .writeText(
+                """
+                # set KMP_TARGETS to override the default selection
+                KMP_TARGETS=appleMobile
+                """
+                    .trimIndent()
+            )
+        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        assertEquals("appleMobile", source.read())
+    }
+
+    @Test
+    fun `given local properties with multiple keys when read then returns the requested one`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("local.properties")
+            .writeText(
+                """
+                sdk.dir=/Users/foo/Library/Android/sdk
+                KMP_TARGETS=android
+                org.gradle.jvmargs=-Xmx2g
+                """
+                    .trimIndent()
+            )
+        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        assertEquals("android", source.read())
+    }
+
+    @Test
+    fun `given different property name when read then looks up that name`(@TempDir dir: Path) {
+        dir.resolve("local.properties").writeText("MY_CUSTOM_KEY=value\n")
+        val source = LocalPropertiesSource(dir.toFile(), "MY_CUSTOM_KEY")
+        assertEquals("value", source.read())
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/source/SelectionSourceTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/source/SelectionSourceTest.kt
@@ -1,0 +1,77 @@
+package com.rsicarelli.kmptargets.source
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+class SelectionSourceTest {
+
+    @Test
+    fun `given a source returning a value when read then returns that value`() {
+        val source = SelectionSource { "android,iosArm64" }
+        assertEquals("android,iosArm64", source.read())
+    }
+
+    @Test
+    fun `given a source returning null when read then returns null`() {
+        val source = SelectionSource { null }
+        assertNull(source.read())
+    }
+
+    @Test
+    fun `given a source returning empty string when read then returns empty string`() {
+        // Empty is "present but blank" — parser, not source, decides what that means
+        val source = SelectionSource { "" }
+        assertEquals("", source.read())
+    }
+
+    @Test
+    fun `given composed sources when first is non-null then first value wins`() {
+        val composed =
+            composeSelectionSources(
+                SelectionSource { "from-first" },
+                SelectionSource { "from-second" },
+            )
+        assertEquals("from-first", composed.read())
+    }
+
+    @Test
+    fun `given composed sources when first is null then falls back to second`() {
+        val composed =
+            composeSelectionSources(SelectionSource { null }, SelectionSource { "from-second" })
+        assertEquals("from-second", composed.read())
+    }
+
+    @Test
+    fun `given composed sources when first is empty then empty wins as present-but-blank`() {
+        // An explicitly-set blank value is meaningful (turns off the plugin's preference);
+        // it must not be skipped in favour of a later non-empty source.
+        val composed =
+            composeSelectionSources(SelectionSource { "" }, SelectionSource { "from-second" })
+        assertEquals("", composed.read())
+    }
+
+    @Test
+    fun `given composed sources when all return null then result is null`() {
+        val composed = composeSelectionSources(SelectionSource { null }, SelectionSource { null })
+        assertNull(composed.read())
+    }
+
+    @Test
+    fun `given empty composition when read then result is null`() {
+        val composed = composeSelectionSources()
+        assertNull(composed.read())
+    }
+
+    @Test
+    fun `given many sources when composed then priority is left-to-right`() {
+        val composed =
+            composeSelectionSources(
+                SelectionSource { null },
+                SelectionSource { null },
+                SelectionSource { "third" },
+                SelectionSource { "fourth" },
+            )
+        assertEquals("third", composed.read())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "2.3.21"
 junit = "5.14.3"
+ktfmt = "0.26.0"
 
 [libraries]
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -8,3 +9,4 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jun
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }

--- a/samples/hello-world/build.gradle.kts
+++ b/samples/hello-world/build.gradle.kts
@@ -1,3 +1,10 @@
 plugins {
+    kotlin("multiplatform") version "2.3.21"
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+}
+
+kotlin {
+    sourceSets.commonMain.dependencies {
+        // empty on purpose — the sample exercises plugin wiring, not third-party deps
+    }
 }

--- a/samples/hello-world/gradle.properties
+++ b/samples/hello-world/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+
+# Default target selection for this sample. Developers override locally via
+# local.properties or `-PKMP_TARGETS=...`.
+KMP_TARGETS=jvm,iosSimulatorArm64

--- a/samples/hello-world/src/commonMain/kotlin/Greeting.kt
+++ b/samples/hello-world/src/commonMain/kotlin/Greeting.kt
@@ -1,0 +1,3 @@
+package com.rsicarelli.kmptargets.sample
+
+fun greeting(): String = "Hello from kmp-targets!"


### PR DESCRIPTION
## Summary

The bootstrap placeholder is gone — this PR ships the real spine of `kmp-targets`:

- **Sealed `KmpTarget` hierarchy** + `@JvmInline value class KmpTargetSet` (under `model/`). Shipped leaves: Android, JVM, iOS Arm64 / SimulatorArm64, macOS Arm64 / X64, JS, WasmJs, WasmWasi. Other branches (Watchos / Tvos / Linux / Mingw / AndroidNative) exist as empty sealed scaffolding for follow-up PRs.
- **Pure parser** for `KMP_TARGETS` strings (`parser/`). Grammar: `(+|-)?token (',' (+|-)?token)*`. Strict-throw with Levenshtein did-you-mean and tailored family-name hints (`ios` → "use 'iosArm64' or 'appleMobile'").
- **Composable selection sources** (`source/`): `SelectionSource` fun interface + `GradlePropertySource` / `EnvironmentVariableSource` / `LocalPropertiesSource`. `LocalPropertyValueSource` wraps the file read as a Gradle `ValueSource` for configuration-cache fingerprinting.
- **Plugin entry point** that reads sources eagerly at apply time, parses, and registers KGP targets via an exhaustive `when` over the sealed leaves inside `pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform")`.
- **Tooling**: ktfmt (`kotlinlang` style) integrated and wired into `check`; `task fmt` / `task dod` / `task hooks:install` (the latter enables a version-controlled `.githooks/pre-commit` DOD gate).
- **Sample**: `samples/hello-world` now declares `KMP_TARGETS=jvm,iosSimulatorArm64` in its `gradle.properties` and builds end-to-end through real KGP. `task ci` is green.

105 unit tests across 8 classes, all green.

## What's intentionally NOT in this PR

- Per-module target configuration (single global `KMP_TARGETS` for now). This is the next load-bearing decision — see [`/tmp/kmp-targets-handover-per-module.md`](https://github.com/rsicarelli/kmp-targets/tree/feat%2Fbootstrap-type-system) (local file in the working tree) for the handover.
- `kmpTargets.applyHierarchyTemplate()` and `kmpTargets.framework { ... }` helpers (deferred).
- Watchos / Tvos / Linux / Mingw / AndroidNative leaves.
- Maven Central publishing, mkdocs site, lint/format tooling beyond ktfmt.

## Known limitations

- `KmpTargetsExtension` exposes `fallback` / `only` / `exclude` helpers in the API, but they are **not safe to use in `build.gradle.kts`** today: `pluginManager.withPlugin` fires synchronously before user DSL runs. The sample sidesteps this by configuring `KMP_TARGETS` via `gradle.properties`. Resolving this properly is part of the per-module work in the next session.

## Test plan

- [x] `task test` — 105 unit tests, 0 failures
- [x] `task ci` — check + publish-local + sample (builds JVM + iosSimulatorArm64 via real KGP)
- [x] `task fmt:check` — all sources ktfmt-formatted
- [x] `.githooks/pre-commit` smoke-runs `fmt:check + build + test` end-to-end
- [ ] Manual verification: drop the plugin into a real multi-module KMP project (deferred until per-module config lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)