### PR TITLE
docs: correct .apple/.mobile supported-set descriptions (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ applies the Kotlin Multiplatform plugin for you (don't add `kotlin("multiplatfor
 // shared-core/build.gradle.kts   — supports all targets
 plugins { id("com.rsicarelli.kmptargets.library") version "<version>" }
 
-// feature-mobile/build.gradle.kts — supports Android + iOS
+// feature-mobile/build.gradle.kts — supports Android + all iOS
 plugins { id("com.rsicarelli.kmptargets.mobile") version "<version>" }
 
 // jvm-tools/build.gradle.kts      — supports JVM only

--- a/convention-plugins/build.gradle.kts
+++ b/convention-plugins/build.gradle.kts
@@ -30,8 +30,9 @@ gradlePlugin {
             Triple("kmpLibrary", "library", "KmpLibraryConventionPlugin") to
                 "all shipped Kotlin Multiplatform targets",
             Triple("kmpMobile", "mobile", "KmpMobileConventionPlugin") to
-                "Android + iOS (the mobile-app shape)",
-            Triple("kmpApple", "apple", "KmpAppleConventionPlugin") to "iOS + macOS",
+                "Android + all iOS (the mobile-app shape)",
+            Triple("kmpApple", "apple", "KmpAppleConventionPlugin") to
+                "all Apple platforms (iOS + macOS + watchOS + tvOS)",
             Triple("kmpJvm", "jvm", "KmpJvmConventionPlugin") to "JVM (desktop/server)",
             Triple("kmpWeb", "web", "KmpWebConventionPlugin") to "JS + Wasm",
         )

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSet.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSet.kt
@@ -123,7 +123,7 @@ public value class KmpTargetSet private constructor(public val members: Set<KmpT
             KmpTargetSet(setOf(KmpTarget.Jvm.Android, KmpTarget.Jvm.Desktop))
 
         /**
-         * The canonical "mobile app" shape: Android plus the two iOS leaves. Backs the
+         * The canonical "mobile app" shape: Android plus all three iOS leaves. Backs the
          * `com.rsicarelli.kmptargets.mobile` convention plugin. Android only registers if the
          * user's selection actually includes it, so this preset does not force AGP onto consumers.
          */

--- a/samples/hello-world/core-and-apple/build.gradle.kts
+++ b/samples/hello-world/core-and-apple/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     // Composition: supported = apple ∪ jvm. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 this
-    // registers jvm + both iOS leaves — more than .apple alone (iOS only) or .jvm alone (jvm only),
+    // registers jvm + both iOS leaves — more than .apple alone (all Apple platforms) or .jvm alone (jvm only),
     // proving that multiple convention ids union their supported sets. The template yields jvm at
     // common + a single `iosMain` (no `appleMain`/`nativeMain`).
     id("com.rsicarelli.kmptargets.apple") version "0.1.0-SNAPSHOT"

--- a/samples/hello-world/feature-mobile/build.gradle.kts
+++ b/samples/hello-world/feature-mobile/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    // Supports Android + iOS only. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 the jvm is
-    // dropped (not supported here) and the two iOS leaves register and share a single `iosMain` —
+    // Supports Android + all iOS. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 the jvm is
+    // dropped (not supported here) and the two selected iOS leaves register and share a single `iosMain` —
     // with NO `appleMain`/`nativeMain`. Android isn't selected, so no AGP. The starkest collapse:
     // KGP's default would add 3 redundant intermediates here; the template adds one.
     id("com.rsicarelli.kmptargets.mobile") version "0.1.0-SNAPSHOT"


### PR DESCRIPTION
## Summary

Issue #13 (label: documentation) reports that inline comments and plugin metadata **understate** two convention plugins' supported sets, contradicting the README table and the actual implementation. This is a **documentation-only fix — no behavioral change**; the implementation and tests already encode the correct behavior.

| Plugin | Stale text | Actual (per code + tests) |
|---|---|---|
| `.apple` | "iOS + macOS" / "iOS only" | **all Apple platforms** — iOS + macOS + watchOS + tvOS (13 leaves). `KmpTargetSet.apple` = `appleMobile + appleDesktop + appleWatch + appleTv` |
| `.mobile` | "Android + iOS" / "two iOS leaves" | **Android + all 3 iOS leaves** (incl. `iosX64`). `KmpTargetSet.mobile` = `Android + appleMobile` |

## Changes

- **`convention-plugins/build.gradle.kts`** — the two stale `description` strings. These are compiled into the **published plugin-marker metadata** (ships to consumers via the Plugin Portal), so this is the most consequential fix, beyond just sample comments.
- **`KmpTargetSet.kt`** — `.mobile` KDoc factual error: "the two iOS leaves" → "all three iOS leaves" (`appleMobile` has Arm64, SimulatorArm64, **X64**).
- **`samples/hello-world/core-and-apple/build.gradle.kts`** — comment called `.apple alone (iOS only)` → `(all Apple platforms)`.
- **`samples/hello-world/feature-mobile/build.gradle.kts`** — "Android + iOS only" → "Android + all iOS"; the example now distinguishes the *supported* set from the *selected* leaves (the sample's teaching point).
- **`README.md`** — the terse inline code-comment (`— supports Android + iOS` → `+ all iOS`). The authoritative table was already correct and is **unchanged**.

### Not changed (verified already correct)
README convention table, `KmpTargetSet.apple` KDoc, all tests, `samples/isolated-projects/**`, and the other hello-world comments where "two iOS leaves" legitimately refers to the two *selected* leaves in that sample's `KMP_TARGETS`.

## Verification

No behavioral change, so the bar is "still formats + tests stay green":
- ✅ `ktfmtCheck` (incl. `ktfmtCheckScripts`, covering the edited `.kts`)
- ✅ `:convention-plugins:test` + `:gradle-plugin:test` — all suites green, 0 failures/errors (the existing tests already assert `.apple` spans iOS/macOS/watchOS/tvOS and `.mobile` covers all iOS).

Closes #13

https://claude.ai/code/session_01TGruwTyzM8XpcVrWtAjLRK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGruwTyzM8XpcVrWtAjLRK)_