### PR TITLE
feat(targets): type-safe kmpTargets DSL for per-module supported/selection (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ plugins {
 If a module's supported set and the selection don't overlap at all, the plugin registers no targets
 for it, logs a warning naming the module/supported/selection, and lets the build proceed.
 
-### Escape hatch (manual wiring)
+### Escape hatch (type-safe DSL)
 
 For a one-off module that fits no preset, apply the base id yourself alongside KGP and declare its
-supported set with the `kmptargets.supported` property (same grammar as `KMP_TARGETS`):
+supported set in the build script with the type-safe `kmpTargets { }` DSL — the whole target
+vocabulary is in scope as set algebra (`+` / `-`):
 
 ```kotlin
 // build.gradle.kts
@@ -76,25 +77,70 @@ plugins {
     kotlin("multiplatform") version "2.3.21"
     id("com.rsicarelli.kmptargets") version "<version>"
 }
+
+kmpTargets {
+    supported { jvm + linuxX64 }        // presets and leaves compose: e.g. mobile + web - iosX64
+}
 ```
 
-```properties
-# this module's gradle.properties
-kmptargets.supported=jvm,linuxX64
+Every preset (`all`, `mobile`, `apple`, `web`, `jvmFamily`, …) and every leaf (`jvm`, `iosArm64`,
+`linuxX64`, …) is available inside the block — no imports, no string parsing. Power users and
+[build-logic](#build-logic-convention-plugins) convention plugins can pass a raw `KmpTargetSet`
+instead: `supported(KmpTargetSet.mobile + KmpTargetSet.web)`.
+
+> The DSL is the per-module escape hatch because a module's `build.gradle.kts` is the one file Gradle
+> evaluates per-project. A `kmptargets.supported` entry in a **subproject's** `gradle.properties` is
+> *not* read by Gradle as a project property (only the root `gradle.properties`, `-P`, env vars, and
+> `GRADLE_USER_HOME` are), so it is silently ignored — use the DSL, or `-Pkmptargets.supported=…` at
+> the root, instead.
+
+Applying the base id with no `supported { }` keeps the original behaviour: supported defaults to all,
+so the global `KMP_TARGETS` alone decides what registers.
+
+You can likewise set a per-module **default** selection with `selection { … }`; a global
+`KMP_TARGETS` (below) always overrides it, so the global switch stays authoritative.
+
+```kotlin
+kmpTargets {
+    supported { mobile + web }
+    selection { jvm + iosArm64 }        // default when no global KMP_TARGETS is set
+}
 ```
 
-Applying the base id with no `kmptargets.supported` keeps the original behaviour: supported defaults
-to all, so the global `KMP_TARGETS` alone decides what registers.
+### Build logic (convention plugins)
+
+In a `build-logic` (precompiled script plugin or `Plugin<Project>`) setup, configure the same
+extension programmatically — the model types (`KmpTargetSet`, `KmpTarget`) are public API, so the
+raw algebra needs no DSL sugar:
+
+```kotlin
+// build-logic/src/main/kotlin/my.kmp-conventions.gradle.kts
+import com.rsicarelli.kmptargets.KmpTargetsExtension
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+
+plugins { id("com.rsicarelli.kmptargets") }
+
+extensions.configure<KmpTargetsExtension> {
+    supported(KmpTargetSet.mobile + KmpTargetSet.web)   // type-safe, no strings
+}
+```
+
+This is how a team centralizes per-module supported sets in their own convention plugins, instead of
+threading a property file through every subproject. The type-safe `supported { … }` / `selection { … }`
+blocks work here too, since they are members of `KmpTargetsExtension`.
 
 ### Selecting targets
 
-Set the selection via any of these sources (priority order, highest first):
+The selection is **global** — one switch narrows the whole build. Set it via any of these sources
+(priority order, highest first):
 
 1. `-PKMP_TARGETS=...` on the CLI
 2. `ORG_GRADLE_PROJECT_KMP_TARGETS` environment variable
-3. `gradle.properties` (project, then root)
+3. the **root** `gradle.properties` (a *subproject's* `gradle.properties` is **not** a source — see
+   the note in [Escape hatch](#escape-hatch-type-safe-dsl))
 4. `local.properties` (per-developer, gitignored)
-5. Plugin default — every target the plugin currently knows about
+5. a per-module `kmpTargets { selection { … } }` default (overridden by all of the above)
+6. Plugin default — every target the plugin currently knows about
 
 ### Selection grammar
 

--- a/convention-plugins/src/test/kotlin/com/rsicarelli/kmptargets/conventions/KmpConventionPluginsTest.kt
+++ b/convention-plugins/src/test/kotlin/com/rsicarelli/kmptargets/conventions/KmpConventionPluginsTest.kt
@@ -30,7 +30,7 @@ class KmpConventionPluginsTest {
         val project = projectWith(dir, kmpTargets = "iosArm64")
         project.pluginManager.apply(KmpMobileConventionPlugin::class.java)
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        assertEquals(KmpTargetSet.mobile, ext.supported.get())
+        assertEquals(KmpTargetSet.mobile, ext.effectiveSupported())
     }
 
     @Test
@@ -50,9 +50,9 @@ class KmpConventionPluginsTest {
         val project = projectWith(dir, kmpTargets = "iosArm64")
         project.pluginManager.apply(KmpAppleConventionPlugin::class.java)
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        assertEquals(KmpTargetSet.apple, ext.supported.get())
-        assertTrue(KmpTarget.Native.Apple.Watchos.Arm64 in ext.supported.get())
-        assertTrue(KmpTarget.Native.Apple.Tvos.Arm64 in ext.supported.get())
+        assertEquals(KmpTargetSet.apple, ext.effectiveSupported())
+        assertTrue(KmpTarget.Native.Apple.Watchos.Arm64 in ext.effectiveSupported())
+        assertTrue(KmpTarget.Native.Apple.Tvos.Arm64 in ext.effectiveSupported())
     }
 
     @Test
@@ -62,7 +62,7 @@ class KmpConventionPluginsTest {
         val project = projectWith(dir, kmpTargets = "iosArm64")
         project.pluginManager.apply(KmpLibraryConventionPlugin::class.java)
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        assertEquals(KmpTargetSet.all, ext.supported.get())
+        assertEquals(KmpTargetSet.all, ext.effectiveSupported())
     }
 
     @Test
@@ -72,7 +72,7 @@ class KmpConventionPluginsTest {
         val project = projectWith(dir, kmpTargets = "jvm")
         project.pluginManager.apply(KmpJvmConventionPlugin::class.java)
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop), ext.supported.get())
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop), ext.effectiveSupported())
         assertRegisteredTargets(project, "jvm")
     }
 
@@ -93,7 +93,7 @@ class KmpConventionPluginsTest {
         project.pluginManager.apply(KmpMobileConventionPlugin::class.java)
         project.pluginManager.apply(KmpWebConventionPlugin::class.java)
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        assertEquals(KmpTargetSet.mobile + KmpTargetSet.web, ext.supported.get())
+        assertEquals(KmpTargetSet.mobile + KmpTargetSet.web, ext.effectiveSupported())
         assertRegisteredTargets(project, "iosArm64", "wasmJs")
     }
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsDsl.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsDsl.kt
@@ -1,0 +1,121 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+
+/**
+ * Marks the receiver of the type-safe `kmpTargets { supported { … } }` / `selection { … }` blocks
+ * so the outer [KmpTargetsExtension] members are not accidentally in scope inside a target
+ * expression.
+ */
+@DslMarker public annotation class KmpTargetsDslMarker
+
+/**
+ * Vocabulary in scope inside a `supported { … }` / `selection { … }` block.
+ *
+ * Every preset and every leaf is exposed as a [KmpTargetSet], so the whole grammar is just set
+ * algebra with `+` and `-`:
+ * ```kotlin
+ * kmpTargets {
+ *     supported { mobile + web }              // two presets
+ *     supported { apple + jvm - iosX64 }      // presets, leaf subtraction
+ *     supported { iosArm64 + iosSimulatorArm64 } // bare leaves
+ * }
+ * ```
+ *
+ * Names mirror the canonical KGP target ids ([KmpTarget.id]) and the [KmpTargetSet] presets
+ * exactly, so what you read in build files matches the `KMP_TARGETS` string grammar and the docs.
+ * Power users and build-logic convention plugins can bypass this sugar entirely and assign the raw
+ * property: `supported.set(KmpTargetSet.mobile + KmpTargetSet.web)`.
+ */
+@KmpTargetsDslMarker
+public object KmpTargetsDsl {
+
+    // --- Presets -------------------------------------------------------------------------------
+
+    /** Every shipped target. */
+    public val all: KmpTargetSet = KmpTargetSet.all
+
+    /** No targets — useful as an explicit starting point, e.g. `empty + jvm`. */
+    public val empty: KmpTargetSet = KmpTargetSet.empty
+
+    /** Every Kotlin/Native target: Apple + Linux + MinGW + Android Native. */
+    public val native: KmpTargetSet = KmpTargetSet.native
+
+    /** All Apple platforms: iOS + macOS + watchOS + tvOS. */
+    public val apple: KmpTargetSet = KmpTargetSet.apple
+
+    /** All iOS leaves. */
+    public val appleMobile: KmpTargetSet = KmpTargetSet.appleMobile
+
+    /** All macOS leaves. */
+    public val appleDesktop: KmpTargetSet = KmpTargetSet.appleDesktop
+
+    /** All watchOS leaves. */
+    public val appleWatch: KmpTargetSet = KmpTargetSet.appleWatch
+
+    /** All tvOS leaves. */
+    public val appleTv: KmpTargetSet = KmpTargetSet.appleTv
+
+    /** `linuxX64`, `linuxArm64`. */
+    public val linux: KmpTargetSet = KmpTargetSet.linux
+
+    /** `mingwX64`. */
+    public val mingw: KmpTargetSet = KmpTargetSet.mingw
+
+    /** Alias of [mingw]. */
+    public val windows: KmpTargetSet = KmpTargetSet.mingw
+
+    /** The four `androidNative*` targets. */
+    public val androidNative: KmpTargetSet = KmpTargetSet.androidNative
+
+    /** `js`, `wasmJs`, `wasmWasi`. */
+    public val web: KmpTargetSet = KmpTargetSet.web
+
+    /** `androidTarget`, `jvm`. */
+    public val jvmFamily: KmpTargetSet = KmpTargetSet.jvmFamily
+
+    /** `androidTarget` + all iOS. */
+    public val mobile: KmpTargetSet = KmpTargetSet.mobile
+
+    // --- Leaves --------------------------------------------------------------------------------
+
+    public val androidTarget: KmpTargetSet = leaf(KmpTarget.Jvm.Android)
+
+    /** `jvm` — the JVM desktop target. */
+    public val jvm: KmpTargetSet = leaf(KmpTarget.Jvm.Desktop)
+
+    public val iosArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Ios.Arm64)
+    public val iosSimulatorArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Ios.SimulatorArm64)
+    public val iosX64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Ios.X64)
+
+    public val macosArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Macos.Arm64)
+    public val macosX64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Macos.X64)
+
+    public val watchosArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Watchos.Arm64)
+    public val watchosArm32: KmpTargetSet = leaf(KmpTarget.Native.Apple.Watchos.Arm32)
+    public val watchosX64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Watchos.X64)
+    public val watchosSimulatorArm64: KmpTargetSet =
+        leaf(KmpTarget.Native.Apple.Watchos.SimulatorArm64)
+    public val watchosDeviceArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Watchos.DeviceArm64)
+
+    public val tvosArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Tvos.Arm64)
+    public val tvosX64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Tvos.X64)
+    public val tvosSimulatorArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Tvos.SimulatorArm64)
+
+    public val linuxX64: KmpTargetSet = leaf(KmpTarget.Native.Linux.X64)
+    public val linuxArm64: KmpTargetSet = leaf(KmpTarget.Native.Linux.Arm64)
+
+    public val mingwX64: KmpTargetSet = leaf(KmpTarget.Native.Mingw.X64)
+
+    public val androidNativeArm32: KmpTargetSet = leaf(KmpTarget.Native.AndroidNative.Arm32)
+    public val androidNativeArm64: KmpTargetSet = leaf(KmpTarget.Native.AndroidNative.Arm64)
+    public val androidNativeX86: KmpTargetSet = leaf(KmpTarget.Native.AndroidNative.X86)
+    public val androidNativeX64: KmpTargetSet = leaf(KmpTarget.Native.AndroidNative.X64)
+
+    public val js: KmpTargetSet = leaf(KmpTarget.Web.Js)
+    public val wasmJs: KmpTargetSet = leaf(KmpTarget.Web.WasmJs)
+    public val wasmWasi: KmpTargetSet = leaf(KmpTarget.Web.WasmWasi)
+
+    private fun leaf(target: KmpTarget): KmpTargetSet = KmpTargetSet.of(target)
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -2,38 +2,41 @@ package com.rsicarelli.kmptargets
 
 import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
+import javax.inject.Inject
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 
 /**
  * Public DSL surface exposed by the plugin as the `kmpTargets` extension.
  *
  * The plugin separates two facts:
- * - [selection] — what the user wants to build *now*, global, resolved from `KMP_TARGETS` (falling
- *   back to [fallback]). This is the same value for every module in the build.
- * - [supported] — what *this module* can build, declared per-module by the convention plugin id it
- *   applies (e.g. `com.rsicarelli.kmptargets.mobile`) or the `kmptargets.supported` property. When
- *   nothing declares it, [effectiveSupported] defaults to [KmpTargetSet.all].
+ * - **selection** — what the user wants to build *now*. Normally global, resolved from
+ *   `KMP_TARGETS` (falling back to [fallback]), and the same value for every module. A per-module
+ *   [selection] block sets the module's *default* desired set; a global `KMP_TARGETS` (`-P`, env,
+ *   root `gradle.properties`, or `local.properties`) always overrides it, so CI stays
+ *   authoritative.
+ * - **supported** — what *this module* can build, declared per-module by the convention plugin id
+ *   it applies (e.g. `com.rsicarelli.kmptargets.mobile`), the type-safe [supported] block, or the
+ *   `kmptargets.supported` property. When nothing declares it, [effectiveSupported] defaults to
+ *   [KmpTargetSet.all].
  *
- * The plugin registers `selection ∩ supported`. `supported` is **not** settable from the
- * build-script body: that runs after KGP target registration has already happened (the "timing
- * wall"), so a DSL setter would silently no-op. Declarations therefore flow through apply-time
- * channels only.
+ * The plugin registers `selection ∩ supported`. Both [supported] and [selection] are settable from
+ * the build-script body via the type-safe blocks below: declarations made during evaluation are
+ * picked up by a deferred (after-evaluate) registration pass, so they are no longer subject to the
+ * old "timing wall". The eager registration pass that the convention plugins rely on only fires
+ * once the supported set has actually been declared, leaving the build-script body its chance to
+ * narrow it.
  *
  * All values are immutable `KmpTargetSet`s of `data object` leaves, so the extension is
  * configuration-cache safe — no `Project` or task state is captured.
  */
-public abstract class KmpTargetsExtension {
-
-    public abstract val selection: Property<KmpTargetSet>
-
-    public abstract val fallback: Property<KmpTargetSet>
+public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFactory) {
 
     /**
-     * The set of targets this module can build. Unset means "not declared"; [effectiveSupported]
-     * treats that as [KmpTargetSet.all]. Written additively via [accumulateSupported] so multiple
-     * convention plugins compose (e.g. `.mobile` + `.web`).
+     * The default selection used when no global `KMP_TARGETS` is provided. Defaults to
+     * [KmpTargetSet.all]. Public so build-logic can set a project-wide floor lazily.
      */
-    public abstract val supported: Property<KmpTargetSet>
+    public abstract val fallback: Property<KmpTargetSet>
 
     /**
      * Per-project opt-out of the minimal custom hierarchy template. Unset defers to the global
@@ -42,10 +45,79 @@ public abstract class KmpTargetsExtension {
      * `applyDefaultHierarchyTemplate()` — also the escape hatch for a module that supplies its own
      * `applyHierarchyTemplate { … }`.
      *
-     * Unlike [supported], this *is* readable from the build-script body: the template is applied in
-     * a deferred pass (after evaluation), by which point the DSL value has been set.
+     * Readable from the build-script body: the template is applied in a deferred pass (after
+     * evaluation), by which point the DSL value has been set.
      */
     public abstract val hierarchyTemplate: Property<Boolean>
+
+    /**
+     * What this module can build. Unset means "not declared"; [effectiveSupported] treats that as
+     * [KmpTargetSet.all]. Written additively via [accumulateSupported] (so multiple convention
+     * plugins compose, e.g. `.mobile` + `.web`) or assigned outright via the [supported] blocks.
+     */
+    internal val supportedProperty: Property<KmpTargetSet> =
+        objects.property(KmpTargetSet::class.java)
+
+    /**
+     * The per-module *default* desired selection. Its convention is [fallback]; a global
+     * `KMP_TARGETS` ([globalSelection]) overrides it in [resolvedSelection].
+     */
+    internal val selectionProperty: Property<KmpTargetSet> =
+        objects.property(KmpTargetSet::class.java)
+
+    /**
+     * Declares this module's supported set with the type-safe target vocabulary:
+     * ```kotlin
+     * kmpTargets { supported { mobile + web - iosX64 } }
+     * ```
+     *
+     * Assigns (replaces) the supported set — the build-script counterpart of applying a convention
+     * plugin id, for a one-off module that fits no preset. Prefer composing convention plugin ids
+     * when a preset (or union of presets) already matches.
+     */
+    public fun supported(block: KmpTargetsDsl.() -> KmpTargetSet) {
+        supportedProperty.set(KmpTargetsDsl.block())
+    }
+
+    /** Type-safe overload for build-logic: `supported(KmpTargetSet.mobile + KmpTargetSet.web)`. */
+    public fun supported(value: KmpTargetSet) {
+        supportedProperty.set(value)
+    }
+
+    /**
+     * Declares this module's *default* desired selection with the type-safe target vocabulary:
+     * ```kotlin
+     * kmpTargets { selection { jvm + iosArm64 } }
+     * ```
+     *
+     * A global `KMP_TARGETS` (CLI `-P`, environment variable, root `gradle.properties`, or
+     * `local.properties`) always overrides this, preserving the "one global switch wins" guarantee.
+     */
+    public fun selection(block: KmpTargetsDsl.() -> KmpTargetSet) {
+        selectionProperty.set(KmpTargetsDsl.block())
+    }
+
+    /** Type-safe overload for build-logic: `selection(KmpTargetSet.jvmFamily)`. */
+    public fun selection(value: KmpTargetSet) {
+        selectionProperty.set(value)
+    }
+
+    /**
+     * The global selection resolved from `KMP_TARGETS` at apply time, or `null` when no global
+     * source provided one. When present it wins over the per-module [selection] block (and an
+     * explicit empty set is honored — see issue #9), which is what keeps the global switch
+     * authoritative. Stored as an immutable [KmpTargetSet], so capturing it in deferred closures
+     * stays configuration-cache safe.
+     */
+    internal var globalSelection: KmpTargetSet? = null
+
+    /**
+     * The selection actually used to register targets: the global override if present, otherwise
+     * the per-module selection (whose own convention is [fallback], defaulting to
+     * [KmpTargetSet.all]). Public so build-logic can read the resolved set (e.g. for conditional
+     * configuration).
+     */
+    public fun resolvedSelection(): KmpTargetSet = globalSelection ?: selectionProperty.get()
 
     /** Leaves already registered with KGP, so repeated registration passes are idempotent. */
     internal val registered: MutableSet<KmpTarget> = mutableSetOf()
@@ -59,11 +131,17 @@ public abstract class KmpTargetsExtension {
      */
     internal var kgpAppliedByConvention: Boolean = false
 
-    /** Unions [add] into [supported]. Order-independent, so composition is commutative. */
+    /** Unions [add] into the supported set. Order-independent, so composition is commutative. */
     internal fun accumulateSupported(add: KmpTargetSet) {
-        supported.set((supported.orNull ?: KmpTargetSet.empty) + add)
+        supportedProperty.set((supportedProperty.orNull ?: KmpTargetSet.empty) + add)
     }
 
-    /** The resolved supported set: the accumulated declaration, or [KmpTargetSet.all] if none. */
-    internal fun effectiveSupported(): KmpTargetSet = supported.orNull ?: KmpTargetSet.all
+    /** Whether a supported set has been declared (by convention, DSL, or property). */
+    internal fun isSupportedDeclared(): Boolean = supportedProperty.isPresent
+
+    /**
+     * The resolved supported set: the accumulated declaration, or [KmpTargetSet.all] if none.
+     * Public so build-logic (and consumers) can read what this module ended up declaring.
+     */
+    public fun effectiveSupported(): KmpTargetSet = supportedProperty.orNull ?: KmpTargetSet.all
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -22,17 +22,22 @@ public class KmpTargetsPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         val ext = target.extensions.create("kmpTargets", KmpTargetsExtension::class.java)
         ext.fallback.convention(KmpTargetSet.all)
+        // The per-module `selection { … }` block (if any) defaults to the fallback. A global
+        // `KMP_TARGETS` is stored separately and wins over it via `resolvedSelection()`.
+        ext.selectionProperty.convention(ext.fallback)
 
         // Global selection: what the user wants to build now. A blank/absent property means "not
-        // overriding" → fallback. A non-blank property that resolves to an empty set via minus
-        // operators (e.g. `jvm,-jvm`) is an explicit "build nothing" and must be honored, not
-        // silently treated as the default-all fallback (issue #9). Keying off `isNotBlank` (rather
-        // than the parsed set's emptiness) is what distinguishes the two cases.
+        // overriding" → defer to the per-module selection/fallback. A non-blank property that
+        // resolves to an empty set via minus operators (e.g. `jvm,-jvm`) is an explicit "build
+        // nothing" and must be honored, not silently treated as the default-all fallback (issue
+        // #9).
+        // Keying off `isNotBlank` (rather than the parsed set's emptiness) is what distinguishes
+        // the
+        // two cases. Storing it as the override (rather than as `selection`'s convention) is what
+        // lets a global value win over a per-module `selection { … }` block.
         val raw: String? = selectionSources(target).read()
         if (raw != null && raw.isNotBlank()) {
-            ext.selection.convention(parseOrThrow(raw, KMP_TARGETS))
-        } else {
-            ext.selection.convention(ext.fallback)
+            ext.globalSelection = parseOrThrow(raw, KMP_TARGETS)
         }
 
         // Per-module supported set declared via the `kmptargets.supported` property (the manual
@@ -44,11 +49,15 @@ public class KmpTargetsPlugin : Plugin<Project> {
         }
 
         // Register selection ∩ supported once KGP is present. Queued here so that, in the
-        // convention
-        // flow (core applied before KGP), the accumulated supported set is already visible when
-        // this
-        // fires. Idempotent, so it composes with the per-declaration passes in declareSupported.
-        target.pluginManager.withPlugin(KGP_ID) { KmpTargets.registerResolved(target, ext) }
+        // convention flow (core applied before KGP), the accumulated supported set is already
+        // visible when this fires. Idempotent, so it composes with the per-declaration passes in
+        // declareSupported. Guarded on `supported` being declared: if it is still unset (a module
+        // that will declare it from its build-script body via `supported { … }`), eager
+        // registration would wrongly register `selection ∩ all` and over-register, so we defer to
+        // the after-evaluate pass below, by which point the DSL block has run.
+        target.pluginManager.withPlugin(KGP_ID) {
+            if (ext.isSupportedDeclared()) KmpTargets.registerResolved(target, ext)
+        }
 
         // Global default for the hierarchy template, read at apply time and pulled out as a
         // primitive so the afterEvaluate closure below never captures `Project` (config-cache
@@ -66,7 +75,12 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // stays configuration-cache safe.
         target.afterEvaluate { p ->
             if (!p.plugins.hasPlugin(KGP_ID)) return@afterEvaluate
-            val selection = ext.selection.get()
+            // Deferred registration pass: picks up a `supported { … }` / `selection { … }` declared
+            // in the build-script body (which runs after apply, so the eager pass above may have
+            // skipped it). Idempotent, so for the convention flow — already registered eagerly —
+            // this is a no-op.
+            KmpTargets.registerResolved(p, ext)
+            val selection = ext.resolvedSelection()
             val active = selection intersect ext.effectiveSupported()
 
             // Advisory only: the selection is non-empty yet genuinely disjoint from the supported
@@ -174,7 +188,7 @@ public object KmpTargets {
     /** Registers `selection ∩ supported`, skipping leaves already registered (idempotent). */
     internal fun registerResolved(project: Project, ext: KmpTargetsExtension) {
         val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
-        val effective = ext.selection.get() intersect ext.effectiveSupported()
+        val effective = ext.resolvedSelection() intersect ext.effectiveSupported()
         (effective.members - ext.registered).forEach { leaf ->
             registerTarget(kotlin, leaf)
             ext.registered.add(leaf)

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslTest.kt
@@ -1,0 +1,153 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Proves the type-safe `kmpTargets { … }` DSL set during the build-script body (the escape-hatch
+ * flow: KGP applied first, then the base plugin, then a narrowing `supported { … }`). This is the
+ * case the old "timing wall" silently dropped: registration is deferred to the after-evaluate pass,
+ * so a `supported`/`selection` declared in the body is honored. `(project as ProjectInternal)
+ * .evaluate()` fires that pass in-process.
+ */
+class KmpTargetsDslTest {
+
+    @Test
+    fun `given supported declared via DSL after KGP when evaluated then only the DSL set registers`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm,iosArm64,linuxX64\n")
+        val project = newEvaluatedProject(dir) { ext -> ext.supported { jvm + linuxX64 } }
+        // selection (jvm,iosArm64,linuxX64) ∩ supported (jvm,linuxX64) = jvm,linuxX64.
+        assertRegisteredTargets(project, "jvm", "linuxX64")
+    }
+
+    @Test
+    fun `given supported leaves composed via DSL when evaluated then the union registers`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        val project =
+            newEvaluatedProject(dir) { ext -> ext.supported { iosArm64 + iosSimulatorArm64 + jvm } }
+        assertRegisteredTargets(project, "iosArm64", "iosSimulatorArm64", "jvm")
+    }
+
+    @Test
+    fun `given a per-module selection default and no global when evaluated then the default applies`(
+        @TempDir dir: Path
+    ) {
+        val project =
+            newEvaluatedProject(dir) { ext ->
+                ext.supported { all }
+                ext.selection { jvm + iosArm64 }
+            }
+        assertRegisteredTargets(project, "jvm", "iosArm64")
+    }
+
+    @Test
+    fun `given a per-module selection default and a global KMP_TARGETS when evaluated then global wins`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm\n")
+        val project =
+            newEvaluatedProject(dir) { ext ->
+                ext.supported { all }
+                ext.selection { iosArm64 + iosSimulatorArm64 } // ignored: global wins
+            }
+        assertRegisteredTargets(project, "jvm")
+    }
+
+    @Test
+    fun `given supported via DSL value overload when evaluated then it registers`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        val project =
+            newEvaluatedProject(dir) { ext -> ext.supported(KmpTargetSet.web + KmpTargetSet.linux) }
+        assertRegisteredTargets(project, "js", "wasmJs", "wasmWasi", "linuxX64", "linuxArm64")
+    }
+
+    @Test
+    fun `given supported block with subtraction when evaluated then the removed leaf does not register`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        val project = newEvaluatedProject(dir) { ext -> ext.supported { appleMobile - iosX64 } }
+        assertRegisteredTargets(project, "iosArm64", "iosSimulatorArm64")
+    }
+
+    @Test
+    fun `given a selection value default and a global KMP_TARGETS when evaluated then global wins`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm\n")
+        val project =
+            newEvaluatedProject(dir) { ext ->
+                ext.supported { all }
+                ext.selection(KmpTargetSet.web) // ignored: global wins
+            }
+        assertRegisteredTargets(project, "jvm")
+    }
+
+    @Test
+    fun `given a blank global and a selection default when evaluated then the default applies`(
+        @TempDir dir: Path
+    ) {
+        // A blank KMP_TARGETS means "not overriding" — the per-module default selection stands.
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=\n")
+        val project =
+            newEvaluatedProject(dir) { ext ->
+                ext.supported { all }
+                ext.selection { jvm + linuxX64 }
+            }
+        assertRegisteredTargets(project, "jvm", "linuxX64")
+    }
+
+    @Test
+    fun `given an empty selection default and no global when evaluated then nothing registers`(
+        @TempDir dir: Path
+    ) {
+        val project =
+            newEvaluatedProject(dir) { ext ->
+                ext.supported { all }
+                ext.selection { empty } // explicit "build nothing"
+            }
+        assertRegisteredTargets(project /* none */)
+    }
+
+    @Test
+    fun `given a supported set disjoint from the selection when evaluated then nothing registers`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=wasmJs\n")
+        val project = newEvaluatedProject(dir) { ext -> ext.supported { jvm + linuxX64 } }
+        assertRegisteredTargets(project /* none — selection ∩ supported is empty */)
+    }
+
+    /**
+     * Escape-hatch order: user applies KGP, then the base plugin, then configures the extension in
+     * the body. The deferred registration runs only on [ProjectInternal.evaluate].
+     */
+    private fun newEvaluatedProject(dir: Path, configure: (KmpTargetsExtension) -> Unit): Project {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        configure(project.extensions.getByType(KmpTargetsExtension::class.java))
+        (project as ProjectInternal).evaluate()
+        return project
+    }
+
+    private fun assertRegisteredTargets(project: Project, vararg expected: String) {
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        val actual = kotlin.targets.names.filter { it != "metadata" }.toSet()
+        assertEquals(expected.toSet(), actual)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslVocabularyTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslVocabularyTest.kt
@@ -7,10 +7,10 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
- * Pure, Gradle-free coverage of the [KmpTargetsDsl] receiver vocabulary used inside
- * `kmpTargets { supported { … } }`. Every preset and every leaf must map to exactly the same
- * `KmpTargetSet` the string grammar and the public model produce — otherwise the type-safe DSL would
- * silently disagree with `KMP_TARGETS=…` and the docs.
+ * Pure, Gradle-free coverage of the [KmpTargetsDsl] receiver vocabulary used inside `kmpTargets {
+ * supported { … } }`. Every preset and every leaf must map to exactly the same `KmpTargetSet` the
+ * string grammar and the public model produce — otherwise the type-safe DSL would silently disagree
+ * with `KMP_TARGETS=…` and the docs.
  */
 class KmpTargetsDslVocabularyTest {
 
@@ -52,7 +52,10 @@ class KmpTargetsDslVocabularyTest {
     @Test
     fun `given the iOS leaves when read then each equals its single-target set`() {
         assertEquals(leaf(KmpTarget.Native.Apple.Ios.Arm64), KmpTargetsDsl.iosArm64)
-        assertEquals(leaf(KmpTarget.Native.Apple.Ios.SimulatorArm64), KmpTargetsDsl.iosSimulatorArm64)
+        assertEquals(
+            leaf(KmpTarget.Native.Apple.Ios.SimulatorArm64),
+            KmpTargetsDsl.iosSimulatorArm64,
+        )
         assertEquals(leaf(KmpTarget.Native.Apple.Ios.X64), KmpTargetsDsl.iosX64)
     }
 
@@ -81,7 +84,10 @@ class KmpTargetsDslVocabularyTest {
     fun `given the tvOS leaves when read then each equals its single-target set`() {
         assertEquals(leaf(KmpTarget.Native.Apple.Tvos.Arm64), KmpTargetsDsl.tvosArm64)
         assertEquals(leaf(KmpTarget.Native.Apple.Tvos.X64), KmpTargetsDsl.tvosX64)
-        assertEquals(leaf(KmpTarget.Native.Apple.Tvos.SimulatorArm64), KmpTargetsDsl.tvosSimulatorArm64)
+        assertEquals(
+            leaf(KmpTarget.Native.Apple.Tvos.SimulatorArm64),
+            KmpTargetsDsl.tvosSimulatorArm64,
+        )
     }
 
     @Test
@@ -142,14 +148,19 @@ class KmpTargetsDslVocabularyTest {
 
     @Test
     fun `given preset union via the DSL when composed then it equals the model union`() {
-        assertEquals(KmpTargetSet.mobile + KmpTargetSet.web, KmpTargetsDsl.mobile + KmpTargetsDsl.web)
+        assertEquals(
+            KmpTargetSet.mobile + KmpTargetSet.web,
+            KmpTargetsDsl.mobile + KmpTargetsDsl.web,
+        )
     }
 
     @Test
     fun `given a preset minus a leaf via the DSL when composed then the leaf is removed`() {
         val expected = KmpTargetSet.appleMobile - KmpTarget.Native.Apple.Ios.X64
         assertEquals(expected, KmpTargetsDsl.appleMobile - KmpTargetsDsl.iosX64)
-        assertTrue(KmpTarget.Native.Apple.Ios.X64 !in (KmpTargetsDsl.appleMobile - KmpTargetsDsl.iosX64))
+        assertTrue(
+            KmpTarget.Native.Apple.Ios.X64 !in (KmpTargetsDsl.appleMobile - KmpTargetsDsl.iosX64)
+        )
     }
 
     @Test

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslVocabularyTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslVocabularyTest.kt
@@ -1,0 +1,160 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure, Gradle-free coverage of the [KmpTargetsDsl] receiver vocabulary used inside
+ * `kmpTargets { supported { … } }`. Every preset and every leaf must map to exactly the same
+ * `KmpTargetSet` the string grammar and the public model produce — otherwise the type-safe DSL would
+ * silently disagree with `KMP_TARGETS=…` and the docs.
+ */
+class KmpTargetsDslVocabularyTest {
+
+    private fun leaf(target: KmpTarget) = KmpTargetSet.of(target)
+
+    // --- Presets ---------------------------------------------------------------------------------
+
+    @Test
+    fun `given the DSL presets when read then each equals its KmpTargetSet counterpart`() {
+        assertEquals(KmpTargetSet.all, KmpTargetsDsl.all)
+        assertEquals(KmpTargetSet.empty, KmpTargetsDsl.empty)
+        assertEquals(KmpTargetSet.native, KmpTargetsDsl.native)
+        assertEquals(KmpTargetSet.apple, KmpTargetsDsl.apple)
+        assertEquals(KmpTargetSet.appleMobile, KmpTargetsDsl.appleMobile)
+        assertEquals(KmpTargetSet.appleDesktop, KmpTargetsDsl.appleDesktop)
+        assertEquals(KmpTargetSet.appleWatch, KmpTargetsDsl.appleWatch)
+        assertEquals(KmpTargetSet.appleTv, KmpTargetsDsl.appleTv)
+        assertEquals(KmpTargetSet.linux, KmpTargetsDsl.linux)
+        assertEquals(KmpTargetSet.mingw, KmpTargetsDsl.mingw)
+        assertEquals(KmpTargetSet.androidNative, KmpTargetsDsl.androidNative)
+        assertEquals(KmpTargetSet.web, KmpTargetsDsl.web)
+        assertEquals(KmpTargetSet.jvmFamily, KmpTargetsDsl.jvmFamily)
+        assertEquals(KmpTargetSet.mobile, KmpTargetsDsl.mobile)
+    }
+
+    @Test
+    fun `given the windows alias when read then it equals the mingw preset`() {
+        assertEquals(KmpTargetSet.mingw, KmpTargetsDsl.windows)
+    }
+
+    // --- Leaves ----------------------------------------------------------------------------------
+
+    @Test
+    fun `given the JVM-family leaves when read then each equals its single-target set`() {
+        assertEquals(leaf(KmpTarget.Jvm.Android), KmpTargetsDsl.androidTarget)
+        assertEquals(leaf(KmpTarget.Jvm.Desktop), KmpTargetsDsl.jvm)
+    }
+
+    @Test
+    fun `given the iOS leaves when read then each equals its single-target set`() {
+        assertEquals(leaf(KmpTarget.Native.Apple.Ios.Arm64), KmpTargetsDsl.iosArm64)
+        assertEquals(leaf(KmpTarget.Native.Apple.Ios.SimulatorArm64), KmpTargetsDsl.iosSimulatorArm64)
+        assertEquals(leaf(KmpTarget.Native.Apple.Ios.X64), KmpTargetsDsl.iosX64)
+    }
+
+    @Test
+    fun `given the macOS leaves when read then each equals its single-target set`() {
+        assertEquals(leaf(KmpTarget.Native.Apple.Macos.Arm64), KmpTargetsDsl.macosArm64)
+        assertEquals(leaf(KmpTarget.Native.Apple.Macos.X64), KmpTargetsDsl.macosX64)
+    }
+
+    @Test
+    fun `given the watchOS leaves when read then each equals its single-target set`() {
+        assertEquals(leaf(KmpTarget.Native.Apple.Watchos.Arm64), KmpTargetsDsl.watchosArm64)
+        assertEquals(leaf(KmpTarget.Native.Apple.Watchos.Arm32), KmpTargetsDsl.watchosArm32)
+        assertEquals(leaf(KmpTarget.Native.Apple.Watchos.X64), KmpTargetsDsl.watchosX64)
+        assertEquals(
+            leaf(KmpTarget.Native.Apple.Watchos.SimulatorArm64),
+            KmpTargetsDsl.watchosSimulatorArm64,
+        )
+        assertEquals(
+            leaf(KmpTarget.Native.Apple.Watchos.DeviceArm64),
+            KmpTargetsDsl.watchosDeviceArm64,
+        )
+    }
+
+    @Test
+    fun `given the tvOS leaves when read then each equals its single-target set`() {
+        assertEquals(leaf(KmpTarget.Native.Apple.Tvos.Arm64), KmpTargetsDsl.tvosArm64)
+        assertEquals(leaf(KmpTarget.Native.Apple.Tvos.X64), KmpTargetsDsl.tvosX64)
+        assertEquals(leaf(KmpTarget.Native.Apple.Tvos.SimulatorArm64), KmpTargetsDsl.tvosSimulatorArm64)
+    }
+
+    @Test
+    fun `given the Linux and MinGW leaves when read then each equals its single-target set`() {
+        assertEquals(leaf(KmpTarget.Native.Linux.X64), KmpTargetsDsl.linuxX64)
+        assertEquals(leaf(KmpTarget.Native.Linux.Arm64), KmpTargetsDsl.linuxArm64)
+        assertEquals(leaf(KmpTarget.Native.Mingw.X64), KmpTargetsDsl.mingwX64)
+    }
+
+    @Test
+    fun `given the Android Native leaves when read then each equals its single-target set`() {
+        assertEquals(leaf(KmpTarget.Native.AndroidNative.Arm32), KmpTargetsDsl.androidNativeArm32)
+        assertEquals(leaf(KmpTarget.Native.AndroidNative.Arm64), KmpTargetsDsl.androidNativeArm64)
+        assertEquals(leaf(KmpTarget.Native.AndroidNative.X86), KmpTargetsDsl.androidNativeX86)
+        assertEquals(leaf(KmpTarget.Native.AndroidNative.X64), KmpTargetsDsl.androidNativeX64)
+    }
+
+    @Test
+    fun `given the web leaves when read then each equals its single-target set`() {
+        assertEquals(leaf(KmpTarget.Web.Js), KmpTargetsDsl.js)
+        assertEquals(leaf(KmpTarget.Web.WasmJs), KmpTargetsDsl.wasmJs)
+        assertEquals(leaf(KmpTarget.Web.WasmWasi), KmpTargetsDsl.wasmWasi)
+    }
+
+    @Test
+    fun `given every shipped leaf when unioned via the DSL vocabulary then it equals KmpTargetSet all`() {
+        val everyLeaf =
+            KmpTargetsDsl.androidTarget +
+                KmpTargetsDsl.jvm +
+                KmpTargetsDsl.iosArm64 +
+                KmpTargetsDsl.iosSimulatorArm64 +
+                KmpTargetsDsl.iosX64 +
+                KmpTargetsDsl.macosArm64 +
+                KmpTargetsDsl.macosX64 +
+                KmpTargetsDsl.watchosArm64 +
+                KmpTargetsDsl.watchosArm32 +
+                KmpTargetsDsl.watchosX64 +
+                KmpTargetsDsl.watchosSimulatorArm64 +
+                KmpTargetsDsl.watchosDeviceArm64 +
+                KmpTargetsDsl.tvosArm64 +
+                KmpTargetsDsl.tvosX64 +
+                KmpTargetsDsl.tvosSimulatorArm64 +
+                KmpTargetsDsl.linuxX64 +
+                KmpTargetsDsl.linuxArm64 +
+                KmpTargetsDsl.mingwX64 +
+                KmpTargetsDsl.androidNativeArm32 +
+                KmpTargetsDsl.androidNativeArm64 +
+                KmpTargetsDsl.androidNativeX86 +
+                KmpTargetsDsl.androidNativeX64 +
+                KmpTargetsDsl.js +
+                KmpTargetsDsl.wasmJs +
+                KmpTargetsDsl.wasmWasi
+        assertEquals(KmpTargetSet.all, everyLeaf)
+        assertEquals(25, everyLeaf.size)
+    }
+
+    // --- Algebra ---------------------------------------------------------------------------------
+
+    @Test
+    fun `given preset union via the DSL when composed then it equals the model union`() {
+        assertEquals(KmpTargetSet.mobile + KmpTargetSet.web, KmpTargetsDsl.mobile + KmpTargetsDsl.web)
+    }
+
+    @Test
+    fun `given a preset minus a leaf via the DSL when composed then the leaf is removed`() {
+        val expected = KmpTargetSet.appleMobile - KmpTarget.Native.Apple.Ios.X64
+        assertEquals(expected, KmpTargetsDsl.appleMobile - KmpTargetsDsl.iosX64)
+        assertTrue(KmpTarget.Native.Apple.Ios.X64 !in (KmpTargetsDsl.appleMobile - KmpTargetsDsl.iosX64))
+    }
+
+    @Test
+    fun `given empty plus two leaves via the DSL when composed then only those leaves are present`() {
+        val set = KmpTargetsDsl.empty + KmpTargetsDsl.jvm + KmpTargetsDsl.iosArm64
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64), set)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionDslTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionDslTest.kt
@@ -27,7 +27,10 @@ class KmpTargetsExtensionDslTest {
     fun `given supported block with subtraction when effectiveSupported then the leaf is removed`() {
         val ext = newExtension()
         ext.supported { appleMobile - iosX64 }
-        assertEquals(KmpTargetSet.appleMobile - KmpTarget.Native.Apple.Ios.X64, ext.effectiveSupported())
+        assertEquals(
+            KmpTargetSet.appleMobile - KmpTarget.Native.Apple.Ios.X64,
+            ext.effectiveSupported(),
+        )
         assertTrue(KmpTarget.Native.Apple.Ios.X64 !in ext.effectiveSupported())
     }
 
@@ -35,7 +38,10 @@ class KmpTargetsExtensionDslTest {
     fun `given supported value overload when effectiveSupported then equals that value`() {
         val ext = newExtension()
         ext.supported(KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Linux.X64))
-        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Linux.X64), ext.effectiveSupported())
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Linux.X64),
+            ext.effectiveSupported(),
+        )
     }
 
     @Test

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionDslTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionDslTest.kt
@@ -1,0 +1,102 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+/**
+ * Extension-level coverage of the type-safe `supported { … }` / `selection { … }` blocks, the raw
+ * value overloads, and the [KmpTargetsExtension.resolvedSelection] precedence (global override wins
+ * over a per-module selection). These assert the pure DSL → property wiring without applying KGP;
+ * the in-process registration is covered by [KmpTargetsDslTest].
+ */
+class KmpTargetsExtensionDslTest {
+
+    @Test
+    fun `given supported block when effectiveSupported then equals the declared union`() {
+        val ext = newExtension()
+        ext.supported { mobile + web }
+        assertEquals(KmpTargetSet.mobile + KmpTargetSet.web, ext.effectiveSupported())
+    }
+
+    @Test
+    fun `given supported block with subtraction when effectiveSupported then the leaf is removed`() {
+        val ext = newExtension()
+        ext.supported { appleMobile - iosX64 }
+        assertEquals(KmpTargetSet.appleMobile - KmpTarget.Native.Apple.Ios.X64, ext.effectiveSupported())
+        assertTrue(KmpTarget.Native.Apple.Ios.X64 !in ext.effectiveSupported())
+    }
+
+    @Test
+    fun `given supported value overload when effectiveSupported then equals that value`() {
+        val ext = newExtension()
+        ext.supported(KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Linux.X64))
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Linux.X64), ext.effectiveSupported())
+    }
+
+    @Test
+    fun `given supported block called twice when effectiveSupported then the last assignment wins`() {
+        val ext = newExtension()
+        ext.supported { mobile }
+        ext.supported { web }
+        // The DSL assigns (replaces); it does not accumulate like the convention path.
+        assertEquals(KmpTargetSet.web, ext.effectiveSupported())
+    }
+
+    @Test
+    fun `given supported never declared when isSupportedDeclared then false and effectiveSupported is all`() {
+        val ext = newExtension()
+        assertFalse(ext.isSupportedDeclared())
+        assertEquals(KmpTargetSet.all, ext.effectiveSupported())
+    }
+
+    @Test
+    fun `given supported block when isSupportedDeclared then true`() {
+        val ext = newExtension()
+        ext.supported { jvm }
+        assertTrue(ext.isSupportedDeclared())
+    }
+
+    @Test
+    fun `given selection block and no global when resolvedSelection then equals the block value`() {
+        val ext = newExtension()
+        ext.selection { jvm + iosArm64 }
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64),
+            ext.resolvedSelection(),
+        )
+    }
+
+    @Test
+    fun `given selection value overload and no global when resolvedSelection then equals that value`() {
+        val ext = newExtension()
+        ext.selection(KmpTargetSet.web)
+        assertEquals(KmpTargetSet.web, ext.resolvedSelection())
+    }
+
+    @Test
+    fun `given both a global selection and a selection block when resolvedSelection then global wins`() {
+        val ext = newExtension()
+        ext.selection { iosArm64 + iosSimulatorArm64 }
+        ext.globalSelection = KmpTargetSet.of(KmpTarget.Jvm.Desktop)
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop), ext.resolvedSelection())
+    }
+
+    @Test
+    fun `given a global selection narrowed to empty when resolvedSelection then it is empty not the block`() {
+        val ext = newExtension()
+        ext.selection { jvm }
+        // An explicit "build nothing" global (e.g. KMP_TARGETS=jvm,-jvm) must win over the block.
+        ext.globalSelection = KmpTargetSet.empty
+        assertEquals(KmpTargetSet.empty, ext.resolvedSelection())
+    }
+
+    private fun newExtension(): KmpTargetsExtension {
+        val project = ProjectBuilder.builder().build()
+        return project.extensions.create("kmpTargets", KmpTargetsExtension::class.java)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
@@ -12,7 +12,7 @@ class KmpTargetsExtensionTest {
     @Test
     fun `given extension created when selection accessed then property is present and unset`() {
         val ext = newExtension()
-        assertFalse(ext.selection.isPresent)
+        assertFalse(ext.selectionProperty.isPresent)
     }
 
     @Test
@@ -24,7 +24,7 @@ class KmpTargetsExtensionTest {
     @Test
     fun `given extension created when supported accessed then property is unset`() {
         val ext = newExtension()
-        assertFalse(ext.supported.isPresent)
+        assertFalse(ext.supportedProperty.isPresent)
     }
 
     @Test
@@ -61,7 +61,7 @@ class KmpTargetsExtensionTest {
         val ext = newExtension()
         ext.fallback.set(KmpTargetSet.web)
         // Setting fallback doesn't auto-populate selection — that's the plugin's job
-        assertFalse(ext.selection.isPresent)
+        assertFalse(ext.selectionProperty.isPresent)
         assertTrue(ext.fallback.isPresent)
         assertEquals(KmpTargetSet.web, ext.fallback.get())
     }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
@@ -33,7 +33,7 @@ class KmpTargetsPluginTest {
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        assertEquals(KmpTargetSet.all, ext.selection.get())
+        assertEquals(KmpTargetSet.all, ext.resolvedSelection())
     }
 
     @Test
@@ -46,7 +46,7 @@ class KmpTargetsPluginTest {
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
         assertEquals(
             KmpTargetSet.of(KmpTarget.Jvm.Android, KmpTarget.Native.Apple.Ios.Arm64),
-            ext.selection.get(),
+            ext.resolvedSelection(),
         )
     }
 
@@ -58,7 +58,7 @@ class KmpTargetsPluginTest {
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        assertEquals(KmpTargetSet.appleMobile, ext.selection.get())
+        assertEquals(KmpTargetSet.appleMobile, ext.resolvedSelection())
     }
 
     @Test
@@ -69,7 +69,7 @@ class KmpTargetsPluginTest {
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
         ext.fallback.set(KmpTargetSet.web)
-        assertEquals(KmpTargetSet.web, ext.selection.get())
+        assertEquals(KmpTargetSet.web, ext.resolvedSelection())
     }
 
     @Test
@@ -130,7 +130,7 @@ class KmpTargetsPluginTest {
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Android), ext.selection.get())
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Android), ext.resolvedSelection())
     }
 
     @Test
@@ -142,7 +142,7 @@ class KmpTargetsPluginTest {
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.selection.get())
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.resolvedSelection())
     }
 
     @Test
@@ -154,7 +154,7 @@ class KmpTargetsPluginTest {
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
         // A blank property is not "I want zero targets" — it's "I'm not overriding"; fallback wins.
-        assertEquals(KmpTargetSet.all, ext.selection.get())
+        assertEquals(KmpTargetSet.all, ext.resolvedSelection())
     }
 
     @Test
@@ -166,7 +166,7 @@ class KmpTargetsPluginTest {
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
         // An explicit selection narrowed to nothing means "build nothing", not "build everything".
-        assertEquals(KmpTargetSet.empty, ext.selection.get())
+        assertEquals(KmpTargetSet.empty, ext.resolvedSelection())
     }
 
     @Test

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsSupportedTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsSupportedTest.kt
@@ -7,6 +7,7 @@ import kotlin.io.path.writeText
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.junit.jupiter.api.Test
@@ -17,10 +18,11 @@ import org.junit.jupiter.api.io.TempDir
  * applied in-process. These are the load-bearing "does the approach actually register the right KGP
  * targets" tests — they assert on `kotlin.targets`, not on our own bookkeeping.
  *
- * Ordering note: scenarios that declare a `supported` set apply the core plugin first (queuing
- * registration), declare supported, then apply KGP last — mirroring exactly what a convention
- * plugin does. This is what lets a narrowed `supported` set be visible before any target is
- * registered, without `afterEvaluate`.
+ * Ordering note: scenarios that declare a `supported` set apply the core plugin first, declare
+ * supported, then apply KGP last — mirroring exactly what a convention plugin does, so the narrowed
+ * `supported` set is visible and targets register eagerly. Scenarios with no declared support rely
+ * on the deferred (after-evaluate) pass, so the shared helper evaluates the project to observe what
+ * a real build would.
  */
 class KmpTargetsSupportedTest {
 
@@ -166,6 +168,11 @@ class KmpTargetsSupportedTest {
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         if (supported != null) KmpTargets.declareSupported(project, supported)
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        // When a supported set is declared (here or by a convention plugin), registration is eager.
+        // When none is — a bare core+KGP module relying on the default `all` — registration is
+        // deferred to the after-evaluate pass so a build-script `supported { … }` can still narrow
+        // it; trigger that pass so these scenarios observe the same result a real build would.
+        (project as ProjectInternal).evaluate()
         return project
     }
 

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
@@ -153,7 +153,7 @@ class HierarchyTemplateInProcessTest {
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        val active = ext.selection.get() intersect KmpTargetSet.all
+        val active = ext.resolvedSelection() intersect KmpTargetSet.all
         val groups = computeHierarchySpec(active).roots.filterIsInstance<HierarchyNode.Group>()
         assertEquals(setOf(HierarchyGroup.IOS), groups.map { it.group }.toSet())
     }

--- a/samples/hello-world/escape-hatch-dsl/build.gradle.kts
+++ b/samples/hello-world/escape-hatch-dsl/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    // Escape hatch: a one-off module that fits no preset. Apply KGP + the base kmp-targets id
+    // yourself, then declare the supported set in the build script with the type-safe DSL — the
+    // whole target vocabulary is in scope as set algebra. (KGP version comes from the root build's
+    // `apply false` declaration, so it isn't repeated here.)
+    kotlin("multiplatform")
+    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+}
+
+kmpTargets {
+    // Supports JVM + Linux only. With the sample's KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64,
+    // selection ∩ supported = jvm — so only `jvm` registers (linuxX64 is supported but unselected;
+    // the iOS leaves are selected but unsupported). This declaration is read from the build-script
+    // body and honored by the deferred registration pass — the old "timing wall" used to drop it.
+    supported { jvm + linuxX64 }
+}

--- a/samples/hello-world/escape-hatch-dsl/src/commonMain/kotlin/EscapeHatch.kt
+++ b/samples/hello-world/escape-hatch-dsl/src/commonMain/kotlin/EscapeHatch.kt
@@ -1,0 +1,3 @@
+package sample.escapehatch
+
+fun escapeHatch() = "escape-hatch"

--- a/samples/hello-world/settings.gradle.kts
+++ b/samples/hello-world/settings.gradle.kts
@@ -26,3 +26,4 @@ include(":jvm-tools") //      .jvm     → jvm only, no intermediate source sets
 include(":core-and-apple") // .apple + .jvm (composition) → jvm + iosMain
 include(":legacy-default") // .library but opts OUT → KGP default: iosMain + appleMain + nativeMain
 include(":plain-kmp") //      no kmp-targets at all → KGP default, untouched (non-interference)
+include(":escape-hatch-dsl") // base id + type-safe `supported { jvm + linuxX64 }` DSL → jvm only


### PR DESCRIPTION
Closes #14.

## Why

Issue #14: in a multi-module build, `kmptargets.supported` / `KMP_TARGETS` in a **subproject's** `gradle.properties` is silently ignored. That's a hard Gradle invariant — only the *root* `gradle.properties`, `-P`, env vars, and `GRADLE_USER_HOME` provide project properties; a subproject's file is never read as project properties. So the documented per-module escape hatch never worked.

The two concepts the plugin separates have **opposite** right answers, which is the framing this PR follows:

| concept | nature | correct home |
|---|---|---|
| `supported` (what a module *can* build) | per-module, static | the module's `build.gradle.kts` |
| `KMP_TARGETS` selection (what you *want* now) | global, dynamic | root / `-P` / env / `local.properties` |

## What

**A — type-safe DSL (the per-module home that actually works)**

```kotlin
kmpTargets {
    supported { mobile + web - iosX64 }   // every preset & leaf in scope as KmpTargetSet algebra
    selection { jvm + iosArm64 }          // per-module *default*; a global KMP_TARGETS overrides it
}
```

- `KmpTargetsDsl` — a `@DslMarker` receiver exposing every preset (`all`, `mobile`, `apple`, `web`, `jvmFamily`, …) and every leaf (`jvm`, `iosArm64`, `linuxX64`, …) as `KmpTargetSet`. No imports, no strings.
- Raw overloads for build-logic: `supported(KmpTargetSet.mobile + KmpTargetSet.web)`.
- **Breaks the "timing wall"**: a `supported`/`selection` set in the build-script body is honored by a deferred (after-evaluate) registration pass. The eager pass the convention plugins rely on only fires once a supported set is actually declared, so it never over-registers `selection ∩ all`.
- **Global wins**: a global `KMP_TARGETS` always overrides a per-module `selection { … }` (kept as `globalSelection`), so CI stays authoritative; an explicit-empty global is still honored (#9).
- New public read APIs: `effectiveSupported()` / `resolvedSelection()`.

**E — docs corrected**

- README escape hatch rewritten to the DSL; new "Build logic (convention plugins)" section; selection documented as global, with a note that a subproject `gradle.properties` is **not** a source.

**Sample & tests**

- New `:escape-hatch-dsl` sample module: `supported { jvm + linuxX64 }` → with `KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64`, only `jvm` registers.
- Broad coverage: vocabulary mapping (every preset/leaf ↔ `KmpTargetSet` + algebra), extension-level DSL + `resolvedSelection` precedence, and in-process KGP registration (deferred pass, global-wins, subtraction, blank/empty global, disjoint sets).

## Verification

Built and tested locally on JDK 21 (this environment lacked the pinned JDK 23 toolchain): **224 unit tests pass, ktfmt clean, `publishToMavenLocal` + the multi-module sample build succeed**, with `:escape-hatch-dsl` registering only `jvm`. Please run `task dod` / `task ci` on JDK 23 to confirm against the pinned toolchain.

## Out of scope (roadmap)

A repo-level TOML/YAML manifest and a settings-plugin were considered for centralized topology + the future `:cli` contract, but are deliberately deferred per the bootstrap notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGREQs92X9mnS276DBYztx)_