### PR TITLE
Fix supported target validation error label

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParser.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParser.kt
@@ -44,14 +44,15 @@ public fun parseKmpTargets(raw: String, registry: Set<KmpTarget> = KmpTarget.all
     }
     val presets: Map<String, KmpTargetSet> = PRESETS
 
-    val knownNames: Set<String> = byCanonical.keys + byAlias.keys + presets.keys
+    val knownNames: Set<String> =
+        registry.flatMap { target -> listOf(target.id) + target.aliases }.toSet() + PRESET_NAMES
 
     var accumulator = KmpTargetSet.empty
     for (rawToken in tokens) {
         val (sign, name) = splitSign(rawToken)
         if (name.isEmpty()) {
             return ParseResult.Err(
-                message = "KMP_TARGETS token '$rawToken' has a sign but no target name",
+                message = "token '$rawToken' has a sign but no target name",
                 offendingToken = rawToken,
             )
         }
@@ -74,23 +75,27 @@ public fun parseKmpTargets(raw: String, registry: Set<KmpTarget> = KmpTarget.all
     return ParseResult.Ok(accumulator)
 }
 
-private val PRESETS: Map<String, KmpTargetSet> =
+private val PRESETS_BY_NAME: Map<String, KmpTargetSet> =
     mapOf(
         "all" to KmpTargetSet.all,
         "native" to KmpTargetSet.native,
-        "applemobile" to KmpTargetSet.appleMobile,
-        "appledesktop" to KmpTargetSet.appleDesktop,
-        "applewatch" to KmpTargetSet.appleWatch,
-        "appletv" to KmpTargetSet.appleTv,
+        "appleMobile" to KmpTargetSet.appleMobile,
+        "appleDesktop" to KmpTargetSet.appleDesktop,
+        "appleWatch" to KmpTargetSet.appleWatch,
+        "appleTv" to KmpTargetSet.appleTv,
         "apple" to KmpTargetSet.apple,
         "linux" to KmpTargetSet.linux,
         "mingw" to KmpTargetSet.mingw,
         "windows" to KmpTargetSet.mingw,
-        "androidnative" to KmpTargetSet.androidNative,
+        "androidNative" to KmpTargetSet.androidNative,
         "web" to KmpTargetSet.web,
-        "jvmfamily" to KmpTargetSet.jvmFamily,
+        "jvmFamily" to KmpTargetSet.jvmFamily,
         "mobile" to KmpTargetSet.mobile,
     )
+
+private val PRESETS: Map<String, KmpTargetSet> = PRESETS_BY_NAME.mapKeys { it.key.lowercase() }
+
+private val PRESET_NAMES: Set<String> = PRESETS_BY_NAME.keys
 
 /**
  * Lowercase family names users commonly try to use as selectors. None of them resolve to a leaf,
@@ -122,12 +127,12 @@ private fun unknownTokenMessage(
     knownNames: Set<String>,
 ): String {
     FAMILY_HINTS[lowered]?.let { hint ->
-        return "KMP_TARGETS: '$original' is a target family, not a selectable target — $hint"
+        return "'$original' is a target family, not a selectable target — $hint"
     }
     val suggestion = didYouMean(lowered, knownNames)
     return if (suggestion != null) {
-        "KMP_TARGETS: unknown target '$original' — did you mean '$suggestion'?"
+        "unknown target '$original' — did you mean '$suggestion'?"
     } else {
-        "KMP_TARGETS: unknown target '$original'"
+        "unknown target '$original'"
     }
 }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
@@ -75,7 +75,7 @@ class KmpTargetsPluginTest {
     fun `given KMP_TARGETS is invalid when plugin is applied then a GradleException surfaces in the failure chain`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=invalidToken\n")
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=iosArm65\n")
         val project = newProject(dir)
         val ex =
             assertFailsWith<Exception> { project.pluginManager.apply("com.rsicarelli.kmptargets") }
@@ -86,8 +86,38 @@ class KmpTargetsPluginTest {
                 .firstOrNull { it.message?.contains("KMP_TARGETS") == true }
         assertNotNull(rootCause, "expected KMP_TARGETS-tagged cause in chain, root: ${ex.message}")
         assertTrue(
-            rootCause.message!!.contains("invalidToken"),
+            rootCause.message!!.contains("iosArm65"),
             "expected message to include offending token, got: ${rootCause.message}",
+        )
+        assertTrue(
+            !rootCause.message!!.contains("KMP_TARGETS: KMP_TARGETS"),
+            "expected a single property prefix, got: ${rootCause.message}",
+        )
+        assertTrue(
+            rootCause.message!!.contains("did you mean 'iosArm64'?"),
+            "expected canonical suggestion, got: ${rootCause.message}",
+        )
+    }
+
+    @Test
+    fun `given kmptargets supported property is invalid when plugin is applied then error names supported property once`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.supported=jvm,bogus\n")
+        val project = newProject(dir)
+        val ex =
+            assertFailsWith<Exception> { project.pluginManager.apply("com.rsicarelli.kmptargets") }
+        val rootCause =
+            generateSequence(ex as Throwable?) { it.cause }
+                .firstOrNull { it.message?.contains("kmptargets.supported") == true }
+        assertNotNull(rootCause, "expected kmptargets.supported-tagged cause, root: ${ex.message}")
+        assertTrue(
+            rootCause.message!!.contains("kmptargets.supported: unknown target 'bogus'"),
+            "expected message to name supported property and offending token, got: ${rootCause.message}",
+        )
+        assertTrue(
+            !rootCause.message!!.contains("kmptargets.supported: KMP_TARGETS"),
+            "expected no nested KMP_TARGETS label, got: ${rootCause.message}",
         )
     }
 

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParserTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParserTest.kt
@@ -134,6 +134,16 @@ class KmpTargetsParserTest {
     }
 
     @Test
+    fun `given unknown mixed-case target close to a known one when parsed then suggestion preserves canonical id`() {
+        val result = parseKmpTargets("iosArm65")
+        assertTrue(result is ParseResult.Err, "expected Err, got $result")
+        assertTrue(
+            result.message.contains("did you mean 'iosArm64'?"),
+            "expected canonical suggestion, got: ${result.message}",
+        )
+    }
+
+    @Test
     fun `given unknown token with no close match when parsed then result is Err without suggestion`() {
         val result = parseKmpTargets("xboxOne")
         assertTrue(result is ParseResult.Err)


### PR DESCRIPTION
## Summary
- make parser errors property-neutral so callers add the correct property label once
- preserve canonical target and preset casing in did-you-mean suggestions
- add regression coverage for KMP_TARGETS and kmptargets.supported validation messages

Fixes #17

## Tests
- `:gradle-plugin:cleanTest :gradle-plugin:check` in Docker JDK 23
- `:gradle-plugin:test --rerun-tasks --no-build-cache` in Docker JDK 23