### PR TITLE
feat: target-driven minimal hierarchy template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ research-prompts-*.txt
 
 # JVM heap dumps from OOM crashes during local test runs
 **/*.hprof
+
+# Stray kotlin_module written to the repo root by KGP applied in-process during tests
+/META-INF/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Dynamically select which Kotlin Multiplatform targets to build.
 
-**Status:** alpha (pre-1.0). The core selector and per-module convention plugins are implemented and exercised by the multi-module sample; helper APIs (`applyHierarchyTemplate`, XCFramework) are roadmap items.
+**Status:** alpha (pre-1.0). The core selector, per-module convention plugins, and the automatic minimal hierarchy template are implemented and exercised by the multi-module sample; further helper APIs (user-defined hierarchy groups, XCFramework) are roadmap items.
 
 `kmp-targets` is a Gradle plugin for Kotlin Multiplatform projects that lets each developer (and each CI runner) choose which KMP targets to build, via a single Gradle property:
 
@@ -141,6 +141,40 @@ Every target Kotlin Multiplatform (KGP 2.3.21) supports, except the deprecated `
 | Web | `js`, `wasmJs`, `wasmWasi` |
 
 Every leaf also accepts a kebab-case alias (e.g. `watchos-sim-arm64`, `linux-x64`, `android-native-arm64`).
+
+### Minimal hierarchy template
+
+KGP's auto-applied `applyDefaultHierarchyTemplate()` builds the *full* source-set hierarchy for all
+possible targets, so an iOS-only module still gets `nativeMain` **and** `appleMain` intermediate
+source sets that are redundant with `iosMain`. Each redundant intermediate spawns ~8 wasteful Gradle
+tasks; across dozens of modules this dominates sync time (see
+[the cost of default hierarchy templates](https://dev.to/rsicarelli/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform-256a)).
+
+Because `kmp-targets` already knows each module's active target set, it applies a **minimal** custom
+hierarchy instead — collapsing every redundant single-child group:
+
+| Active targets | Intermediate source sets |
+|---|---|
+| one iOS leaf | none (target attaches to `commonMain`) |
+| iOS (≥2 leaves) | `iosMain` only — no `appleMain`, no `nativeMain` |
+| iOS + macOS | `appleMain` over `iosMain` + `macosMain` — no `nativeMain` |
+| iOS + Linux | `nativeMain` over `iosMain` + `linuxMain` — no `appleMain` |
+
+It's **on by default** and applied automatically — no configuration needed. To opt out (and let KGP
+apply its own default), set the Gradle property globally or override per project (project wins):
+
+```properties
+# root gradle.properties — global default
+kmptargets.hierarchyTemplate=false
+```
+
+```kotlin
+// any module's build.gradle.kts — per-project override
+kmpTargets { hierarchyTemplate.set(false) }
+```
+
+Precedence is **project DSL > global property > built-in default (`true`)**. Opt out when a module
+supplies its own `applyHierarchyTemplate { … }`, so the plugin stays out of the way.
 
 ## Installation
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -35,8 +35,23 @@ public abstract class KmpTargetsExtension {
      */
     public abstract val supported: Property<KmpTargetSet>
 
+    /**
+     * Per-project opt-out of the minimal custom hierarchy template. Unset defers to the global
+     * `kmptargets.hierarchyTemplate` Gradle property, which itself defaults to `true`. When
+     * `false`, the plugin applies no template and KGP falls back to its own
+     * `applyDefaultHierarchyTemplate()` — also the escape hatch for a module that supplies its own
+     * `applyHierarchyTemplate { … }`.
+     *
+     * Unlike [supported], this *is* readable from the build-script body: the template is applied in
+     * a deferred pass (after evaluation), by which point the DSL value has been set.
+     */
+    public abstract val hierarchyTemplate: Property<Boolean>
+
     /** Leaves already registered with KGP, so repeated registration passes are idempotent. */
     internal val registered: MutableSet<KmpTarget> = mutableSetOf()
+
+    /** True once the minimal hierarchy template has been applied, so it is applied at most once. */
+    internal var hierarchyTemplateApplied: Boolean = false
 
     /**
      * True once a kmp-targets convention plugin has applied KGP, distinguishing it from a

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -1,5 +1,8 @@
 package com.rsicarelli.kmptargets
 
+import com.rsicarelli.kmptargets.hierarchy.computeHierarchySpec
+import com.rsicarelli.kmptargets.hierarchy.resolveHierarchyTemplateEnabled
+import com.rsicarelli.kmptargets.hierarchy.toTemplate
 import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
 import com.rsicarelli.kmptargets.parser.ParseResult
@@ -44,27 +47,33 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // fires. Idempotent, so it composes with the per-declaration passes in declareSupported.
         target.pluginManager.withPlugin(KGP_ID) { KmpTargets.registerResolved(target, ext) }
 
-        // Advisory only: warn when a module ends up with zero targets because its supported set and
-        // the global selection don't overlap. Deferred to afterEvaluate because there is no public
-        // apply-time "all plugins applied" hook, and under composition (.mobile + .web) an earlier
-        // pass is transiently empty before later contributions land — emitting during a pass would
-        // be
-        // spurious. Registration itself stays eager and afterEvaluate-free; only this log line
-        // waits.
+        // Global default for the hierarchy template, read at apply time and pulled out as a
+        // primitive so the afterEvaluate closure below never captures `Project` (config-cache
+        // safe).
+        val globalHierarchyEnabled: Boolean? = hierarchyTemplateEnabledGlobally(target)
+
+        // Two things deferred to afterEvaluate, for the same reason: the final active set is only
+        // known after every convention plugin has declared its supported slice (under composition
+        // .mobile + .web an earlier pass is transiently incomplete), and there is no public
+        // apply-time "all plugins applied" hook. Target *registration* stays eager; only these —
+        // the
+        // advisory warning and the hierarchy template, both functions of the final active set —
+        // wait.
+        // The closure captures only `ext` (immutable sets + booleans) and the primitive flag, so it
+        // stays configuration-cache safe.
         target.afterEvaluate { p ->
-            if (
-                p.plugins.hasPlugin(KGP_ID) &&
-                    ext.registered.isEmpty() &&
-                    ext.selection.get().isNotEmpty()
-            ) {
+            if (!p.plugins.hasPlugin(KGP_ID)) return@afterEvaluate
+            val selection = ext.selection.get()
+            val active = selection intersect ext.effectiveSupported()
+
+            // Advisory only: the supported set and the global selection don't overlap.
+            if (ext.registered.isEmpty() && selection.isNotEmpty()) {
                 p.logger.warn(
-                    KmpTargets.emptyOverlapWarning(
-                        p.path,
-                        ext.selection.get(),
-                        ext.effectiveSupported(),
-                    )
+                    KmpTargets.emptyOverlapWarning(p.path, selection, ext.effectiveSupported())
                 )
             }
+
+            KmpTargets.maybeApplyHierarchyTemplate(p, ext, active, globalHierarchyEnabled)
         }
     }
 
@@ -80,6 +89,21 @@ public class KmpTargetsPlugin : Plugin<Project> {
             GradlePropertySource(target.providers, SUPPORTED_PROPERTY),
             localPropertiesSource(target, SUPPORTED_PROPERTY),
         )
+
+    /**
+     * Reads the global `kmptargets.hierarchyTemplate` flag (Gradle property or `local.properties`).
+     * `null` means "not set — use the built-in default"; anything other than `true`/`false`
+     * (case-insensitive) is treated as unset.
+     */
+    private fun hierarchyTemplateEnabledGlobally(target: Project): Boolean? =
+        composeSelectionSources(
+                GradlePropertySource(target.providers, HIERARCHY_TEMPLATE_PROPERTY),
+                localPropertiesSource(target, HIERARCHY_TEMPLATE_PROPERTY),
+            )
+            .read()
+            ?.trim()
+            ?.lowercase()
+            ?.toBooleanStrictOrNull()
 
     private fun localPropertiesSource(target: Project, propertyName: String): SelectionSource {
         val provider =
@@ -99,6 +123,7 @@ public class KmpTargetsPlugin : Plugin<Project> {
     internal companion object {
         const val KMP_TARGETS: String = "KMP_TARGETS"
         const val SUPPORTED_PROPERTY: String = "kmptargets.supported"
+        const val HIERARCHY_TEMPLATE_PROPERTY: String = "kmptargets.hierarchyTemplate"
         const val KGP_ID: String = "org.jetbrains.kotlin.multiplatform"
     }
 }
@@ -149,6 +174,25 @@ public object KmpTargets {
             registerTarget(kotlin, leaf)
             ext.registered.add(leaf)
         }
+    }
+
+    /**
+     * Applies the minimal hierarchy template for [active], at most once per module. Calling
+     * `applyHierarchyTemplate` is itself what suppresses KGP's costly default: KGP only
+     * auto-applies its default when no template has been applied yet. When disabled (or the active
+     * set is empty), we apply nothing and let KGP fall back to its default.
+     */
+    internal fun maybeApplyHierarchyTemplate(
+        project: Project,
+        ext: KmpTargetsExtension,
+        active: KmpTargetSet,
+        globalEnabled: Boolean?,
+    ) {
+        if (ext.hierarchyTemplateApplied || active.isEmpty()) return
+        if (!resolveHierarchyTemplateEnabled(ext.hierarchyTemplate.orNull, globalEnabled)) return
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        kotlin.applyHierarchyTemplate(computeHierarchySpec(active).toTemplate())
+        ext.hierarchyTemplateApplied = true
     }
 
     internal fun emptyOverlapWarning(

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyComposer.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyComposer.kt
@@ -1,0 +1,56 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+
+/**
+ * Computes the minimal correct hierarchy for [active] — the heart of the feature.
+ *
+ * Walks the fixed group taxonomy ([HierarchyGroup]) restricted to the active leaves and applies the
+ * collapse rule uniformly, bottom-up: a group materializes a source set only when it merges ≥2
+ * present children; a group with exactly one present child collapses (that child reconnects to the
+ * group's parent, so collapses chain); a group with no present children is dropped. A single leaf
+ * is always present.
+ *
+ * Consequence (the article's point): an iOS-only module yields `iosMain` only — no redundant
+ * `appleMain`/`nativeMain` — while iOS + linux yields `nativeMain` over `iosMain` + `linuxMain`.
+ */
+internal fun computeHierarchySpec(active: KmpTargetSet): HierarchySpec {
+    // The native subtree, collapsed; plus any leaf that belongs to no group (jvm/android/web),
+    // which always attaches directly to `common`.
+    val nativeRoots = contributionOf(HierarchyGroup.NATIVE, active)
+    val ungrouped =
+        active.members
+            .filter { mostSpecificGroup(it) == null }
+            .map<KmpTarget, HierarchyNode> { HierarchyNode.Leaf(it) }
+            .toSet()
+    return HierarchySpec(nativeRoots + ungrouped)
+}
+
+/**
+ * The set of nodes [group] contributes to its parent's children, with the collapse rule applied: ≥2
+ * present children ⇒ a single [HierarchyNode.Group]; exactly one ⇒ that child bubbles up unchanged
+ * (collapse); none ⇒ nothing.
+ */
+private fun contributionOf(group: HierarchyGroup, active: KmpTargetSet): Set<HierarchyNode> {
+    val fromChildGroups: Set<HierarchyNode> =
+        HierarchyGroup.entries
+            .filter { it.parent == group }
+            .flatMap { contributionOf(it, active) }
+            .toSet()
+    val directLeaves: Set<HierarchyNode> =
+        active.members
+            .filter { mostSpecificGroup(it) == group }
+            .map { HierarchyNode.Leaf(it) }
+            .toSet()
+    val presentChildren = fromChildGroups + directLeaves
+    return when (presentChildren.size) {
+        0 -> emptySet()
+        1 -> presentChildren
+        else -> setOf(HierarchyNode.Group(group, presentChildren))
+    }
+}
+
+/** The deepest group that owns [target], or `null` if no contributor owns it (jvm/android/web). */
+private fun mostSpecificGroup(target: KmpTarget): HierarchyGroup? =
+    HierarchyContributor.all.filter { it.owns(target) }.maxByOrNull { it.group.depth }?.group

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyContributor.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyContributor.kt
@@ -1,0 +1,89 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+
+/**
+ * One contributor per [HierarchyGroup]: it knows the [group] it represents and which [KmpTarget]
+ * leaves belong to it ([owns]). Membership is expressed as a pure predicate over the sealed
+ * [KmpTarget] branches — the single source of truth, so it never drifts when a leaf is added.
+ *
+ * The composer walks [all] to discover, for any active target, its most-specific owning group, then
+ * prunes and collapses redundant groups. Keeping membership here (not as duplicated leaf lists)
+ * means a new target is classified automatically by its branch type.
+ */
+internal sealed interface HierarchyContributor {
+
+    val group: HierarchyGroup
+
+    fun owns(target: KmpTarget): Boolean
+
+    companion object {
+        /** All contributors, deepest-first is not required; ordering is by taxonomy for clarity. */
+        val all: List<HierarchyContributor> =
+            listOf(
+                NativeContributor,
+                AppleContributor,
+                IosContributor,
+                MacosContributor,
+                WatchosContributor,
+                TvosContributor,
+                LinuxContributor,
+                MingwContributor,
+                AndroidNativeContributor,
+            )
+    }
+}
+
+internal data object NativeContributor : HierarchyContributor {
+    override val group = HierarchyGroup.NATIVE
+
+    override fun owns(target: KmpTarget): Boolean = target is KmpTarget.Native
+}
+
+internal data object AppleContributor : HierarchyContributor {
+    override val group = HierarchyGroup.APPLE
+
+    override fun owns(target: KmpTarget): Boolean = target is KmpTarget.Native.Apple
+}
+
+internal data object IosContributor : HierarchyContributor {
+    override val group = HierarchyGroup.IOS
+
+    override fun owns(target: KmpTarget): Boolean = target is KmpTarget.Native.Apple.Ios
+}
+
+internal data object MacosContributor : HierarchyContributor {
+    override val group = HierarchyGroup.MACOS
+
+    override fun owns(target: KmpTarget): Boolean = target is KmpTarget.Native.Apple.Macos
+}
+
+internal data object WatchosContributor : HierarchyContributor {
+    override val group = HierarchyGroup.WATCHOS
+
+    override fun owns(target: KmpTarget): Boolean = target is KmpTarget.Native.Apple.Watchos
+}
+
+internal data object TvosContributor : HierarchyContributor {
+    override val group = HierarchyGroup.TVOS
+
+    override fun owns(target: KmpTarget): Boolean = target is KmpTarget.Native.Apple.Tvos
+}
+
+internal data object LinuxContributor : HierarchyContributor {
+    override val group = HierarchyGroup.LINUX
+
+    override fun owns(target: KmpTarget): Boolean = target is KmpTarget.Native.Linux
+}
+
+internal data object MingwContributor : HierarchyContributor {
+    override val group = HierarchyGroup.MINGW
+
+    override fun owns(target: KmpTarget): Boolean = target is KmpTarget.Native.Mingw
+}
+
+internal data object AndroidNativeContributor : HierarchyContributor {
+    override val group = HierarchyGroup.ANDROID_NATIVE
+
+    override fun owns(target: KmpTarget): Boolean = target is KmpTarget.Native.AndroidNative
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyGroup.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyGroup.kt
@@ -1,0 +1,43 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+/**
+ * The intermediate source-set groups Kotlin Multiplatform can introduce in a hierarchy template.
+ *
+ * This mirrors KGP's own group taxonomy exactly — and ONLY the native subtree, because that is the
+ * only place KGP creates intermediate source sets. JVM, Android and web targets attach directly to
+ * `common` with no intermediate group, so they have no entry here.
+ *
+ * [groupName] is the KGP group name; the source set it materializes is `groupName + "Main"/"Test"`
+ * (e.g. [APPLE] → `appleMain`/`appleTest`). [parent] encodes the fixed nesting that the collapse
+ * rule prunes against.
+ */
+internal enum class HierarchyGroup(val groupName: String) {
+    NATIVE("native"),
+    APPLE("apple"),
+    IOS("ios"),
+    MACOS("macos"),
+    WATCHOS("watchos"),
+    TVOS("tvos"),
+    LINUX("linux"),
+    MINGW("mingw"),
+    ANDROID_NATIVE("androidNative");
+
+    /** The enclosing group, or `null` for a group that attaches directly to `common`. */
+    val parent: HierarchyGroup?
+        get() =
+            when (this) {
+                NATIVE -> null
+                APPLE,
+                LINUX,
+                MINGW,
+                ANDROID_NATIVE -> NATIVE
+                IOS,
+                MACOS,
+                WATCHOS,
+                TVOS -> APPLE
+            }
+
+    /** Depth from the `common` root (NATIVE = 0, APPLE = 1, IOS = 2). */
+    val depth: Int
+        get() = generateSequence(parent) { it.parent }.count()
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchySpec.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchySpec.kt
@@ -1,0 +1,21 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+
+/**
+ * The minimal hierarchy to apply, as a pure tree rooted at `common`.
+ *
+ * [roots] are the nodes that attach directly under `commonMain`. Children are held as [Set]s so
+ * equality is order-independent — the collapse rule and its tests compare specs structurally, and
+ * KGP does not care about the order `with…()`/`group()` calls are emitted in.
+ */
+internal data class HierarchySpec(val roots: Set<HierarchyNode>)
+
+internal sealed interface HierarchyNode {
+
+    /** An intermediate group source set (e.g. `appleMain`), invariant: always ≥2 [children]. */
+    data class Group(val group: HierarchyGroup, val children: Set<HierarchyNode>) : HierarchyNode
+
+    /** A single KMP target leaf (e.g. `iosArm64Main`). */
+    data class Leaf(val target: KmpTarget) : HierarchyNode
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateAdapter.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateAdapter.kt
@@ -1,0 +1,59 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinHierarchyBuilder
+
+/**
+ * Turns a pure [HierarchySpec] into the builder lambda KGP's `applyHierarchyTemplate { … }`
+ * expects.
+ *
+ * Only the group structure (and the leaves *inside* groups) is emitted: a leaf that sits directly
+ * under `common` is skipped, because KGP already attaches every registered target's `*Main` to
+ * `commonMain` — emitting `withJvm()` at the common root would be a redundant no-op. So a spec with
+ * no groups (e.g. jvm-only, web-only) yields an effectively empty template.
+ */
+internal fun HierarchySpec.toTemplate(): KotlinHierarchyBuilder.Root.() -> Unit = {
+    common { roots.filterIsInstance<HierarchyNode.Group>().forEach { emit(it) } }
+}
+
+private fun KotlinHierarchyBuilder.emit(node: HierarchyNode) {
+    when (node) {
+        is HierarchyNode.Group -> group(node.group.groupName) { node.children.forEach { emit(it) } }
+        is HierarchyNode.Leaf -> withLeaf(node.target)
+    }
+}
+
+/**
+ * Attaches a single target to the current group. Exhaustive `when` over the sealed [KmpTarget] —
+ * mirrors `KmpTargets.registerTarget`, so adding a new leaf forces a corresponding builder call
+ * here (compile error until handled).
+ */
+private fun KotlinHierarchyBuilder.withLeaf(target: KmpTarget) {
+    when (target) {
+        KmpTarget.Jvm.Android -> withAndroidTarget()
+        KmpTarget.Jvm.Desktop -> withJvm()
+        KmpTarget.Native.Apple.Ios.Arm64 -> withIosArm64()
+        KmpTarget.Native.Apple.Ios.SimulatorArm64 -> withIosSimulatorArm64()
+        KmpTarget.Native.Apple.Ios.X64 -> withIosX64()
+        KmpTarget.Native.Apple.Macos.Arm64 -> withMacosArm64()
+        KmpTarget.Native.Apple.Macos.X64 -> withMacosX64()
+        KmpTarget.Native.Apple.Watchos.Arm64 -> withWatchosArm64()
+        KmpTarget.Native.Apple.Watchos.Arm32 -> withWatchosArm32()
+        KmpTarget.Native.Apple.Watchos.X64 -> withWatchosX64()
+        KmpTarget.Native.Apple.Watchos.SimulatorArm64 -> withWatchosSimulatorArm64()
+        KmpTarget.Native.Apple.Watchos.DeviceArm64 -> withWatchosDeviceArm64()
+        KmpTarget.Native.Apple.Tvos.Arm64 -> withTvosArm64()
+        KmpTarget.Native.Apple.Tvos.X64 -> withTvosX64()
+        KmpTarget.Native.Apple.Tvos.SimulatorArm64 -> withTvosSimulatorArm64()
+        KmpTarget.Native.Linux.X64 -> withLinuxX64()
+        KmpTarget.Native.Linux.Arm64 -> withLinuxArm64()
+        KmpTarget.Native.Mingw.X64 -> withMingwX64()
+        KmpTarget.Native.AndroidNative.Arm32 -> withAndroidNativeArm32()
+        KmpTarget.Native.AndroidNative.Arm64 -> withAndroidNativeArm64()
+        KmpTarget.Native.AndroidNative.X86 -> withAndroidNativeX86()
+        KmpTarget.Native.AndroidNative.X64 -> withAndroidNativeX64()
+        KmpTarget.Web.Js -> withJs()
+        KmpTarget.Web.WasmJs -> withWasmJs()
+        KmpTarget.Web.WasmWasi -> withWasmWasi()
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateGate.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateGate.kt
@@ -1,0 +1,13 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+/**
+ * Resolves whether the minimal hierarchy template is enabled for a module.
+ *
+ * Precedence: per-project override ([projectOverride], the `kmpTargets { hierarchyTemplate }` DSL)
+ * wins over the [globalProperty] default (`kmptargets.hierarchyTemplate`), which wins over the
+ * built-in default of `true`. A `null` at a level means "not set — defer to the next level".
+ */
+internal fun resolveHierarchyTemplateEnabled(
+    projectOverride: Boolean?,
+    globalProperty: Boolean?,
+): Boolean = projectOverride ?: globalProperty ?: true

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyComposerTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyComposerTest.kt
@@ -1,0 +1,232 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Exhaustive proof of the collapse rule — the heart of the feature — as a pure function over the
+ * active target set. Asserts the exact group set, nesting, and that redundant single-child groups
+ * are collapsed. No Gradle involved.
+ */
+class HierarchyComposerTest {
+
+    @Test
+    fun `given a single iOS leaf when computed then no intermediate groups`() {
+        val spec = computeHierarchySpec(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64))
+        assertEquals(spec(leaf(KmpTarget.Native.Apple.Ios.Arm64)), spec)
+        assertTrue(spec.allGroups().isEmpty())
+    }
+
+    @Test
+    fun `given iOS only when computed then iosMain only and no appleMain or nativeMain`() {
+        val spec = computeHierarchySpec(KmpTargetSet.appleMobile)
+        assertEquals(spec(iosGroup()), spec)
+        assertEquals(setOf(HierarchyGroup.IOS), spec.allGroups().toSet())
+    }
+
+    @Test
+    fun `given iOS and macOS when computed then appleMain over iosMain and macosMain and no nativeMain`() {
+        val spec = computeHierarchySpec(KmpTargetSet.appleMobile + KmpTargetSet.appleDesktop)
+        assertEquals(spec(group(HierarchyGroup.APPLE, iosGroup(), macosGroup())), spec)
+        assertTrue(HierarchyGroup.NATIVE !in spec.allGroups())
+    }
+
+    @Test
+    fun `given iOS and a single linuxX64 when computed then nativeMain over iosMain and the linux leaf`() {
+        val spec = computeHierarchySpec(KmpTargetSet.appleMobile + KmpTarget.Native.Linux.X64)
+        assertEquals(
+            spec(group(HierarchyGroup.NATIVE, iosGroup(), leaf(KmpTarget.Native.Linux.X64))),
+            spec,
+        )
+        assertTrue(HierarchyGroup.APPLE !in spec.allGroups())
+        assertTrue(HierarchyGroup.LINUX !in spec.allGroups())
+    }
+
+    @Test
+    fun `given iOS and linux when computed then nativeMain over iosMain and linuxMain and no appleMain`() {
+        val spec = computeHierarchySpec(KmpTargetSet.appleMobile + KmpTargetSet.linux)
+        assertEquals(spec(group(HierarchyGroup.NATIVE, iosGroup(), linuxGroup())), spec)
+        assertTrue(HierarchyGroup.APPLE !in spec.allGroups())
+    }
+
+    @Test
+    fun `given all Apple when computed then appleMain over ios macos watchos tvos`() {
+        val spec = computeHierarchySpec(KmpTargetSet.apple)
+        assertEquals(
+            spec(
+                group(HierarchyGroup.APPLE, iosGroup(), macosGroup(), watchosGroup(), tvosGroup())
+            ),
+            spec,
+        )
+        assertTrue(HierarchyGroup.NATIVE !in spec.allGroups())
+    }
+
+    @Test
+    fun `given native preset when computed then nativeMain over apple linux mingw-leaf androidNative`() {
+        val spec = computeHierarchySpec(KmpTargetSet.native)
+        val expected =
+            spec(
+                group(
+                    HierarchyGroup.NATIVE,
+                    group(
+                        HierarchyGroup.APPLE,
+                        iosGroup(),
+                        macosGroup(),
+                        watchosGroup(),
+                        tvosGroup(),
+                    ),
+                    linuxGroup(),
+                    leaf(KmpTarget.Native.Mingw.X64),
+                    androidNativeGroup(),
+                )
+            )
+        assertEquals(expected, spec)
+    }
+
+    @Test
+    fun `given jvm only when computed then no groups`() {
+        val spec = computeHierarchySpec(KmpTargetSet.of(KmpTarget.Jvm.Desktop))
+        assertEquals(spec(leaf(KmpTarget.Jvm.Desktop)), spec)
+        assertTrue(spec.allGroups().isEmpty())
+    }
+
+    @Test
+    fun `given web only when computed then no groups`() {
+        val spec = computeHierarchySpec(KmpTargetSet.web)
+        assertTrue(spec.allGroups().isEmpty())
+        assertEquals(
+            setOf(KmpTarget.Web.Js, KmpTarget.Web.WasmJs, KmpTarget.Web.WasmWasi),
+            spec.leafTargets(),
+        )
+    }
+
+    @Test
+    fun `given jvm and web when computed then no native groups`() {
+        val spec = computeHierarchySpec(KmpTargetSet.of(KmpTarget.Jvm.Desktop) + KmpTargetSet.web)
+        assertTrue(spec.allGroups().isEmpty())
+    }
+
+    @Test
+    fun `given empty set when computed then empty spec`() {
+        assertEquals(HierarchySpec(emptySet()), computeHierarchySpec(KmpTargetSet.empty))
+    }
+
+    @Test
+    fun `given the full all set when computed then the complete canonical tree`() {
+        val spec = computeHierarchySpec(KmpTargetSet.all)
+        val expected =
+            spec(
+                group(
+                    HierarchyGroup.NATIVE,
+                    group(
+                        HierarchyGroup.APPLE,
+                        iosGroup(),
+                        macosGroup(),
+                        watchosGroup(),
+                        tvosGroup(),
+                    ),
+                    linuxGroup(),
+                    leaf(KmpTarget.Native.Mingw.X64),
+                    androidNativeGroup(),
+                ),
+                leaf(KmpTarget.Jvm.Android),
+                leaf(KmpTarget.Jvm.Desktop),
+                leaf(KmpTarget.Web.Js),
+                leaf(KmpTarget.Web.WasmJs),
+                leaf(KmpTarget.Web.WasmWasi),
+            )
+        assertEquals(expected, spec)
+    }
+
+    @Test
+    fun `given any single-leaf selection when computed then zero group nodes`() {
+        for (target in KmpTarget.all) {
+            val spec = computeHierarchySpec(KmpTargetSet.of(target))
+            assertTrue(spec.allGroups().isEmpty(), "single leaf $target produced groups")
+        }
+    }
+
+    @Test
+    fun `given a single watchos leaf when computed then collapses through watchos apple and native`() {
+        val spec = computeHierarchySpec(KmpTargetSet.of(KmpTarget.Native.Apple.Watchos.Arm64))
+        assertEquals(spec(leaf(KmpTarget.Native.Apple.Watchos.Arm64)), spec)
+    }
+
+    // -- helpers --------------------------------------------------------------------------------
+
+    private fun leaf(t: KmpTarget) = HierarchyNode.Leaf(t)
+
+    private fun group(g: HierarchyGroup, vararg children: HierarchyNode) =
+        HierarchyNode.Group(g, children.toSet())
+
+    private fun spec(vararg roots: HierarchyNode) = HierarchySpec(roots.toSet())
+
+    private fun iosGroup() =
+        group(
+            HierarchyGroup.IOS,
+            leaf(KmpTarget.Native.Apple.Ios.Arm64),
+            leaf(KmpTarget.Native.Apple.Ios.SimulatorArm64),
+            leaf(KmpTarget.Native.Apple.Ios.X64),
+        )
+
+    private fun macosGroup() =
+        group(
+            HierarchyGroup.MACOS,
+            leaf(KmpTarget.Native.Apple.Macos.Arm64),
+            leaf(KmpTarget.Native.Apple.Macos.X64),
+        )
+
+    private fun watchosGroup() =
+        group(
+            HierarchyGroup.WATCHOS,
+            leaf(KmpTarget.Native.Apple.Watchos.Arm64),
+            leaf(KmpTarget.Native.Apple.Watchos.Arm32),
+            leaf(KmpTarget.Native.Apple.Watchos.X64),
+            leaf(KmpTarget.Native.Apple.Watchos.SimulatorArm64),
+            leaf(KmpTarget.Native.Apple.Watchos.DeviceArm64),
+        )
+
+    private fun tvosGroup() =
+        group(
+            HierarchyGroup.TVOS,
+            leaf(KmpTarget.Native.Apple.Tvos.Arm64),
+            leaf(KmpTarget.Native.Apple.Tvos.X64),
+            leaf(KmpTarget.Native.Apple.Tvos.SimulatorArm64),
+        )
+
+    private fun linuxGroup() =
+        group(
+            HierarchyGroup.LINUX,
+            leaf(KmpTarget.Native.Linux.X64),
+            leaf(KmpTarget.Native.Linux.Arm64),
+        )
+
+    private fun androidNativeGroup() =
+        group(
+            HierarchyGroup.ANDROID_NATIVE,
+            leaf(KmpTarget.Native.AndroidNative.Arm32),
+            leaf(KmpTarget.Native.AndroidNative.Arm64),
+            leaf(KmpTarget.Native.AndroidNative.X86),
+            leaf(KmpTarget.Native.AndroidNative.X64),
+        )
+}
+
+private fun HierarchySpec.allGroups(): List<HierarchyGroup> = roots.flatMap { it.groupsRecursive() }
+
+private fun HierarchyNode.groupsRecursive(): List<HierarchyGroup> =
+    when (this) {
+        is HierarchyNode.Leaf -> emptyList()
+        is HierarchyNode.Group -> listOf(group) + children.flatMap { it.groupsRecursive() }
+    }
+
+private fun HierarchySpec.leafTargets(): Set<KmpTarget> =
+    roots.flatMap { it.leavesRecursive() }.toSet()
+
+private fun HierarchyNode.leavesRecursive(): List<KmpTarget> =
+    when (this) {
+        is HierarchyNode.Leaf -> listOf(target)
+        is HierarchyNode.Group -> children.flatMap { it.leavesRecursive() }
+    }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyContributorTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyContributorTest.kt
@@ -1,0 +1,71 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Each contributor's [HierarchyContributor.owns] predicate must match exactly its KGP family
+ * membership across every known leaf. Guards against drift if a leaf is added to a branch.
+ */
+class HierarchyContributorTest {
+
+    @Test
+    fun `given NativeContributor when matched against all leaves then it owns exactly the native preset`() {
+        assertOwns(NativeContributor, KmpTargetSet.native)
+    }
+
+    @Test
+    fun `given AppleContributor when matched against all leaves then it owns exactly the apple preset`() {
+        assertOwns(AppleContributor, KmpTargetSet.apple)
+    }
+
+    @Test
+    fun `given IosContributor when matched against all leaves then it owns exactly the iOS leaves`() {
+        assertOwns(IosContributor, KmpTargetSet.appleMobile)
+    }
+
+    @Test
+    fun `given MacosContributor when matched against all leaves then it owns exactly the macOS leaves`() {
+        assertOwns(MacosContributor, KmpTargetSet.appleDesktop)
+    }
+
+    @Test
+    fun `given WatchosContributor when matched against all leaves then it owns exactly the watchOS leaves`() {
+        assertOwns(WatchosContributor, KmpTargetSet.appleWatch)
+    }
+
+    @Test
+    fun `given TvosContributor when matched against all leaves then it owns exactly the tvOS leaves`() {
+        assertOwns(TvosContributor, KmpTargetSet.appleTv)
+    }
+
+    @Test
+    fun `given LinuxContributor when matched against all leaves then it owns exactly the linux leaves`() {
+        assertOwns(LinuxContributor, KmpTargetSet.linux)
+    }
+
+    @Test
+    fun `given MingwContributor when matched against all leaves then it owns exactly the mingw leaf`() {
+        assertOwns(MingwContributor, KmpTargetSet.mingw)
+    }
+
+    @Test
+    fun `given AndroidNativeContributor when matched against all leaves then it owns exactly the androidNative leaves`() {
+        assertOwns(AndroidNativeContributor, KmpTargetSet.androidNative)
+    }
+
+    @Test
+    fun `given the contributor registry when listed then there is one per native group`() {
+        assertEquals(
+            HierarchyGroup.entries.toSet(),
+            HierarchyContributor.all.map { it.group }.toSet(),
+        )
+        assertEquals(HierarchyContributor.all.size, HierarchyContributor.all.map { it.group }.size)
+    }
+
+    private fun assertOwns(contributor: HierarchyContributor, expected: KmpTargetSet) {
+        assertEquals(expected.members, KmpTarget.all.filter { contributor.owns(it) }.toSet())
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateGateTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateGateTest.kt
@@ -1,0 +1,43 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/** The opt-out precedence: project DSL override > global property > built-in default (true). */
+class HierarchyTemplateGateTest {
+
+    @Test
+    fun `given nothing set when resolved then enabled by default`() {
+        assertTrue(resolveHierarchyTemplateEnabled(projectOverride = null, globalProperty = null))
+    }
+
+    @Test
+    fun `given global property false and no project override when resolved then disabled`() {
+        assertFalse(resolveHierarchyTemplateEnabled(projectOverride = null, globalProperty = false))
+    }
+
+    @Test
+    fun `given global property true and no project override when resolved then enabled`() {
+        assertTrue(resolveHierarchyTemplateEnabled(projectOverride = null, globalProperty = true))
+    }
+
+    @Test
+    fun `given project override true and global false when resolved then project wins enabled`() {
+        assertTrue(resolveHierarchyTemplateEnabled(projectOverride = true, globalProperty = false))
+    }
+
+    @Test
+    fun `given project override false and global true when resolved then project wins disabled`() {
+        assertFalse(resolveHierarchyTemplateEnabled(projectOverride = false, globalProperty = true))
+    }
+
+    @Test
+    fun `given project override false and no global when resolved then disabled`() {
+        assertEquals(
+            false,
+            resolveHierarchyTemplateEnabled(projectOverride = false, globalProperty = null),
+        )
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
@@ -1,0 +1,157 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+import com.rsicarelli.kmptargets.KmpTargetsExtension
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Proves the hierarchy template against the *real* Kotlin Multiplatform plugin applied in-process.
+ *
+ * `ProjectBuilder` + [ProjectInternal.evaluate] pumps KGP's lifecycle far enough that hierarchy
+ * source sets actually materialize (verified: KGP's default template creates
+ * `appleMain`/`nativeMain` for an iOS-only module). So these tests assert on the concrete
+ * `kotlin.sourceSets` names — the load-bearing "does the minimal template actually apply, and does
+ * it suppress KGP's default" proof.
+ */
+class HierarchyTemplateInProcessTest {
+
+    @Test
+    fun `given iOS only when applied then iosMain materializes and appleMain nativeMain are suppressed`(
+        @TempDir dir: Path
+    ) {
+        val sourceSets = sourceSetsOf(dir, "iosArm64,iosX64,iosSimulatorArm64")
+        assertTrue("iosMain" in sourceSets, sourceSets.toString())
+        assertFalse("appleMain" in sourceSets, "default not suppressed: $sourceSets")
+        assertFalse("nativeMain" in sourceSets, "default not suppressed: $sourceSets")
+    }
+
+    @Test
+    fun `given iOS and macOS when applied then appleMain materializes but nativeMain is suppressed`(
+        @TempDir dir: Path
+    ) {
+        val sourceSets = sourceSetsOf(dir, "iosArm64,iosX64,iosSimulatorArm64,macosArm64,macosX64")
+        assertTrue("appleMain" in sourceSets, sourceSets.toString())
+        assertTrue("iosMain" in sourceSets, sourceSets.toString())
+        assertTrue("macosMain" in sourceSets, sourceSets.toString())
+        assertFalse("nativeMain" in sourceSets, "nativeMain should collapse: $sourceSets")
+    }
+
+    @Test
+    fun `given jvm only when applied then no native intermediate source sets exist`(
+        @TempDir dir: Path
+    ) {
+        val sourceSets = sourceSetsOf(dir, "jvm")
+        assertFalse("nativeMain" in sourceSets, sourceSets.toString())
+        assertFalse("appleMain" in sourceSets, sourceSets.toString())
+    }
+
+    @Test
+    fun `given hierarchyTemplate disabled via extension and iOS only when applied then KGP default applies`(
+        @TempDir dir: Path
+    ) {
+        val sourceSets =
+            sourceSetsOf(dir, "iosArm64,iosX64,iosSimulatorArm64") {
+                it.extensions
+                    .getByType(KmpTargetsExtension::class.java)
+                    .hierarchyTemplate
+                    .set(false)
+            }
+        assertTrue(
+            "appleMain" in sourceSets,
+            "opt-out should fall back to KGP default: $sourceSets",
+        )
+        assertTrue("nativeMain" in sourceSets, sourceSets.toString())
+    }
+
+    @Test
+    fun `given global property false and iOS only when applied then KGP default applies`(
+        @TempDir dir: Path
+    ) {
+        val sourceSets =
+            sourceSetsOf(
+                dir,
+                "iosArm64,iosX64,iosSimulatorArm64",
+                extraProps = "kmptargets.hierarchyTemplate=false\n",
+            )
+        assertTrue("appleMain" in sourceSets, "global off should keep KGP default: $sourceSets")
+    }
+
+    @Test
+    fun `given global property false but project override true when applied then minimal template wins`(
+        @TempDir dir: Path
+    ) {
+        val sourceSets =
+            sourceSetsOf(
+                dir,
+                "iosArm64,iosX64,iosSimulatorArm64",
+                extraProps = "kmptargets.hierarchyTemplate=false\n",
+            ) {
+                it.extensions.getByType(KmpTargetsExtension::class.java).hierarchyTemplate.set(true)
+            }
+        assertTrue("iosMain" in sourceSets, sourceSets.toString())
+        assertFalse("appleMain" in sourceSets, "project override should win: $sourceSets")
+    }
+
+    @Test
+    fun `given a plain Kotlin Multiplatform module without kmp-targets when applied then KGP default is untouched`(
+        @TempDir dir: Path
+    ) {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        kotlin.iosArm64()
+        kotlin.iosX64()
+        kotlin.iosSimulatorArm64()
+        (project as ProjectInternal).evaluate()
+        val sourceSets = kotlin.sourceSets.names.toSet()
+        assertTrue("appleMain" in sourceSets, "non-interference: KGP default expected: $sourceSets")
+        assertTrue("nativeMain" in sourceSets, sourceSets.toString())
+    }
+
+    @Test
+    fun `given core and KGP applied when reading the active set then the spec matches the minimal tree`(
+        @TempDir dir: Path
+    ) {
+        // Proves the active-set -> spec wiring uses selection ∩ effectiveSupported. Materialization
+        // is asserted by the source-set tests above; here we pin the pure decision on a real
+        // extension fed by a real KMP_TARGETS property.
+        dir.resolve("gradle.properties")
+            .writeText("KMP_TARGETS=iosArm64,iosX64,iosSimulatorArm64\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        val active = ext.selection.get() intersect KmpTargetSet.all
+        val groups = computeHierarchySpec(active).roots.filterIsInstance<HierarchyNode.Group>()
+        assertEquals(setOf(HierarchyGroup.IOS), groups.map { it.group }.toSet())
+    }
+
+    private fun sourceSetsOf(
+        dir: Path,
+        kmpTargets: String,
+        extraProps: String = "",
+        configure: (Project) -> Unit = {},
+    ): Set<String> {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=$kmpTargets\n$extraProps")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        configure(project)
+        (project as ProjectInternal).evaluate()
+        return project.extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .sourceSets
+            .names
+            .toSet()
+    }
+}

--- a/samples/hello-world/build.gradle.kts
+++ b/samples/hello-world/build.gradle.kts
@@ -1,3 +1,9 @@
-// Root of the multi-module sample — intentionally empty.
-// Each subproject applies a `com.rsicarelli.kmptargets.*` convention plugin to declare its supported
+// Root of the multi-module sample.
+// Most subprojects apply a `com.rsicarelli.kmptargets.*` convention plugin to declare their supported
 // targets; the global KMP_TARGETS (gradle.properties) is intersected against each.
+//
+// Kotlin Multiplatform is declared here once with `apply false` so every subproject shares a single
+// KGP classloader — both those that apply it via a convention plugin and :plain-kmp, which applies it
+// directly. Without this, KGP's shared KotlinNativeBundleBuildService conflicts across sibling
+// projects loaded by different classloaders.
+plugins { kotlin("multiplatform") version "2.3.21" apply false }

--- a/samples/hello-world/core-and-apple/build.gradle.kts
+++ b/samples/hello-world/core-and-apple/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    // Composition: supported = apple ∪ jvm. With KMP_TARGETS=jvm,iosSimulatorArm64 this registers
-    // BOTH jvm and iosSimulatorArm64 — more than .apple alone (iOS only) or .jvm alone (jvm only),
-    // proving that multiple convention ids union their supported sets.
+    // Composition: supported = apple ∪ jvm. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 this
+    // registers jvm + both iOS leaves — more than .apple alone (iOS only) or .jvm alone (jvm only),
+    // proving that multiple convention ids union their supported sets. The template yields jvm at
+    // common + a single `iosMain` (no `appleMain`/`nativeMain`).
     id("com.rsicarelli.kmptargets.apple") version "0.1.0-SNAPSHOT"
     id("com.rsicarelli.kmptargets.jvm") version "0.1.0-SNAPSHOT"
 }

--- a/samples/hello-world/feature-mobile/build.gradle.kts
+++ b/samples/hello-world/feature-mobile/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
-    // Supports Android + iOS only. With KMP_TARGETS=jvm,iosSimulatorArm64 the jvm is dropped
-    // (not supported here) and only iosSimulatorArm64 registers — Android isn't selected, so no AGP.
+    // Supports Android + iOS only. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 the jvm is
+    // dropped (not supported here) and the two iOS leaves register and share a single `iosMain` —
+    // with NO `appleMain`/`nativeMain`. Android isn't selected, so no AGP. The starkest collapse:
+    // KGP's default would add 3 redundant intermediates here; the template adds one.
     id("com.rsicarelli.kmptargets.mobile") version "0.1.0-SNAPSHOT"
 }

--- a/samples/hello-world/gradle.properties
+++ b/samples/hello-world/gradle.properties
@@ -1,6 +1,8 @@
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 
-# Default target selection for this sample. Developers override locally via
+# Default target selection for this sample. Two iOS leaves are selected so the minimal hierarchy
+# template has something to collapse: iOS-supporting modules get a single `iosMain` (no redundant
+# `appleMain`/`nativeMain`), which is the whole point of the feature. Developers override locally via
 # local.properties or `-PKMP_TARGETS=...`.
-KMP_TARGETS=jvm,iosSimulatorArm64
+KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64

--- a/samples/hello-world/legacy-default/build.gradle.kts
+++ b/samples/hello-world/legacy-default/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    // Same convention plugin and same KMP_TARGETS as :shared-core, but this module opts OUT of the
+    // minimal template. KGP then applies its default hierarchy, so the two iOS leaves get the full
+    // redundant chain — `iosMain` + `appleMain` + `nativeMain` — instead of just `iosMain`. This is
+    // the side-by-side proof of what the feature removes.
+    id("com.rsicarelli.kmptargets.library") version "0.1.0-SNAPSHOT"
+}
+
+kmpTargets {
+    // Project-level override (wins over the global `kmptargets.hierarchyTemplate` default of true).
+    hierarchyTemplate.set(false)
+}

--- a/samples/hello-world/legacy-default/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
+++ b/samples/hello-world/legacy-default/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
@@ -1,0 +1,3 @@
+package com.rsicarelli.kmptargets.sample
+
+fun legacyDefaultGreeting(): String = "Hello from legacy-default (.library, hierarchy opt-out)!"

--- a/samples/hello-world/plain-kmp/build.gradle.kts
+++ b/samples/hello-world/plain-kmp/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    // No kmp-targets here — a plain Kotlin Multiplatform module. Proves non-interference: the
+    // plugin only ever touches modules that apply it, so this module keeps KGP's default hierarchy
+    // untouched (its two iOS leaves get the full `iosMain` + `appleMain` + `nativeMain` chain).
+    kotlin("multiplatform")
+}
+
+kotlin {
+    jvm()
+    iosArm64()
+    iosSimulatorArm64()
+}

--- a/samples/hello-world/plain-kmp/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
+++ b/samples/hello-world/plain-kmp/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
@@ -1,0 +1,3 @@
+package com.rsicarelli.kmptargets.sample
+
+fun plainKmpGreeting(): String = "Hello from plain-kmp (no kmp-targets)!"

--- a/samples/hello-world/settings.gradle.kts
+++ b/samples/hello-world/settings.gradle.kts
@@ -18,8 +18,11 @@ dependencyResolutionManagement {
 rootProject.name = "hello-world"
 
 // Heterogeneous modules, each declaring its supported shape by the convention plugin id it applies.
-// The global KMP_TARGETS (see gradle.properties) is intersected against each module's set.
-include(":shared-core") //    .library → all targets
-include(":feature-mobile") // .mobile  → Android + iOS
-include(":jvm-tools") //      .jvm     → JVM only
-include(":core-and-apple") // .apple + .jvm (composition) → iOS/macOS ∪ JVM
+// The global KMP_TARGETS (see gradle.properties) is intersected against each module's set, then a
+// minimal hierarchy template is applied. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64:
+include(":shared-core") //    .library → jvm + iosMain (the 2 iOS leaves share iosMain; no appleMain)
+include(":feature-mobile") // .mobile  → iosMain only (jvm unsupported here, Android unselected)
+include(":jvm-tools") //      .jvm     → jvm only, no intermediate source sets
+include(":core-and-apple") // .apple + .jvm (composition) → jvm + iosMain
+include(":legacy-default") // .library but opts OUT → KGP default: iosMain + appleMain + nativeMain
+include(":plain-kmp") //      no kmp-targets at all → KGP default, untouched (non-interference)

--- a/samples/hello-world/shared-core/build.gradle.kts
+++ b/samples/hello-world/shared-core/build.gradle.kts
@@ -1,4 +1,6 @@
 plugins {
-    // Supports every target. With KMP_TARGETS=jvm,iosSimulatorArm64 this registers exactly those two.
+    // Supports every target. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 this registers those
+    // three; the minimal template shares the two iOS leaves under a single `iosMain` (no redundant
+    // `appleMain`/`nativeMain`). Compare with :legacy-default, which opts out and keeps both.
     id("com.rsicarelli.kmptargets.library") version "0.1.0-SNAPSHOT"
 }


### PR DESCRIPTION
## What & why

KGP auto-applies `applyDefaultHierarchyTemplate()`, which builds the **full** source-set hierarchy for all possible targets. An iOS-only module still gets `nativeMain` **and** `appleMain` intermediate source sets that are redundant with `iosMain` — and each redundant intermediate spawns ~8 wasteful Gradle tasks (`compile<SS>KotlinMetadata`, `metadata<SS>Classes`, …). At scale this dominates sync time ([the hidden cost of default hierarchy templates](https://dev.to/rsicarelli/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform-256a)).

Since `kmp-targets` already knows each module's active target set (`selection ∩ supported`), it now generates the **minimal correct** hierarchy and applies it instead of KGP's default — collapsing every redundant single-child group.

| Active targets | Intermediate source sets |
|---|---|
| one iOS leaf | none (attaches to `commonMain`) |
| iOS (≥2 leaves) | `iosMain` only — no `appleMain`, no `nativeMain` |
| iOS + macOS | `appleMain` over `iosMain` + `macosMain` — no `nativeMain` |
| iOS + Linux | `nativeMain` over `iosMain` + `linuxMain` — no `appleMain` |

## Design

- **Pure engine** (`com.rsicarelli.kmptargets.hierarchy`, no Gradle): `HierarchyGroup` taxonomy, one `HierarchyContributor` per group (membership as predicates over the sealed `KmpTarget` branches — single source of truth), a `HierarchySpec` tree, the `computeHierarchySpec` collapse rule, gate precedence, and a thin adapter to `KotlinHierarchyBuilder` (exhaustive leaf `when`, mirroring `registerTarget`).
- **On by default.** Opt out via `kmptargets.hierarchyTemplate=false` (global, root `gradle.properties`) or `kmpTargets { hierarchyTemplate.set(false) }` (per-project; project wins). Precedence: **project DSL > global property > built-in `true`**.
- **Suppression is automatic** — verified against KGP 2.3.21 bytecode: KGP only auto-applies its default when no template was applied yet, so calling `applyHierarchyTemplate` ourselves suppresses it. Opting out applies nothing → KGP's default returns. Same mechanism is the contract for a consumer supplying their own template.
- Applied **once** from the final active set in the **existing** `afterEvaluate` (no new one); configuration-cache safe (no `Project` captured).

## Tests (RED → GREEN throughout)

38 new tests:
- **Pure combinatorics** — every required collapse outcome + edge cases (chained single-leaf collapses, full `all` tree), contributor `owns` predicates, gate precedence table.
- **In-process real KGP** — `ProjectBuilder` + `evaluate()` materializes hierarchy source sets, so these assert on concrete `kotlin.sourceSets`: iOS-only ⇒ `iosMain` only with `appleMain`/`nativeMain` **absent** (default suppressed); opt-out and global/project precedence; plain-KGP non-interference.

## Sample

`samples/hello-world` selection now `jvm,iosArm64,iosSimulatorArm64` so iOS modules exercise `iosMain`. Added `:legacy-default` (`.library` + opt-out — a same-plugin/same-selection contrast against `:shared-core`) and `:plain-kmp` (no kmp-targets — non-interference). The win is visible in the real build: `:feature-mobile` compiles only `iosMainKotlinMetadata`, while `:legacy-default` compiles `iosMain` **+ `appleMain` + `nativeMain`**.

`task ci` is green (check + publish + sample configure + native build).

## Out of scope (follow-ups)

User-defined custom hierarchy groups DSL, `framework {}`, XCFramework, docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)