### PR TITLE
fix: trigger empty-overlap warning on disjointness, not registration (#10)

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -69,8 +69,10 @@ public class KmpTargetsPlugin : Plugin<Project> {
             val selection = ext.selection.get()
             val active = selection intersect ext.effectiveSupported()
 
-            // Advisory only: the supported set and the global selection don't overlap.
-            if (ext.registered.isEmpty() && selection.isNotEmpty()) {
+            // Advisory only: the selection is non-empty yet genuinely disjoint from the supported
+            // set, so nothing registers. Keyed off the actual overlap (not "nothing registered"),
+            // so the message can never name a token present in both lists (issue #10).
+            if (KmpTargets.shouldWarnEmptyOverlap(selection, ext.effectiveSupported())) {
                 p.logger.warn(
                     KmpTargets.emptyOverlapWarning(p.path, selection, ext.effectiveSupported())
                 )
@@ -197,6 +199,14 @@ public object KmpTargets {
         kotlin.applyHierarchyTemplate(computeHierarchySpec(active).toTemplate())
         ext.hierarchyTemplateApplied = true
     }
+
+    /**
+     * Whether to emit [emptyOverlapWarning]: only when the selection is non-empty yet genuinely
+     * disjoint from the supported set. Keyed off the actual overlap (not "nothing registered with
+     * KGP"), so the message can never name a token present in both lists (issue #10).
+     */
+    internal fun shouldWarnEmptyOverlap(selection: KmpTargetSet, supported: KmpTargetSet): Boolean =
+        selection.isNotEmpty() && (selection intersect supported).isEmpty()
 
     internal fun emptyOverlapWarning(
         path: String,

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
@@ -6,6 +6,7 @@ import java.nio.file.Path
 import kotlin.io.path.writeText
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import org.gradle.api.Project
@@ -176,6 +177,28 @@ class KmpTargetsPluginTest {
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         // The bootstrap placeholder task has been replaced with the real selector wiring.
         assertEquals(null, project.tasks.findByName("kmpTargetsHello"))
+    }
+
+    @Test
+    fun `given selection overlaps supported when deciding empty-overlap warning then it does not warn`() {
+        // androidTarget is in the supported set, so the selection is NOT disjoint — warning here
+        // would be self-contradictory (issue #10).
+        assertFalse(
+            KmpTargets.shouldWarnEmptyOverlap(
+                selection = KmpTargetSet.of(KmpTarget.Jvm.Android),
+                supported = KmpTargetSet.all,
+            )
+        )
+    }
+
+    @Test
+    fun `given selection disjoint from supported when deciding empty-overlap warning then it warns`() {
+        assertTrue(
+            KmpTargets.shouldWarnEmptyOverlap(
+                selection = KmpTargetSet.of(KmpTarget.Web.WasmJs),
+                supported = KmpTargetSet.of(KmpTarget.Jvm.Desktop),
+            )
+        )
     }
 
     private fun newProject(dir: Path): Project =


### PR DESCRIPTION
## What & why

Fixes #10. The advisory "no targets registered" warning is **self-contradictory**: it claims the selection "matches none of" the supported targets while listing the **same token in both** lists — e.g. `.library` + `KMP_TARGETS=android` (no AGP) prints `supports [...androidTarget...] but the selection [androidTarget] matches none of them`.

## Root cause

In the `afterEvaluate` block the warning is **triggered** by `ext.registered.isEmpty()` ("nothing got registered with KGP"), but the **message** describes a set-overlap fact ("selection matches none of supported"). These two diverge: a token (e.g. `androidTarget`) can be in *both* `selection` and `supported` — so the overlap is non-empty — yet still fail to register, leaving `registered` empty. The warning then names that token in both lists.

The message function `emptyOverlapWarning` is pure and correct; only the **trigger** was wrong. The right condition is the overlap itself (`selection ∩ supported`), which was already being computed one line above for the hierarchy template.

## Fix

Extract the decision into a pure function and key the warning off genuine disjointness:

```kotlin
internal fun shouldWarnEmptyOverlap(selection: KmpTargetSet, supported: KmpTargetSet): Boolean =
    selection.isNotEmpty() && (selection intersect supported).isEmpty()
```

```kotlin
if (KmpTargets.shouldWarnEmptyOverlap(selection, ext.effectiveSupported())) {
    p.logger.warn(KmpTargets.emptyOverlapWarning(p.path, selection, ext.effectiveSupported()))
}
```

Now the warning fires **iff** the selection is non-empty and disjoint from supported, so a token can never appear in both lists of the emitted message. A genuinely disjoint selection (e.g. supported `{jvm}`, selection `{wasmJs}`) still warns, accurately.

## RED → GREEN

1. 🔴 `test:` adds two pure-function tests asserting the warning decision is a function of selection-vs-supported disjointness (overlap ⇒ no warn; disjoint ⇒ warn). They fail to compile against the missing `shouldWarnEmptyOverlap` seam — the red bar.
2. 🟢 `fix:` adds the function + rewires the trigger — both tests pass.

A pure-function test was chosen deliberately: the bug's only effect is the emitted log line (no functional side effect), the android-without-AGP runtime path is hard to reproduce deterministically in-process, and this matches the repo's existing pure-function test style (parser/model/hierarchy). The fix is provable by set logic.

## Verification

- `./gradlew test` — full suite, both `:gradle-plugin` and `:convention-plugins`, green.
- The existing disjoint-selection test in `KmpTargetsSupportedTest.kt` (supported `{jvm}`, `KMP_TARGETS=wasmJs`) is unaffected — a real no-overlap still warns.

## Scope note

This is the warning-accuracy counterpart to #9 (empty selection via `-`, fixed in #19). With this trigger change, the `linux,-linuxX64,-linuxArm64` repro is also covered independently of #9.

https://claude.ai/code/session_0172qaYCYX68QRxT3FsqPtie

---
_Generated by [Claude Code](https://claude.ai/code/session_0172qaYCYX68QRxT3FsqPtie)_