### PR TITLE
test: guard Isolated Projects compatibility with a sample + CI (#15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
 
       - name: Build sample (hello-world)
         run: ./gradlew -p samples/hello-world build
+
+      - name: Build sample (isolated-projects, Isolated Projects enabled)
+        run: ./gradlew -p samples/isolated-projects build

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,12 +41,19 @@ tasks:
     cmds:
       - "{{.GRADLE}} -p samples/hello-world build"
 
+  sample:isolated:
+    desc: Build the isolated-projects sample with Gradle Isolated Projects enabled (depends on publish-local)
+    deps: [publish-local]
+    cmds:
+      - "{{.GRADLE}} -p samples/isolated-projects build"
+
   ci:
-    desc: Full local CI dry-run (check + publish-local + sample)
+    desc: Full local CI dry-run (check + publish-local + samples)
     cmds:
       - task: check
       - task: sample
       - task: sample:build
+      - task: sample:isolated
 
   dod:
     desc: Definition of Done — fmt + build + test (run before committing)
@@ -72,6 +79,7 @@ tasks:
     cmds:
       - "{{.GRADLE}} clean"
       - rm -rf samples/hello-world/build samples/hello-world/.gradle
+      - rm -rf samples/isolated-projects/build samples/isolated-projects/.gradle samples/isolated-projects/*/build
 
   fmt:
     desc: Format Kotlin sources with ktfmt (kotlinlang style)

--- a/samples/isolated-projects/README.md
+++ b/samples/isolated-projects/README.md
@@ -1,0 +1,36 @@
+# isolated-projects sample
+
+A standalone, multi-module build that proves `kmp-targets` is **Gradle [Isolated
+Projects](https://docs.gradle.org/current/userguide/isolated_projects.html)** compatible.
+
+Isolated Projects is the step beyond the configuration cache: it isolates each project's
+configuration and **forbids cross-project access** at configuration time (and capturing a `Project`
+into task actions). The plugin already follows config-cache-safe patterns — it only ever touches the
+project it is applied to. This sample turns that into an **executable guard**: with
+`org.gradle.unsafe.isolated-projects=true` (see [`gradle.properties`](./gradle.properties)), if the
+plugin ever reaches across projects or captures a `Project`, this build *fails to configure* and CI
+goes red.
+
+## Layout
+
+| Module | Convention plugin | Supported | Registered with `KMP_TARGETS=jvm` |
+|---|---|---|---|
+| `:lib` | `com.rsicarelli.kmptargets.library` | all targets | `jvm` |
+| `:app` | `com.rsicarelli.kmptargets.jvm` | `jvm` | `jvm` |
+
+`:app` depends on `:lib` via a `project(":lib")` dependency — a real cross-project edge that Isolated
+Projects must wire while keeping each project's configuration isolated. Only the JVM target is
+selected, so no Android SDK or Apple toolchain is needed in CI.
+
+Like the other samples this is a **standalone** build that consumes the plugin from `mavenLocal()`,
+so publish the plugin first.
+
+## Run
+
+```bash
+# from the repo root
+task sample:isolated
+# or, equivalently:
+task publish-local
+./gradlew -p samples/isolated-projects build
+```

--- a/samples/isolated-projects/app/build.gradle.kts
+++ b/samples/isolated-projects/app/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    // Supports jvm only; registers jvm under KMP_TARGETS=jvm. Depends on :lib through a project
+    // dependency — a real cross-project edge that Isolated Projects must wire while keeping each
+    // project's configuration isolated.
+    id("com.rsicarelli.kmptargets.jvm") version "0.1.0-SNAPSHOT"
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":lib"))
+        }
+    }
+}

--- a/samples/isolated-projects/app/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/App.kt
+++ b/samples/isolated-projects/app/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/App.kt
@@ -1,0 +1,3 @@
+package com.rsicarelli.kmptargets.sample
+
+fun appGreeting(): String = "${libGreeting()} — and hello from :app (.jvm)!"

--- a/samples/isolated-projects/build.gradle.kts
+++ b/samples/isolated-projects/build.gradle.kts
@@ -1,0 +1,6 @@
+// Root of the isolated-projects sample.
+// Kotlin Multiplatform is declared once with `apply false` so every subproject shares a single KGP
+// classloader (mirrors samples/hello-world). Each subproject applies a `com.rsicarelli.kmptargets.*`
+// convention plugin, which applies KGP for it and registers KMP_TARGETS ∩ supported — all under
+// Isolated Projects (see gradle.properties).
+plugins { kotlin("multiplatform") version "2.3.21" apply false }

--- a/samples/isolated-projects/gradle.properties
+++ b/samples/isolated-projects/gradle.properties
@@ -1,0 +1,11 @@
+# Gradle Isolated Projects — the step beyond the configuration cache: each project's configuration is
+# isolated and cross-project access at configuration time is forbidden. Enabling it turns this sample
+# into a regression guard — if the plugin ever reaches across projects or captures a `Project`, this
+# build fails to configure. Isolated Projects implies the configuration cache, so no separate flag.
+org.gradle.unsafe.isolated-projects=true
+org.gradle.caching=true
+
+# Build only the JVM target so CI needs no Android SDK or Apple toolchain. The .library module
+# supports all targets and the .jvm module supports jvm; intersected with this selection both
+# register jvm only.
+KMP_TARGETS=jvm

--- a/samples/isolated-projects/lib/build.gradle.kts
+++ b/samples/isolated-projects/lib/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    // Supports every target; intersected with KMP_TARGETS=jvm (see ../gradle.properties) it registers
+    // jvm only. Configured under Isolated Projects — proof the convention applies without reaching
+    // across projects.
+    id("com.rsicarelli.kmptargets.library") version "0.1.0-SNAPSHOT"
+}

--- a/samples/isolated-projects/lib/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Lib.kt
+++ b/samples/isolated-projects/lib/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Lib.kt
@@ -1,0 +1,3 @@
+package com.rsicarelli.kmptargets.sample
+
+fun libGreeting(): String = "Hello from :lib (.library), built with Isolated Projects!"

--- a/samples/isolated-projects/settings.gradle.kts
+++ b/samples/isolated-projects/settings.gradle.kts
@@ -1,0 +1,26 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        google()
+    }
+}
+
+rootProject.name = "isolated-projects"
+
+// Two modules applying different convention plugins, built with Gradle Isolated Projects enabled
+// (see gradle.properties). Isolated Projects isolates each project's configuration and forbids
+// cross-project access (and `Project` capture). This sample therefore only configures cleanly while
+// the plugin keeps touching nothing but the project it is applied to — making it the executable
+// guard for that contract.
+include(":lib") // .library → supports all targets; with KMP_TARGETS=jvm registers jvm only
+include(":app") // .jvm     → supports jvm; depends on :lib through a project dependency


### PR DESCRIPTION
## Summary

Issue #15 reports that `KmpTargetsPlugin` reads the **root** project's extension container when applied to a subproject, which Gradle Isolated Projects rejects (`Project ':c' cannot access 'Project.extensions' … on another project ':'`).

**Investigation finding: this is not reproducible on current `main`.** There was nothing to fix in plugin code, so this PR instead adds an **executable guard** that proves IP compatibility today and locks it in against regressions. Full evidence is posted on #15.

### Why no code fix

- Every `.extensions` access in the plugin is on the project being configured (`target` / `project`), **never** `rootProject`. The only root-ish reference is `target.rootDir` (the *current* project's root dir, used to locate `local.properties`) — IP-safe.
- A scan of **every historical commit** of `gradle-plugin/src/main` + `convention-plugins/src/main` shows no version ever accessed the root project's extensions.
- The issue's **exact** repro — three modules each applying a convention plugin, run with `:a:tasks :b:tasks :c:tasks -Dorg.gradle.unsafe.isolated-projects=true` — builds successfully with no plugin-attributable violation. (The issue notes the same run also surfaced KGP-internal JS-plugin violations, which are Kotlin's, not this plugin's.)

## What's in this PR

- **`samples/isolated-projects/`** — a standalone multi-module build with `org.gradle.unsafe.isolated-projects=true`:
  - `:lib` applies `com.rsicarelli.kmptargets.library`
  - `:app` applies `com.rsicarelli.kmptargets.jvm` and depends on `:lib` via a `project(":lib")` dependency (a real cross-project edge)
  - `KMP_TARGETS=jvm` keeps it toolchain-light (no Android SDK / Apple toolchain), mirroring `samples/hello-world`'s standalone `mavenLocal()` consumption. No per-sample wrapper — runs via the root wrapper.
- **Taskfile** — new `sample:isolated` task, added to the `ci` aggregate and `clean`.
- **CI (`ci.yml`)** — new "Build sample (isolated-projects)" step after the hello-world build, once `mavenLocal` is populated. A future regression that reaches across projects fails this job.

## Verification

Verified end-to-end with the pinned JDK 23 (Temurin 23.0.2+7), Gradle 9.5.1, KGP 2.3.21:

1. ✅ `publishToMavenLocal` + `./gradlew -p samples/isolated-projects build` succeeds — both modules compile, the project dependency resolves, Isolated Projects active.
2. ✅ Configuration cache **reused** on a second run (`Reusing configuration cache` → `BUILD SUCCESSFUL in 982ms`).
3. ✅ Guard proven: a temporary cross-project access is **rejected** with `Project ':app' cannot access 'Project.tasks' functionality on another project ':lib'`, then reverted — confirming IP enforcement is genuinely active and the guard bites.

## Note for the maintainer

The branch/commit carries `Closes #15` per the "close as already-resolved" direction. If you still have the original failing build/commit where the `Project.extensions` violation pointed at `KmpTargetsPlugin`, share it and I'll re-investigate — happy to be proven wrong, in which case we'd keep #15 open and add the actual fix on top of this guard.

https://claude.ai/code/session_01TGruwTyzM8XpcVrWtAjLRK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGruwTyzM8XpcVrWtAjLRK)_