### PR TITLE
feat: per-module target configuration via convention plugins

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,12 +2,13 @@
 
 ## Repo shape
 
-This is a **multi-module Gradle build**, intentionally so even though only one module exists today:
+This is a **multi-module Gradle build**:
 
-- `:gradle-plugin` — the Gradle plugin (`com.rsicarelli.kmptargets`). Source under `gradle-plugin/src/`.
+- `:gradle-plugin` — the core plugin (`com.rsicarelli.kmptargets`) + the `KmpTargets` entry point. Source under `gradle-plugin/src/`.
+- `:convention-plugins` — the per-module convention plugins (`com.rsicarelli.kmptargets.{library,mobile,apple,jvm,web}`), thin wrappers over `KmpTargets.applyConvention`. Depends on `:gradle-plugin` (api) + KGP (implementation, so it can apply KGP for consumers).
 - Future: `:cli` — companion CLI for driving target selection from outside Gradle. Reserved as a sibling subproject.
 
-Do **not** collapse into a single-module layout. The structure exists to make adding `:cli` (and other siblings) painless.
+Do **not** collapse into a single-module layout. The structure keeps the dependency-light core publishable on its own and makes adding siblings painless.
 
 ## Dev loop
 
@@ -21,7 +22,10 @@ task ci
 
 ## Gradle invocations
 
-Always prefix subproject task names: `:gradle-plugin:test`, not `:test`. Root-level `./gradlew test` does nothing useful right now.
+Now that more than one module exists, the Taskfile uses root-level aggregating invocations
+(`./gradlew test` / `build` / `check` / `ktfmtFormat` / `publishToMavenLocal`) which run across every
+module. Prefer `task build` / `task test` / `task dod`. Prefix a single module
+(`:gradle-plugin:test`) only when you deliberately want to scope to it.
 
 ## Tool chain
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Check (compile + test)
-        run: ./gradlew :gradle-plugin:check
+        run: ./gradlew check
 
-      - name: Publish plugin to Maven Local
-        run: ./gradlew :gradle-plugin:publishPluginMavenPublicationToMavenLocal :gradle-plugin:publishKmpTargetsPluginMarkerMavenPublicationToMavenLocal
+      - name: Publish plugins to Maven Local
+        run: ./gradlew publishToMavenLocal
 
       - name: Build sample (hello-world)
         run: ./gradlew -p samples/hello-world build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Dynamically select which Kotlin Multiplatform targets to build.
 
-**Status:** alpha (pre-1.0). The core selector is implemented and exercised by the sample; per-module configuration and helper APIs (`applyHierarchyTemplate`, XCFramework) are roadmap items.
+**Status:** alpha (pre-1.0). The core selector and per-module convention plugins are implemented and exercised by the multi-module sample; helper APIs (`applyHierarchyTemplate`, XCFramework) are roadmap items.
 
 `kmp-targets` is a Gradle plugin for Kotlin Multiplatform projects that lets each developer (and each CI runner) choose which KMP targets to build, via a single Gradle property:
 
@@ -15,6 +15,61 @@ Targets you don't select are never registered with KGP, so their compile/link/KS
 
 ## Usage
 
+A real multi-module project is heterogeneous: a shared module builds every platform, a mobile
+feature builds only Android + iOS, a tooling module builds only the JVM. `kmp-targets` separates two
+facts:
+
+- **What a module *can* build** — its *supported* set, declared per-module.
+- **What you *want* to build now** — the global `KMP_TARGETS` *selection*.
+
+The plugin registers `selection ∩ supported` for each module. A module never builds a target outside
+its supported set, and the global selection narrows that further.
+
+### Convention plugins (recommended)
+
+Each module declares its supported shape by the convention plugin id it applies — one line, and it
+applies the Kotlin Multiplatform plugin for you (don't add `kotlin("multiplatform")` yourself):
+
+```kotlin
+// shared-core/build.gradle.kts   — supports all targets
+plugins { id("com.rsicarelli.kmptargets.library") version "<version>" }
+
+// feature-mobile/build.gradle.kts — supports Android + iOS
+plugins { id("com.rsicarelli.kmptargets.mobile") version "<version>" }
+
+// jvm-tools/build.gradle.kts      — supports JVM only
+plugins { id("com.rsicarelli.kmptargets.jvm") version "<version>" }
+```
+
+| Plugin id | Supports |
+|---|---|
+| `com.rsicarelli.kmptargets.library` | all shipped targets |
+| `com.rsicarelli.kmptargets.mobile` | `androidTarget`, `iosArm64`, `iosSimulatorArm64` |
+| `com.rsicarelli.kmptargets.apple` | `iosArm64`, `iosSimulatorArm64`, `macosArm64`, `macosX64` |
+| `com.rsicarelli.kmptargets.jvm` | `jvm` |
+| `com.rsicarelli.kmptargets.web` | `js`, `wasmJs`, `wasmWasi` |
+
+With `KMP_TARGETS=jvm,iosSimulatorArm64`: `library` registers both, `mobile` registers only
+`iosSimulatorArm64`, `jvm` registers only `jvm`.
+
+**Composition** — apply more than one id and their supported sets *union*:
+
+```kotlin
+plugins {
+    id("com.rsicarelli.kmptargets.apple") version "<version>"
+    id("com.rsicarelli.kmptargets.jvm") version "<version>"
+}
+// supports iOS/macOS ∪ JVM
+```
+
+If a module's supported set and the selection don't overlap at all, the plugin registers no targets
+for it, logs a warning naming the module/supported/selection, and lets the build proceed.
+
+### Escape hatch (manual wiring)
+
+For a one-off module that fits no preset, apply the base id yourself alongside KGP and declare its
+supported set with the `kmptargets.supported` property (same grammar as `KMP_TARGETS`):
+
 ```kotlin
 // build.gradle.kts
 plugins {
@@ -22,6 +77,16 @@ plugins {
     id("com.rsicarelli.kmptargets") version "<version>"
 }
 ```
+
+```properties
+# this module's gradle.properties
+kmptargets.supported=jvm,linuxX64
+```
+
+Applying the base id with no `kmptargets.supported` keeps the original behaviour: supported defaults
+to all, so the global `KMP_TARGETS` alone decides what registers.
+
+### Selecting targets
 
 Set the selection via any of these sources (priority order, highest first):
 
@@ -61,8 +126,8 @@ This release ships leaves for the most-used target families. Other branches (`wa
 The plugin is not yet published to the Gradle Plugin Portal or Maven Central. Track progress in the issues / releases. Locally:
 
 ```bash
-task publish-local           # publishes :gradle-plugin to mavenLocal
-task sample                  # smoke test against samples/hello-world
+task publish-local           # publishes the core + convention plugins to mavenLocal
+task sample                  # smoke test against the multi-module samples/hello-world
 ```
 
 ## Development

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,24 +10,24 @@ tasks:
       - task --list
 
   build:
-    desc: Build the plugin module
+    desc: Build all plugin modules (core + convention plugins)
     cmds:
-      - "{{.GRADLE}} :gradle-plugin:build"
+      - "{{.GRADLE}} build"
 
   test:
-    desc: Run all tests (TestKit functional tests included)
+    desc: Run all tests across modules (TestKit functional tests included)
     cmds:
-      - "{{.GRADLE}} :gradle-plugin:test"
+      - "{{.GRADLE}} test"
 
   check:
-    desc: Run all checks (test + future lint/format/api)
+    desc: Run all checks across modules (test + ktfmt)
     cmds:
-      - "{{.GRADLE}} :gradle-plugin:check"
+      - "{{.GRADLE}} check"
 
   publish-local:
-    desc: Publish plugin to Maven Local for sample iteration
+    desc: Publish core + convention plugins (and their markers) to Maven Local for sample iteration
     cmds:
-      - "{{.GRADLE}} :gradle-plugin:publishPluginMavenPublicationToMavenLocal :gradle-plugin:publishKmpTargetsPluginMarkerMavenPublicationToMavenLocal"
+      - "{{.GRADLE}} publishToMavenLocal"
 
   sample:
     desc: Quick smoke — plugin applies and registers KMP targets (depends on publish-local)
@@ -76,9 +76,9 @@ tasks:
   fmt:
     desc: Format Kotlin sources with ktfmt (kotlinlang style)
     cmds:
-      - "{{.GRADLE}} :gradle-plugin:ktfmtFormat"
+      - "{{.GRADLE}} ktfmtFormat"
 
   fmt:check:
     desc: Verify Kotlin sources are ktfmt-formatted (run by `task check`)
     cmds:
-      - "{{.GRADLE}} :gradle-plugin:ktfmtCheck"
+      - "{{.GRADLE}} ktfmtCheck"

--- a/convention-plugins/build.gradle.kts
+++ b/convention-plugins/build.gradle.kts
@@ -1,0 +1,63 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ktfmt)
+    `java-gradle-plugin`
+    `maven-publish`
+}
+
+kotlin { jvmToolchain(23) }
+
+ktfmt { kotlinLangStyle() }
+
+dependencies {
+    // The core plugin supplies KmpTargets.applyConvention + the type model.
+    api(project(":gradle-plugin"))
+    // KGP is applied at runtime by each convention plugin, so it must be on their runtime classpath
+    // (and, transitively, on consumers' buildscript classpath) — not compileOnly.
+    implementation(libs.kotlin.gradlePlugin)
+
+    testImplementation(gradleTestKit())
+    testImplementation(libs.kotlin.gradlePlugin)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(kotlin("test-junit5"))
+}
+
+gradlePlugin {
+    website.set("https://github.com/rsicarelli/kmp-targets")
+    vcsUrl.set("https://github.com/rsicarelli/kmp-targets.git")
+    val conventions =
+        listOf(
+            Triple("kmpLibrary", "library", "KmpLibraryConventionPlugin") to
+                "all shipped Kotlin Multiplatform targets",
+            Triple("kmpMobile", "mobile", "KmpMobileConventionPlugin") to
+                "Android + iOS (the mobile-app shape)",
+            Triple("kmpApple", "apple", "KmpAppleConventionPlugin") to "iOS + macOS",
+            Triple("kmpJvm", "jvm", "KmpJvmConventionPlugin") to "JVM (desktop/server)",
+            Triple("kmpWeb", "web", "KmpWebConventionPlugin") to "JS + Wasm",
+        )
+    plugins {
+        conventions.forEach { (coords, desc) ->
+            val (name, idSuffix, implClass) = coords
+            create(name) {
+                id = "com.rsicarelli.kmptargets.$idSuffix"
+                implementationClass = "com.rsicarelli.kmptargets.conventions.$implClass"
+                displayName = "KMP Targets — $idSuffix"
+                description =
+                    "Declares this module supports $desc; intersects the KMP_TARGETS selection against it."
+                tags.set(listOf("kotlin", "kmp", "multiplatform", "convention", idSuffix))
+            }
+        }
+    }
+}
+
+publishing {
+    publications.withType<MavenPublication>().configureEach {
+        if (name == "pluginMaven") {
+            artifactId = "kmp-targets-conventions"
+        }
+    }
+}
+
+tasks.test { useJUnitPlatform() }
+
+tasks.named("check") { dependsOn("ktfmtCheck") }

--- a/convention-plugins/src/main/kotlin/com/rsicarelli/kmptargets/conventions/KmpConventionPlugins.kt
+++ b/convention-plugins/src/main/kotlin/com/rsicarelli/kmptargets/conventions/KmpConventionPlugins.kt
@@ -1,0 +1,38 @@
+package com.rsicarelli.kmptargets.conventions
+
+import com.rsicarelli.kmptargets.KmpTargets
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Convention plugins that declare a module's supported target shape by its plugin id. Each one is a
+ * one-liner over [KmpTargets.applyConvention], which applies the Kotlin Multiplatform plugin and
+ * the core kmp-targets plugin, declares the baked supported set, and registers `supported ∩
+ * KMP_TARGETS`.
+ *
+ * Applying more than one composes: the supported sets union (e.g. `.mobile` + `.web`).
+ */
+public class KmpLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit = KmpTargets.applyConvention(target, KmpTargetSet.all)
+}
+
+public class KmpMobileConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit =
+        KmpTargets.applyConvention(target, KmpTargetSet.mobile)
+}
+
+public class KmpAppleConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit =
+        KmpTargets.applyConvention(target, KmpTargetSet.apple)
+}
+
+public class KmpJvmConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit =
+        KmpTargets.applyConvention(target, KmpTargetSet.of(KmpTarget.Jvm.Desktop))
+}
+
+public class KmpWebConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit = KmpTargets.applyConvention(target, KmpTargetSet.web)
+}

--- a/convention-plugins/src/test/kotlin/com/rsicarelli/kmptargets/conventions/KmpConventionPluginsTest.kt
+++ b/convention-plugins/src/test/kotlin/com/rsicarelli/kmptargets/conventions/KmpConventionPluginsTest.kt
@@ -1,0 +1,116 @@
+package com.rsicarelli.kmptargets.conventions
+
+import com.rsicarelli.kmptargets.KmpTargetsExtension
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Proves the convention-plugin layer: applying an id declares the right supported set, applies KGP
+ * for the consumer, and registers `supported ∩ selection` — including composition of multiple ids.
+ * Plugins are applied by class (no published descriptor needed in-process); the end-to-end id-based
+ * application is covered by the multi-module sample under `task ci`.
+ */
+class KmpConventionPluginsTest {
+
+    @Test
+    fun `given mobile convention applied when supported is read then it equals the mobile preset`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, kmpTargets = "iosArm64")
+        project.pluginManager.apply(KmpMobileConventionPlugin::class.java)
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(KmpTargetSet.mobile, ext.supported.get())
+    }
+
+    @Test
+    fun `given mobile convention and KMP_TARGETS iosArm64 when applied then only iosArm64 registers and KGP is applied`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, kmpTargets = "iosArm64")
+        project.pluginManager.apply(KmpMobileConventionPlugin::class.java)
+        assertTrue(project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform"))
+        assertRegisteredTargets(project, "iosArm64")
+    }
+
+    @Test
+    fun `given jvm convention applied when supported is read then it equals jvm desktop only`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, kmpTargets = "jvm")
+        project.pluginManager.apply(KmpJvmConventionPlugin::class.java)
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(
+            KmpTargetSet.of(com.rsicarelli.kmptargets.model.KmpTarget.Jvm.Desktop),
+            ext.supported.get(),
+        )
+        assertRegisteredTargets(project, "jvm")
+    }
+
+    @Test
+    fun `given library convention and KMP_TARGETS jvm,wasmJs when applied then both register`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, kmpTargets = "jvm,wasmJs")
+        project.pluginManager.apply(KmpLibraryConventionPlugin::class.java)
+        assertRegisteredTargets(project, "jvm", "wasmJs")
+    }
+
+    @Test
+    fun `given mobile plus web conventions and KMP_TARGETS iosArm64,wasmJs when applied then supported unions and both register`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, kmpTargets = "iosArm64,wasmJs")
+        project.pluginManager.apply(KmpMobileConventionPlugin::class.java)
+        project.pluginManager.apply(KmpWebConventionPlugin::class.java)
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(KmpTargetSet.mobile + KmpTargetSet.web, ext.supported.get())
+        assertRegisteredTargets(project, "iosArm64", "wasmJs")
+    }
+
+    @Test
+    fun `given jvm convention and KMP_TARGETS wasmJs when applied then nothing registers (empty overlap is skipped)`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, kmpTargets = "wasmJs")
+        project.pluginManager.apply(KmpJvmConventionPlugin::class.java)
+        assertRegisteredTargets(project /* none */)
+    }
+
+    @Test
+    fun `given user already applied KGP when a convention plugin is applied then it fails with a helpful message`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, kmpTargets = "iosArm64")
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        val ex =
+            assertFailsWith<Exception> {
+                project.pluginManager.apply(KmpMobileConventionPlugin::class.java)
+            }
+        val helpful =
+            generateSequence(ex as Throwable?) { it.cause }
+                .firstOrNull { it.message?.contains("convention plugin") == true }
+        assertNotNull(helpful, "expected a helpful cause in chain, root: ${ex.message}")
+        assertTrue(helpful.message!!.contains("kotlin(\"multiplatform\")"), helpful.message)
+    }
+
+    private fun projectWith(dir: Path, kmpTargets: String): Project {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=$kmpTargets\n")
+        return ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+    }
+
+    private fun assertRegisteredTargets(project: Project, vararg expected: String) {
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        val actual = kotlin.targets.names.filter { it != "metadata" }.toSet()
+        assertEquals(expected.toSet(), actual)
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -7,15 +7,20 @@ import org.gradle.api.provider.Property
 /**
  * Public DSL surface exposed by the plugin as the `kmpTargets` extension.
  *
- * [selection] is the resolved target set the plugin will register with KGP. The plugin sets a
- * convention on it (parsed from the `KMP_TARGETS` property, falling back to [fallback]), and the
- * user can override it explicitly via [selection.set], or via the [only] / [exclude] helpers for
- * common cases.
+ * The plugin separates two facts:
+ * - [selection] — what the user wants to build *now*, global, resolved from `KMP_TARGETS` (falling
+ *   back to [fallback]). This is the same value for every module in the build.
+ * - [supported] — what *this module* can build, declared per-module by the convention plugin id it
+ *   applies (e.g. `com.rsicarelli.kmptargets.mobile`) or the `kmptargets.supported` property. When
+ *   nothing declares it, [effectiveSupported] defaults to [KmpTargetSet.all].
  *
- * [fallback] is consulted only when `KMP_TARGETS` is absent. Convention: [KmpTargetSet.all].
+ * The plugin registers `selection ∩ supported`. `supported` is **not** settable from the
+ * build-script body: that runs after KGP target registration has already happened (the "timing
+ * wall"), so a DSL setter would silently no-op. Declarations therefore flow through apply-time
+ * channels only.
  *
- * Both properties hold immutable `KmpTargetSet` values composed of `data object` leaves, so the
- * extension itself is configuration-cache safe — no `Project` or mutable state is captured.
+ * All values are immutable `KmpTargetSet`s of `data object` leaves, so the extension is
+ * configuration-cache safe — no `Project` or task state is captured.
  */
 public abstract class KmpTargetsExtension {
 
@@ -23,19 +28,27 @@ public abstract class KmpTargetsExtension {
 
     public abstract val fallback: Property<KmpTargetSet>
 
-    /** Replaces the current selection with exactly [targets]. Last write wins. */
-    public fun only(vararg targets: KmpTarget) {
-        selection.set(KmpTargetSet.of(*targets))
-    }
+    /**
+     * The set of targets this module can build. Unset means "not declared"; [effectiveSupported]
+     * treats that as [KmpTargetSet.all]. Written additively via [accumulateSupported] so multiple
+     * convention plugins compose (e.g. `.mobile` + `.web`).
+     */
+    public abstract val supported: Property<KmpTargetSet>
+
+    /** Leaves already registered with KGP, so repeated registration passes are idempotent. */
+    internal val registered: MutableSet<KmpTarget> = mutableSetOf()
 
     /**
-     * Removes [targets] from the current selection. Resolves the current value eagerly against
-     * [selection] (which may carry a convention from the plugin) and falls back to [fallback] or
-     * [KmpTargetSet.empty] if neither is set.
+     * True once a kmp-targets convention plugin has applied KGP, distinguishing it from a
+     * user-applied `kotlin("multiplatform")`.
      */
-    public fun exclude(vararg targets: KmpTarget) {
-        val excluded = KmpTargetSet.of(*targets)
-        val current = selection.orNull ?: fallback.orNull ?: KmpTargetSet.empty
-        selection.set(current - excluded)
+    internal var kgpAppliedByConvention: Boolean = false
+
+    /** Unions [add] into [supported]. Order-independent, so composition is commutative. */
+    internal fun accumulateSupported(add: KmpTargetSet) {
+        supported.set((supported.orNull ?: KmpTargetSet.empty) + add)
     }
+
+    /** The resolved supported set: the accumulated declaration, or [KmpTargetSet.all] if none. */
+    internal fun effectiveSupported(): KmpTargetSet = supported.orNull ?: KmpTargetSet.all
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -20,42 +20,146 @@ public class KmpTargetsPlugin : Plugin<Project> {
         val ext = target.extensions.create("kmpTargets", KmpTargetsExtension::class.java)
         ext.fallback.convention(KmpTargetSet.all)
 
-        val sources =
-            composeSelectionSources(
-                GradlePropertySource(target.providers, PROPERTY_NAME),
-                EnvironmentVariableSource(target.providers, PROPERTY_NAME),
-                localPropertiesSource(target),
-            )
-
-        val raw: String? = sources.read()
-        val parsedFromProperty: KmpTargetSet? = raw?.let { parseOrThrow(it) }
-
+        // Global selection: what the user wants to build now.
+        val raw: String? = selectionSources(target).read()
+        val parsedFromProperty: KmpTargetSet? = raw?.let { parseOrThrow(it, KMP_TARGETS) }
         if (parsedFromProperty != null && parsedFromProperty.isNotEmpty()) {
             ext.selection.convention(parsedFromProperty)
         } else {
             ext.selection.convention(ext.fallback)
         }
 
-        target.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
-            val kotlin = target.extensions.getByType(KotlinMultiplatformExtension::class.java)
-            ext.selection.get().forEach { kmp -> registerTarget(kotlin, kmp) }
+        // Per-module supported set declared via the `kmptargets.supported` property (the manual
+        // escape hatch for modules that don't apply a convention plugin). Convention plugins
+        // declare
+        // theirs through KmpTargets.declareSupported instead.
+        supportedSources(target).read()?.let { rawSupported ->
+            ext.accumulateSupported(parseOrThrow(rawSupported, SUPPORTED_PROPERTY))
+        }
+
+        // Register selection ∩ supported once KGP is present. Queued here so that, in the
+        // convention
+        // flow (core applied before KGP), the accumulated supported set is already visible when
+        // this
+        // fires. Idempotent, so it composes with the per-declaration passes in declareSupported.
+        target.pluginManager.withPlugin(KGP_ID) { KmpTargets.registerResolved(target, ext) }
+
+        // Advisory only: warn when a module ends up with zero targets because its supported set and
+        // the global selection don't overlap. Deferred to afterEvaluate because there is no public
+        // apply-time "all plugins applied" hook, and under composition (.mobile + .web) an earlier
+        // pass is transiently empty before later contributions land — emitting during a pass would
+        // be
+        // spurious. Registration itself stays eager and afterEvaluate-free; only this log line
+        // waits.
+        target.afterEvaluate { p ->
+            if (
+                p.plugins.hasPlugin(KGP_ID) &&
+                    ext.registered.isEmpty() &&
+                    ext.selection.get().isNotEmpty()
+            ) {
+                p.logger.warn(
+                    KmpTargets.emptyOverlapWarning(
+                        p.path,
+                        ext.selection.get(),
+                        ext.effectiveSupported(),
+                    )
+                )
+            }
         }
     }
 
-    private fun localPropertiesSource(target: Project): SelectionSource {
+    private fun selectionSources(target: Project): SelectionSource =
+        composeSelectionSources(
+            GradlePropertySource(target.providers, KMP_TARGETS),
+            EnvironmentVariableSource(target.providers, KMP_TARGETS),
+            localPropertiesSource(target, KMP_TARGETS),
+        )
+
+    private fun supportedSources(target: Project): SelectionSource =
+        composeSelectionSources(
+            GradlePropertySource(target.providers, SUPPORTED_PROPERTY),
+            localPropertiesSource(target, SUPPORTED_PROPERTY),
+        )
+
+    private fun localPropertiesSource(target: Project, propertyName: String): SelectionSource {
         val provider =
             target.providers.of(LocalPropertyValueSource::class.java) {
                 it.parameters.rootDir.set(target.rootDir)
-                it.parameters.propertyName.set(PROPERTY_NAME)
+                it.parameters.propertyName.set(propertyName)
             }
         return SelectionSource { provider.orNull }
     }
 
-    private fun parseOrThrow(raw: String): KmpTargetSet =
+    private fun parseOrThrow(raw: String, propertyName: String): KmpTargetSet =
         when (val r = parseKmpTargets(raw)) {
             is ParseResult.Ok -> r.set
-            is ParseResult.Err -> throw GradleException(r.message)
+            is ParseResult.Err -> throw GradleException("$propertyName: ${r.message}")
         }
+
+    internal companion object {
+        const val KMP_TARGETS: String = "KMP_TARGETS"
+        const val SUPPORTED_PROPERTY: String = "kmptargets.supported"
+        const val KGP_ID: String = "org.jetbrains.kotlin.multiplatform"
+    }
+}
+
+/**
+ * Entry point convention plugins use to declare a module's supported targets and wire KGP. Lives in
+ * the core so the registration mechanism (intersection, idempotency, ordering) has a single home
+ * and convention plugins stay trivial.
+ */
+public object KmpTargets {
+
+    /**
+     * Applies the core plugin, declares [supported] for this module, and applies the Kotlin
+     * Multiplatform plugin if it isn't already. Fails fast if the user applied
+     * `kotlin("multiplatform")` themselves — a convention plugin owns KGP application, and a
+     * pre-applied KGP would register targets before the supported set narrows them.
+     */
+    public fun applyConvention(project: Project, supported: KmpTargetSet) {
+        project.pluginManager.apply(KmpTargetsPlugin::class.java)
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        check(!project.plugins.hasPlugin(KmpTargetsPlugin.KGP_ID) || ext.kgpAppliedByConvention) {
+            "kmp-targets: do not apply kotlin(\"multiplatform\") yourself when using a kmp-targets " +
+                "convention plugin — it applies the Kotlin Multiplatform plugin for you " +
+                "(project '${project.path}')."
+        }
+        declareSupported(project, supported)
+        if (!project.plugins.hasPlugin(KmpTargetsPlugin.KGP_ID)) {
+            project.pluginManager.apply(KmpTargetsPlugin.KGP_ID)
+            ext.kgpAppliedByConvention = true
+        }
+    }
+
+    /**
+     * Adds [add] to this module's supported set and (re)runs an idempotent registration pass once
+     * KGP is present. Calling it repeatedly is how `.mobile` + `.web` compose into the union.
+     */
+    public fun declareSupported(project: Project, add: KmpTargetSet) {
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        ext.accumulateSupported(add)
+        project.pluginManager.withPlugin(KmpTargetsPlugin.KGP_ID) { registerResolved(project, ext) }
+    }
+
+    /** Registers `selection ∩ supported`, skipping leaves already registered (idempotent). */
+    internal fun registerResolved(project: Project, ext: KmpTargetsExtension) {
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        val effective = ext.selection.get() intersect ext.effectiveSupported()
+        (effective.members - ext.registered).forEach { leaf ->
+            registerTarget(kotlin, leaf)
+            ext.registered.add(leaf)
+        }
+    }
+
+    internal fun emptyOverlapWarning(
+        path: String,
+        selection: KmpTargetSet,
+        supported: KmpTargetSet,
+    ): String =
+        "kmp-targets: '$path' supports ${ids(supported)} but the selection ${ids(selection)} " +
+            "matches none of them — registering no targets for this module."
+
+    private fun ids(set: KmpTargetSet): List<String> = set.members.map { it.id }.sorted()
 
     private fun registerTarget(kotlin: KotlinMultiplatformExtension, target: KmpTarget) {
         when (target) {
@@ -77,9 +181,5 @@ public class KmpTargetsPlugin : Plugin<Project> {
                 }
             KmpTarget.Web.WasmWasi -> kotlin.wasmWasi { nodejs() }
         }
-    }
-
-    private companion object {
-        const val PROPERTY_NAME: String = "KMP_TARGETS"
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSet.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSet.kt
@@ -35,6 +35,15 @@ public value class KmpTargetSet private constructor(public val members: Set<KmpT
     public operator fun minus(other: KmpTargetSet): KmpTargetSet =
         KmpTargetSet(members - other.members)
 
+    /**
+     * Returns the intersection of this set with [other] — the targets present in both. Defined as a
+     * member (not an extension) so it shadows the stdlib `Iterable.intersect`, which would
+     * otherwise win and return a plain `Set` because [KmpTargetSet] is [Iterable]. This is the
+     * operation the plugin uses to compute `selection ∩ supported`.
+     */
+    public infix fun intersect(other: KmpTargetSet): KmpTargetSet =
+        KmpTargetSet(members intersect other.members)
+
     override fun toString(): String =
         members.joinToString(prefix = "KmpTargetSet(", postfix = ")") { it.id }
 
@@ -61,6 +70,20 @@ public value class KmpTargetSet private constructor(public val members: Set<KmpT
 
         public val jvmFamily: KmpTargetSet =
             KmpTargetSet(setOf(KmpTarget.Jvm.Android, KmpTarget.Jvm.Desktop))
+
+        /**
+         * The canonical "mobile app" shape: Android plus the two iOS leaves. Backs the
+         * `com.rsicarelli.kmptargets.mobile` convention plugin. Android only registers if the
+         * user's selection actually includes it, so this preset does not force AGP onto consumers.
+         */
+        public val mobile: KmpTargetSet =
+            KmpTargetSet(
+                setOf(
+                    KmpTarget.Jvm.Android,
+                    KmpTarget.Native.Apple.Ios.Arm64,
+                    KmpTarget.Native.Apple.Ios.SimulatorArm64,
+                )
+            )
 
         public fun of(vararg targets: KmpTarget): KmpTargetSet = KmpTargetSet(targets.toSet())
     }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
@@ -1,6 +1,5 @@
 package com.rsicarelli.kmptargets
 
-import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -23,51 +22,38 @@ class KmpTargetsExtensionTest {
     }
 
     @Test
-    fun `given only when called then selection contains exactly those targets`() {
+    fun `given extension created when supported accessed then property is unset`() {
         val ext = newExtension()
-        ext.only(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64)
-        assertEquals(
-            KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64),
-            ext.selection.get(),
-        )
+        assertFalse(ext.supported.isPresent)
     }
 
     @Test
-    fun `given only called with no targets when invoked then selection is empty`() {
+    fun `given supported unset when effectiveSupported then defaults to all`() {
         val ext = newExtension()
-        ext.only()
-        assertEquals(KmpTargetSet.empty, ext.selection.get())
+        assertEquals(KmpTargetSet.all, ext.effectiveSupported())
     }
 
     @Test
-    fun `given convention set when exclude is called then selection is convention minus excluded`() {
+    fun `given accumulateSupported called once when effectiveSupported then equals that set`() {
         val ext = newExtension()
-        ext.selection.convention(KmpTargetSet.appleMobile)
-        ext.exclude(KmpTarget.Native.Apple.Ios.SimulatorArm64)
-        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.selection.get())
+        ext.accumulateSupported(KmpTargetSet.apple)
+        assertEquals(KmpTargetSet.apple, ext.effectiveSupported())
     }
 
     @Test
-    fun `given fallback set and no selection when exclude is called then exclude resolves against fallback`() {
+    fun `given accumulateSupported called twice when effectiveSupported then equals the union`() {
         val ext = newExtension()
-        ext.fallback.set(KmpTargetSet.appleMobile)
-        ext.exclude(KmpTarget.Native.Apple.Ios.SimulatorArm64)
-        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.selection.get())
+        ext.accumulateSupported(KmpTargetSet.mobile)
+        ext.accumulateSupported(KmpTargetSet.web)
+        assertEquals(KmpTargetSet.mobile + KmpTargetSet.web, ext.effectiveSupported())
     }
 
     @Test
-    fun `given neither selection nor fallback when exclude is called then selection is empty`() {
+    fun `given accumulateSupported with overlapping sets when effectiveSupported then duplicates collapse`() {
         val ext = newExtension()
-        ext.exclude(KmpTarget.Jvm.Android)
-        assertEquals(KmpTargetSet.empty, ext.selection.get())
-    }
-
-    @Test
-    fun `given only then exclude when invoked then exclude applies to the only-set value`() {
-        val ext = newExtension()
-        ext.only(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64)
-        ext.exclude(KmpTarget.Jvm.Android)
-        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.selection.get())
+        ext.accumulateSupported(KmpTargetSet.apple)
+        ext.accumulateSupported(KmpTargetSet.appleMobile)
+        assertEquals(KmpTargetSet.apple, ext.effectiveSupported())
     }
 
     @Test

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
@@ -72,18 +72,6 @@ class KmpTargetsPluginTest {
     }
 
     @Test
-    fun `given user only override when plugin applied with property set then user value wins`(
-        @TempDir dir: Path
-    ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=android\n")
-        val project = newProject(dir)
-        project.pluginManager.apply("com.rsicarelli.kmptargets")
-        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        ext.only(KmpTarget.Native.Apple.Ios.Arm64)
-        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.selection.get())
-    }
-
-    @Test
     fun `given KMP_TARGETS is invalid when plugin is applied then a GradleException surfaces in the failure chain`(
         @TempDir dir: Path
     ) {

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsSupportedTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsSupportedTest.kt
@@ -1,0 +1,130 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Proves the capability ∩ selection model end-to-end against the *real* Kotlin Multiplatform plugin
+ * applied in-process. These are the load-bearing "does the approach actually register the right KGP
+ * targets" tests — they assert on `kotlin.targets`, not on our own bookkeeping.
+ *
+ * Ordering note: scenarios that declare a `supported` set apply the core plugin first (queuing
+ * registration), declare supported, then apply KGP last — mirroring exactly what a convention
+ * plugin does. This is what lets a narrowed `supported` set be visible before any target is
+ * registered, without `afterEvaluate`.
+ */
+class KmpTargetsSupportedTest {
+
+    @Test
+    fun `given no supported declared and KMP_TARGETS jvm,iosArm64 when applied then exactly those targets register`(
+        @TempDir dir: Path
+    ) {
+        val project = coreThenKgp(dir, kmpTargets = "jvm,iosArm64", supported = null)
+        assertRegisteredTargets(project, "jvm", "iosArm64")
+    }
+
+    @Test
+    fun `given supported apple and KMP_TARGETS jvm,iosArm64 when applied then only iosArm64 registers`(
+        @TempDir dir: Path
+    ) {
+        val project = coreThenKgp(dir, kmpTargets = "jvm,iosArm64", supported = KmpTargetSet.apple)
+        assertRegisteredTargets(project, "iosArm64")
+    }
+
+    @Test
+    fun `given supported jvm only and KMP_TARGETS wasmJs when applied then no targets register`(
+        @TempDir dir: Path
+    ) {
+        val project =
+            coreThenKgp(
+                dir,
+                kmpTargets = "wasmJs",
+                supported = KmpTargetSet.of(KmpTarget.Jvm.Desktop),
+            )
+        assertRegisteredTargets(project /* none */)
+        // warn + skip: skipping is the behavioural guarantee asserted here.
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertTrue(ext.registered.isEmpty())
+    }
+
+    @Test
+    fun `given supported mobile then web declared before KGP and KMP_TARGETS iosArm64,wasmJs when applied then union registers`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=iosArm64,wasmJs\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        KmpTargets.declareSupported(project, KmpTargetSet.mobile)
+        KmpTargets.declareSupported(project, KmpTargetSet.web)
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        assertRegisteredTargets(project, "iosArm64", "wasmJs")
+    }
+
+    @Test
+    fun `given supported web declared after KGP already applied and KMP_TARGETS iosArm64,wasmJs when applied then composition still unions incrementally`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=iosArm64,wasmJs\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        KmpTargets.declareSupported(project, KmpTargetSet.mobile)
+        // KGP applied here (as the first convention plugin would) — registers the mobile slice.
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        // A second convention plugin contributes web *after* KGP is already applied.
+        KmpTargets.declareSupported(project, KmpTargetSet.web)
+        assertRegisteredTargets(project, "iosArm64", "wasmJs")
+    }
+
+    @Test
+    fun `given kmptargets supported property apple and KMP_TARGETS all when applied then only apple targets register`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\nkmptargets.supported=apple\n")
+        val project = newProject(dir)
+        // Property-declared support must be visible before registration, so core-first / KGP-last.
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        assertRegisteredTargets(project, "iosArm64", "iosSimulatorArm64", "macosArm64", "macosX64")
+    }
+
+    @Test
+    fun `given selection disjoint from supported when emptyOverlapWarning then message names path selection and supported`() {
+        val msg =
+            KmpTargets.emptyOverlapWarning(
+                path = ":feature-mobile",
+                selection = KmpTargetSet.of(KmpTarget.Jvm.Desktop),
+                supported = KmpTargetSet.appleMobile,
+            )
+        assertTrue(msg.contains(":feature-mobile"), msg)
+        assertTrue(msg.contains("jvm"), msg)
+        assertTrue(msg.contains("iosArm64"), msg)
+    }
+
+    private fun coreThenKgp(dir: Path, kmpTargets: String, supported: KmpTargetSet?): Project {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=$kmpTargets\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        if (supported != null) KmpTargets.declareSupported(project, supported)
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        return project
+    }
+
+    private fun newProject(dir: Path): Project =
+        ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+
+    /** Asserts the KGP targets registered equal [expected] (ignoring KGP's implicit `metadata`). */
+    private fun assertRegisteredTargets(project: Project, vararg expected: String) {
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        val actual = kotlin.targets.names.filter { it != "metadata" }.toSet()
+        assertEquals(expected.toSet(), actual)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSetTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSetTest.kt
@@ -131,4 +131,42 @@ class KmpTargetSetTest {
         assertEquals(a, b)
         assertEquals(a.hashCode(), b.hashCode())
     }
+
+    @Test
+    fun `given two overlapping sets when intersect then result contains only their common members`() {
+        val a = KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64)
+        val b = KmpTargetSet.apple
+        val result = a intersect b
+        assertEquals(setOf<KmpTarget>(KmpTarget.Native.Apple.Ios.Arm64), result.members)
+    }
+
+    @Test
+    fun `given disjoint sets when intersect then result is empty`() {
+        val result = KmpTargetSet.web intersect KmpTargetSet.appleMobile
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `given a set when intersected with all then result equals the original set`() {
+        val set = KmpTargetSet.of(KmpTarget.Web.Js, KmpTarget.Jvm.Desktop)
+        assertEquals(set.members, (set intersect KmpTargetSet.all).members)
+    }
+
+    @Test
+    fun `given intersect when applied then it is commutative on members`() {
+        val a = KmpTargetSet.apple
+        val b = KmpTargetSet.appleMobile
+        assertEquals((a intersect b).members, (b intersect a).members)
+    }
+
+    @Test
+    fun `given mobile preset when accessed then contains Android and the two iOS leaves`() {
+        val expected =
+            setOf<KmpTarget>(
+                KmpTarget.Jvm.Android,
+                KmpTarget.Native.Apple.Ios.Arm64,
+                KmpTarget.Native.Apple.Ios.SimulatorArm64,
+            )
+        assertEquals(expected, KmpTargetSet.mobile.members)
+    }
 }

--- a/samples/hello-world/build.gradle.kts
+++ b/samples/hello-world/build.gradle.kts
@@ -1,10 +1,3 @@
-plugins {
-    kotlin("multiplatform") version "2.3.21"
-    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
-}
-
-kotlin {
-    sourceSets.commonMain.dependencies {
-        // empty on purpose — the sample exercises plugin wiring, not third-party deps
-    }
-}
+// Root of the multi-module sample — intentionally empty.
+// Each subproject applies a `com.rsicarelli.kmptargets.*` convention plugin to declare its supported
+// targets; the global KMP_TARGETS (gradle.properties) is intersected against each.

--- a/samples/hello-world/core-and-apple/build.gradle.kts
+++ b/samples/hello-world/core-and-apple/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    // Composition: supported = apple ∪ jvm. With KMP_TARGETS=jvm,iosSimulatorArm64 this registers
+    // BOTH jvm and iosSimulatorArm64 — more than .apple alone (iOS only) or .jvm alone (jvm only),
+    // proving that multiple convention ids union their supported sets.
+    id("com.rsicarelli.kmptargets.apple") version "0.1.0-SNAPSHOT"
+    id("com.rsicarelli.kmptargets.jvm") version "0.1.0-SNAPSHOT"
+}

--- a/samples/hello-world/core-and-apple/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
+++ b/samples/hello-world/core-and-apple/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
@@ -1,0 +1,3 @@
+package com.rsicarelli.kmptargets.sample
+
+fun coreAndAppleGreeting(): String = "Hello from core-and-apple (.apple + .jvm)!"

--- a/samples/hello-world/feature-mobile/build.gradle.kts
+++ b/samples/hello-world/feature-mobile/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    // Supports Android + iOS only. With KMP_TARGETS=jvm,iosSimulatorArm64 the jvm is dropped
+    // (not supported here) and only iosSimulatorArm64 registers — Android isn't selected, so no AGP.
+    id("com.rsicarelli.kmptargets.mobile") version "0.1.0-SNAPSHOT"
+}

--- a/samples/hello-world/feature-mobile/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
+++ b/samples/hello-world/feature-mobile/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
@@ -1,0 +1,3 @@
+package com.rsicarelli.kmptargets.sample
+
+fun featureMobileGreeting(): String = "Hello from feature-mobile (.mobile)!"

--- a/samples/hello-world/jvm-tools/build.gradle.kts
+++ b/samples/hello-world/jvm-tools/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    // Supports JVM only. With KMP_TARGETS=jvm,iosSimulatorArm64 the iOS target is dropped and only
+    // jvm registers.
+    id("com.rsicarelli.kmptargets.jvm") version "0.1.0-SNAPSHOT"
+}

--- a/samples/hello-world/jvm-tools/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
+++ b/samples/hello-world/jvm-tools/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
@@ -1,0 +1,3 @@
+package com.rsicarelli.kmptargets.sample
+
+fun jvmToolsGreeting(): String = "Hello from jvm-tools (.jvm)!"

--- a/samples/hello-world/settings.gradle.kts
+++ b/samples/hello-world/settings.gradle.kts
@@ -16,3 +16,10 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "hello-world"
+
+// Heterogeneous modules, each declaring its supported shape by the convention plugin id it applies.
+// The global KMP_TARGETS (see gradle.properties) is intersected against each module's set.
+include(":shared-core") //    .library → all targets
+include(":feature-mobile") // .mobile  → Android + iOS
+include(":jvm-tools") //      .jvm     → JVM only
+include(":core-and-apple") // .apple + .jvm (composition) → iOS/macOS ∪ JVM

--- a/samples/hello-world/shared-core/build.gradle.kts
+++ b/samples/hello-world/shared-core/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    // Supports every target. With KMP_TARGETS=jvm,iosSimulatorArm64 this registers exactly those two.
+    id("com.rsicarelli.kmptargets.library") version "0.1.0-SNAPSHOT"
+}

--- a/samples/hello-world/shared-core/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
+++ b/samples/hello-world/shared-core/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
@@ -1,0 +1,3 @@
+package com.rsicarelli.kmptargets.sample
+
+fun sharedCoreGreeting(): String = "Hello from shared-core (.library)!"

--- a/samples/hello-world/src/commonMain/kotlin/Greeting.kt
+++ b/samples/hello-world/src/commonMain/kotlin/Greeting.kt
@@ -1,3 +1,0 @@
-package com.rsicarelli.kmptargets.sample
-
-fun greeting(): String = "Hello from kmp-targets!"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,3 +18,4 @@ dependencyResolutionManagement {
 rootProject.name = "kmp-targets"
 
 include(":gradle-plugin")
+include(":convention-plugins")


### PR DESCRIPTION
## What & why

`KMP_TARGETS` was **global** — one value forced the same targets on every module, which is wrong for heterogeneous KMP repos. This adds a **per-module capability model**:

- **`supported`** — what a module *can* build (declared per-module).
- **`selection`** — what you *want* to build now (global `KMP_TARGETS`).
- The plugin registers **`selection ∩ supported`** per module.

## How a module declares its shape

Convention plugins (new `:convention-plugins` module) — one line, and they apply KGP for you:

| id | supports |
|---|---|
| `com.rsicarelli.kmptargets.library` | all shipped targets |
| `com.rsicarelli.kmptargets.mobile` | `androidTarget`, `iosArm64`, `iosSimulatorArm64` |
| `com.rsicarelli.kmptargets.apple` | `iosArm64`, `iosSimulatorArm64`, `macosArm64`, `macosX64` |
| `com.rsicarelli.kmptargets.jvm` | `jvm` |
| `com.rsicarelli.kmptargets.web` | `js`, `wasmJs`, `wasmWasi` |

**Composition:** applying multiple ids unions their supported sets (`.apple` + `.jvm` → both families).

**Escape hatch:** the base `com.rsicarelli.kmptargets` id + a `kmptargets.supported` property for one-off modules; with neither, `supported` defaults to all (original behaviour preserved).

**Empty overlap** (`selection ∩ supported = ∅`) → register nothing, log a warning, build proceeds.

## The interesting constraint: composition without `afterEvaluate`

`pluginManager.withPlugin("…multiplatform")` fires synchronously during `apply()`, before the build-script body — so per-module config can't come from the DSL. Convention plugins **accumulate** their baked set into the extension and trigger an **idempotent registration pass** (each pass registers only new leaves), so `.mobile` + `.web` converge on the union regardless of apply order. Registration stays eager and config-cache-safe; only the *advisory* empty-overlap warning uses a narrow, guarded `afterEvaluate`.

`only`/`exclude` are dropped — the build-script write path was dead under the timing wall (pre-release, nothing published to Maven Central).

## Tests (red→green) & verification

**122 tests, 0 failures.** Highlights apply the *real* KGP in-process and assert on `kotlin.targets`:
- `KmpTargetsSupportedTest` — intersection narrowing, empty-overlap skip, composition (both orderings), property-based support.
- `KmpConventionPluginsTest` — each id bakes the right set, composition unions, empty skip, and fails loud if `kotlin("multiplatform")` is pre-applied.
- `KmpTargetSetTest` — `intersect` + `mobile` preset.

End-to-end:
- `task ci` green — multi-module sample: `feature-mobile`→iosSimulatorArm64 only, `jvm-tools`→jvm only, `core-and-apple` (`.apple`+`.jvm`)→both.
- Config cache reused on rebuild.
- Empty-overlap warning verified in a real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)