### PR TITLE
fix: honor empty KMP_TARGETS selection instead of falling back to all (#9)

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -23,11 +23,14 @@ public class KmpTargetsPlugin : Plugin<Project> {
         val ext = target.extensions.create("kmpTargets", KmpTargetsExtension::class.java)
         ext.fallback.convention(KmpTargetSet.all)
 
-        // Global selection: what the user wants to build now.
+        // Global selection: what the user wants to build now. A blank/absent property means "not
+        // overriding" → fallback. A non-blank property that resolves to an empty set via minus
+        // operators (e.g. `jvm,-jvm`) is an explicit "build nothing" and must be honored, not
+        // silently treated as the default-all fallback (issue #9). Keying off `isNotBlank` (rather
+        // than the parsed set's emptiness) is what distinguishes the two cases.
         val raw: String? = selectionSources(target).read()
-        val parsedFromProperty: KmpTargetSet? = raw?.let { parseOrThrow(it, KMP_TARGETS) }
-        if (parsedFromProperty != null && parsedFromProperty.isNotEmpty()) {
-            ext.selection.convention(parsedFromProperty)
+        if (raw != null && raw.isNotBlank()) {
+            ext.selection.convention(parseOrThrow(raw, KMP_TARGETS))
         } else {
             ext.selection.convention(ext.fallback)
         }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
@@ -157,6 +157,18 @@ class KmpTargetsPluginTest {
     }
 
     @Test
+    fun `given KMP_TARGETS narrows to nothing via minus when selection is read then it is empty not fallback`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm,-jvm\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        // An explicit selection narrowed to nothing means "build nothing", not "build everything".
+        assertEquals(KmpTargetSet.empty, ext.selection.get())
+    }
+
+    @Test
     fun `given the legacy placeholder task name when listed then it does not exist`(
         @TempDir dir: Path
     ) {


### PR DESCRIPTION
## What & why

Fixes #9. When a `KMP_TARGETS` value is narrowed to the **empty set** with `-` (minus) operators (e.g. `jvm,-jvm`, `linux,-linuxX64,-linuxArm64`), the plugin silently fell back to the **default all-targets selection** instead of honoring the explicit "build nothing" intent. In the worst case (`linux,-linuxX64,-linuxArm64` on a `.library`) it tried to register all 25 targets including `androidTarget`, failing the build with KGP's "Missing Android Gradle Plugin".

## Root cause

In `KmpTargetsPlugin.apply`, the guard `parsedFromProperty.isNotEmpty()` conflated two cases that both produce `KmpTargetSet.empty`:

- a **blank/absent** property → fallback is correct ("not overriding"), and
- a **non-blank** property that resolves to empty via minus operators → should be honored as "build nothing".

Both hit the `else` branch and fell back to all. The parser itself was already correct (`parseKmpTargets("jvm,-jvm")` returns `Ok(empty)`); the discriminator we actually needed is simply whether the raw string is blank.

## Fix

Key the selection decision off `raw.isNotBlank()` rather than the parsed set's emptiness:

```kotlin
val raw: String? = selectionSources(target).read()
if (raw != null && raw.isNotBlank()) {
    ext.selection.convention(parseOrThrow(raw, KMP_TARGETS))   // honor, even if empty
} else {
    ext.selection.convention(ext.fallback)
}
```

Downstream is already empty-safe: `registerResolved` registers `empty ∩ supported` = nothing, and `maybeApplyHierarchyTemplate` returns early when the active set is empty, so the build proceeds with 0 targets.

## RED → GREEN

1. 🔴 `test:` adds `given KMP_TARGETS narrows to nothing via minus when selection is read then it is empty not fallback` — fails against current behavior (resolves to `KmpTargetSet.all`).
2. 🟢 `fix:` applies the `isNotBlank` discriminator — test passes.

## Verification

- `./gradlew test` (both `:gradle-plugin` and `:convention-plugins`) is green.
- The existing `given KMP_TARGETS is blank ... falls back to default` test still passes — a blank property remains "not overriding".

## Scope note

Issue #9 also mentions "log the advisory warning". The existing `emptyOverlapWarning` only fires for a non-empty selection, and reusing it for a genuinely-empty selection would be self-contradictory — that's the separate #10. This PR keeps to the core behavior fix (0 targets, build proceeds) and leaves an empty-selection notice to #10.