### PR TITLE
fix: keep commonMain edge for directly-attached leaves in minimal hierarchy template (#16)

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateAdapter.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateAdapter.kt
@@ -7,13 +7,14 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinHierarchyBuilder
  * Turns a pure [HierarchySpec] into the builder lambda KGP's `applyHierarchyTemplate { … }`
  * expects.
  *
- * Only the group structure (and the leaves *inside* groups) is emitted: a leaf that sits directly
- * under `common` is skipped, because KGP already attaches every registered target's `*Main` to
- * `commonMain` — emitting `withJvm()` at the common root would be a redundant no-op. So a spec with
- * no groups (e.g. jvm-only, web-only) yields an effectively empty template.
+ * Every root is emitted, including a leaf that sits directly under `common` (e.g. standalone `jvm`
+ * or a single collapsed native leaf like `iosArm64`). `applyHierarchyTemplate` *replaces* KGP's
+ * default hierarchy, so the `commonMain`→leaf edge is no longer auto-wired — emitting `withJvm()`
+ * at the common root is what keeps that edge. Skipping it dropped `commonMain` from the target
+ * (issue #16). Leaves inside groups reach `commonMain` transitively via their group's edge.
  */
 internal fun HierarchySpec.toTemplate(): KotlinHierarchyBuilder.Root.() -> Unit = {
-    common { roots.filterIsInstance<HierarchyNode.Group>().forEach { emit(it) } }
+    common { roots.forEach { emit(it) } }
 }
 
 private fun KotlinHierarchyBuilder.emit(node: HierarchyNode) {

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
@@ -119,6 +119,28 @@ class HierarchyTemplateInProcessTest {
     }
 
     @Test
+    fun `given jvm only when applied then jvmMain still depends on commonMain`(@TempDir dir: Path) {
+        // jvm is a standalone family with no intermediate, so it attaches directly to commonMain.
+        // The minimal template must keep that edge, or commonMain code is excluded (issue #16).
+        assertTrue(
+            "commonMain" in dependsOnOf(dir, "jvm", "jvmMain"),
+            "commonMain edge dropped (#16)",
+        )
+    }
+
+    @Test
+    fun `given single iosArm64 when applied then iosArm64Main still depends on commonMain`(
+        @TempDir dir: Path
+    ) {
+        // A single-leaf native family collapses all the way to a leaf attached directly to
+        // commonMain — same dropped-edge hazard as jvm (issue #16).
+        assertTrue(
+            "commonMain" in dependsOnOf(dir, "iosArm64", "iosArm64Main"),
+            "commonMain edge dropped (#16)",
+        )
+    }
+
+    @Test
     fun `given core and KGP applied when reading the active set then the spec matches the minimal tree`(
         @TempDir dir: Path
     ) {
@@ -152,6 +174,22 @@ class HierarchyTemplateInProcessTest {
             .getByType(KotlinMultiplatformExtension::class.java)
             .sourceSets
             .names
+            .toSet()
+    }
+
+    /** Direct `dependsOn` source-set names of [sourceSet] after the minimal template is applied. */
+    private fun dependsOnOf(dir: Path, kmpTargets: String, sourceSet: String): Set<String> {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=$kmpTargets\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        (project as ProjectInternal).evaluate()
+        return project.extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .sourceSets
+            .getByName(sourceSet)
+            .dependsOn
+            .map { it.name }
             .toSet()
     }
 }


### PR DESCRIPTION
Closes #16.

## Problem

When the minimal hierarchy template is active (the default), a leaf target attached **directly** to `commonMain` — instead of being routed through a generated intermediate source set — lost its `commonMain` linkage. `commonMain` code was then excluded from that target: platform code referencing common code failed to compile (`Unresolved reference`), and `jvm`'s jar silently omitted common code.

This broke very common configs: `KMP_TARGETS=jvm` (always — `jvm` is a standalone family with no intermediate), any single-leaf selection (e.g. `iosArm64`), and the `jvm` target of any multi-target module.

## Root cause

`HierarchyTemplateAdapter.toTemplate()` emitted **only `HierarchyNode.Group` roots** and filtered out top-level `Leaf` roots:

```kotlin
common { roots.filterIsInstance<HierarchyNode.Group>().forEach { emit(it) } }
```

The old doc comment assumed emitting `withJvm()` at the common root was a redundant no-op "because KGP already attaches every registered target's `*Main` to `commonMain`". That assumption is false once we call `applyHierarchyTemplate(...)`: a custom template **replaces** KGP's default hierarchy (the existing in-process tests rely on exactly this — they assert `appleMain`/`nativeMain` are *suppressed*). So KGP no longer auto-wires `commonMain`→leaf, and for a directly-attached leaf the template declared **nothing** — no edge was created.

Leaves inside a group still worked, because the `commonMain`→group and group→leaf edges were emitted.

## Fix

Emit every root, not just groups (`emit()` already dispatches on node kind):

```kotlin
common { roots.forEach { emit(it) } }
```

Leaves inside groups still reach `commonMain` transitively via their group's edge; directly-attached leaves now get their own `withJvm()`/`withIosArm64()` call.

## Tests (RED → GREEN)

The existing in-process tests assert only source-set **names**, which never catches this (the `*Main` set always exists). Added two tests asserting the **`dependsOn` edge** for the two directly-attached shapes from the issue — standalone `jvm` and a single collapsed native leaf (`iosArm64`). Both **failed** against the old adapter and pass after the fix.

- `test:` commit adds the failing tests (red bar verified)
- `fix:` commit removes the filter (green)

## Verification

```
./gradlew :gradle-plugin:test --tests '*HierarchyTemplateInProcessTest*'   # red before, green after
./gradlew test          # full suite, both modules — green
./gradlew ktfmtCheck    # clean
```

https://claude.ai/code/session_0172qaYCYX68QRxT3FsqPtie

---
_Generated by [Claude Code](https://claude.ai/code/session_0172qaYCYX68QRxT3FsqPtie)_