### PR TITLE
chore: cover root + samples with ktfmt; share libs catalog

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -82,11 +82,15 @@ tasks:
       - rm -rf samples/isolated-projects/build samples/isolated-projects/.gradle samples/isolated-projects/*/build
 
   fmt:
-    desc: Format Kotlin sources with ktfmt (kotlinlang style)
+    desc: Format Kotlin sources with ktfmt (kotlinlang style) across the main build and both samples
     cmds:
       - "{{.GRADLE}} ktfmtFormat"
+      - "{{.GRADLE}} -p samples/hello-world ktfmtFormat"
+      - "{{.GRADLE}} -p samples/isolated-projects ktfmtFormat"
 
   fmt:check:
-    desc: Verify Kotlin sources are ktfmt-formatted (run by `task check`)
+    desc: Verify Kotlin sources are ktfmt-formatted across the main build and both samples (run by `task check`)
     cmds:
       - "{{.GRADLE}} ktfmtCheck"
+      - "{{.GRADLE}} -p samples/hello-world ktfmtCheck"
+      - "{{.GRADLE}} -p samples/isolated-projects ktfmtCheck"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,3 +2,19 @@
 // The plugin lives under :gradle-plugin. Future modules (e.g. :cli) will sit
 // alongside it. Add shared configuration here only when more than one
 // subproject needs it.
+//
+// ktfmt is applied here so the root scripts (this file, settings.gradle.kts)
+// are covered by `task fmt` / `task fmt:check` alongside :gradle-plugin's own
+// sources. Kotlin is declared `apply false` only to put KGP on the buildscript
+// classpath — ktfmt's plugin class references `KotlinSourceSet` and refuses to
+// load without it. Each sample project applies ktfmt itself, since the samples
+// are standalone builds.
+plugins {
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.ktfmt)
+    base
+}
+
+ktfmt { kotlinLangStyle() }
+
+tasks.named("check") { dependsOn("ktfmtCheck") }

--- a/samples/hello-world/build.gradle.kts
+++ b/samples/hello-world/build.gradle.kts
@@ -6,4 +6,24 @@
 // Kotlin Multiplatform is declared here once with `apply false` so every subproject shares a single
 // KGP classloader. Without this, KGP's shared KotlinNativeBundleBuildService conflicts across
 // sibling projects loaded by different classloaders.
-plugins { kotlin("multiplatform") version "2.3.21" apply false }
+//
+// ktfmt is applied here and propagated to every subproject so the sample's build scripts and any
+// Kotlin sources are checked alongside the main repo's by `task fmt` / `task fmt:check`.
+//
+// Kotlin and ktfmt versions come from the main repo's `gradle/libs.versions.toml` (imported by
+// `settings.gradle.kts`) so they stay in lock-step with the plugin under test.
+plugins {
+    kotlin("multiplatform") version libs.versions.kotlin.get() apply false
+    id("com.ncorti.ktfmt.gradle") version libs.versions.ktfmt.get()
+    base
+}
+
+ktfmt { kotlinLangStyle() }
+
+tasks.named("check") { dependsOn("ktfmtCheck") }
+
+subprojects {
+    plugins.apply("com.ncorti.ktfmt.gradle")
+    extensions.configure<com.ncorti.ktfmt.gradle.KtfmtExtension> { kotlinLangStyle() }
+    tasks.matching { it.name == "check" }.configureEach { dependsOn("ktfmtCheck") }
+}

--- a/samples/hello-world/core-and-apple/build.gradle.kts
+++ b/samples/hello-world/core-and-apple/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     // Composition: supported = apple ∪ jvm. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 this
-    // registers jvm + both iOS leaves — more than `apple` alone (all Apple platforms) or `jvm` alone
+    // registers jvm + both iOS leaves — more than `apple` alone (all Apple platforms) or `jvm`
+    // alone
     // (jvm only). The DSL takes the place of stacking two convention ids: the supported set is just
     // set algebra in the block. The template yields jvm at common + a single `iosMain` (no
     // `appleMain`/`nativeMain`).

--- a/samples/hello-world/feature-mobile/build.gradle.kts
+++ b/samples/hello-world/feature-mobile/build.gradle.kts
@@ -1,8 +1,10 @@
 plugins {
-    // Supports Android + all iOS (the `mobile` preset). With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64
+    // Supports Android + all iOS (the `mobile` preset). With
+    // KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64
     // the jvm is dropped (not supported here) and the two selected iOS leaves register and share a
     // single `iosMain` — with NO `appleMain`/`nativeMain`. Android isn't selected, so no AGP. The
-    // starkest collapse: KGP's default would add 3 redundant intermediates here; the template adds one.
+    // starkest collapse: KGP's default would add 3 redundant intermediates here; the template adds
+    // one.
     kotlin("multiplatform")
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
 }

--- a/samples/hello-world/jvm-tools/build.gradle.kts
+++ b/samples/hello-world/jvm-tools/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    // Supports JVM only. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 the iOS targets are dropped
+    // Supports JVM only. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 the iOS targets are
+    // dropped
     // and only `jvm` registers.
     kotlin("multiplatform")
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"

--- a/samples/hello-world/legacy-default/build.gradle.kts
+++ b/samples/hello-world/legacy-default/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     // Same DSL flow and same KMP_TARGETS as :shared-core, but this module opts OUT of the minimal
-    // template. KGP then applies its default hierarchy, so the two iOS leaves get the full redundant
+    // template. KGP then applies its default hierarchy, so the two iOS leaves get the full
+    // redundant
     // chain — `iosMain` + `appleMain` + `nativeMain` — instead of just `iosMain`. This is the
     // side-by-side proof of what the feature removes. `supported` is left at its default of `all`.
     kotlin("multiplatform")

--- a/samples/hello-world/settings.gradle.kts
+++ b/samples/hello-world/settings.gradle.kts
@@ -13,6 +13,12 @@ dependencyResolutionManagement {
         mavenCentral()
         google()
     }
+
+    // Share the main repo's version catalog so the Kotlin and ktfmt versions stay in lock-step with
+    // the plugin under test. The `0.1.0-SNAPSHOT` of kmp-targets remains hardcoded in each sample's
+    // `build.gradle.kts` — that's the version a consumer would type, so the sample shows it
+    // verbatim.
+    versionCatalogs { create("libs") { from(files("../../gradle/libs.versions.toml")) } }
 }
 
 rootProject.name = "hello-world"
@@ -21,10 +27,24 @@ rootProject.name = "hello-world"
 // its build script (or leaving it unset for the default-all). The global KMP_TARGETS (see
 // gradle.properties) is intersected against each module's set, then a minimal hierarchy template is
 // applied. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64:
-include(":shared-core") //    default-all  → jvm + iosMain (the 2 iOS leaves share iosMain; no appleMain)
-include(":feature-mobile") // supported{mobile}     → iosMain only (jvm unsupported, Android unselected)
-include(":jvm-tools") //      supported{jvm}        → jvm only, no intermediate source sets
-include(":core-and-apple") // supported{apple+jvm}  → jvm + iosMain
-include(":legacy-default") // default-all, opts OUT → KGP default: iosMain + appleMain + nativeMain
-include(":plain-kmp") //      no kmp-targets at all → KGP default, untouched (non-interference)
-include(":escape-hatch-dsl") // supported{jvm+linuxX64}  → jvm only (linuxX64 unselected, iOS unsupported)
+
+// default-all → jvm + iosMain (the 2 iOS leaves share iosMain; no appleMain)
+include(":shared-core")
+
+// supported{mobile} → iosMain only (jvm unsupported here, Android unselected)
+include(":feature-mobile")
+
+// supported{jvm} → jvm only, no intermediate source sets
+include(":jvm-tools")
+
+// supported{apple+jvm} → jvm + iosMain
+include(":core-and-apple")
+
+// default-all, opts OUT → KGP default: iosMain + appleMain + nativeMain
+include(":legacy-default")
+
+// no kmp-targets at all → KGP default, untouched (non-interference)
+include(":plain-kmp")
+
+// supported{jvm+linuxX64} → jvm only (linuxX64 unselected, iOS unsupported)
+include(":escape-hatch-dsl")

--- a/samples/hello-world/shared-core/build.gradle.kts
+++ b/samples/hello-world/shared-core/build.gradle.kts
@@ -1,8 +1,10 @@
 plugins {
     // Apply KGP + the base kmp-targets id; the supported set defaults to `all` when no
-    // `kmpTargets { supported { … } }` block is declared. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64
+    // `kmpTargets { supported { … } }` block is declared. With
+    // KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64
     // this registers those three; the minimal template shares the two iOS leaves under a single
-    // `iosMain` (no redundant `appleMain`/`nativeMain`). Compare with :legacy-default, which opts out
+    // `iosMain` (no redundant `appleMain`/`nativeMain`). Compare with :legacy-default, which opts
+    // out
     // and keeps both.
     kotlin("multiplatform")
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"

--- a/samples/isolated-projects/app/build.gradle.kts
+++ b/samples/isolated-projects/app/build.gradle.kts
@@ -4,14 +4,13 @@ plugins {
     // project's configuration isolated.
     kotlin("multiplatform")
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    id("com.ncorti.ktfmt.gradle")
 }
+
+ktfmt { kotlinLangStyle() }
+
+tasks.named("check") { dependsOn("ktfmtCheck") }
 
 kmpTargets { supported { jvm } }
 
-kotlin {
-    sourceSets {
-        commonMain.dependencies {
-            implementation(project(":lib"))
-        }
-    }
-}
+kotlin { sourceSets { commonMain.dependencies { implementation(project(":lib")) } } }

--- a/samples/isolated-projects/build.gradle.kts
+++ b/samples/isolated-projects/build.gradle.kts
@@ -3,4 +3,17 @@
 // classloader (mirrors samples/hello-world). Each subproject applies KGP + the
 // `com.rsicarelli.kmptargets` base plugin and declares its supported set via the
 // `kmpTargets { supported { … } }` DSL — all under Isolated Projects (see gradle.properties).
-plugins { kotlin("multiplatform") version "2.3.21" apply false }
+//
+// ktfmt is applied here so the root scripts (this file + settings.gradle.kts) get formatted; each
+// subproject also applies it directly. Isolated Projects forbids `subprojects { … }` cross-project
+// configuration, so per-subproject apply is the only IP-compatible pattern. Versions come from the
+// main repo's `libs.versions.toml` (imported by `settings.gradle.kts`).
+plugins {
+    kotlin("multiplatform") version libs.versions.kotlin.get() apply false
+    id("com.ncorti.ktfmt.gradle") version libs.versions.ktfmt.get()
+    base
+}
+
+ktfmt { kotlinLangStyle() }
+
+tasks.named("check") { dependsOn("ktfmtCheck") }

--- a/samples/isolated-projects/lib/build.gradle.kts
+++ b/samples/isolated-projects/lib/build.gradle.kts
@@ -4,4 +4,9 @@ plugins {
     // under Isolated Projects — proof the plugin applies without reaching across projects.
     kotlin("multiplatform")
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    id("com.ncorti.ktfmt.gradle")
 }
+
+ktfmt { kotlinLangStyle() }
+
+tasks.named("check") { dependsOn("ktfmtCheck") }

--- a/samples/isolated-projects/settings.gradle.kts
+++ b/samples/isolated-projects/settings.gradle.kts
@@ -13,6 +13,10 @@ dependencyResolutionManagement {
         mavenCentral()
         google()
     }
+
+    // Share the main repo's version catalog so Kotlin/ktfmt versions stay in lock-step with the
+    // plugin under test (see `../hello-world/settings.gradle.kts` for the same pattern).
+    versionCatalogs { create("libs") { from(files("../../gradle/libs.versions.toml")) } }
 }
 
 rootProject.name = "isolated-projects"
@@ -22,5 +26,9 @@ rootProject.name = "isolated-projects"
 // cross-project access (and `Project` capture). This sample therefore only configures cleanly while
 // the plugin keeps touching nothing but the project it is applied to — making it the executable
 // guard for that contract.
-include(":lib") // default-all → supports every target; with KMP_TARGETS=jvm registers jvm only
-include(":app") // supported{jvm} → registers jvm; depends on :lib through a project dependency
+
+// default-all → supports every target; with KMP_TARGETS=jvm registers jvm only
+include(":lib")
+
+// supported{jvm} → registers jvm; depends on :lib through a project dependency
+include(":app")


### PR DESCRIPTION
## Summary

Extends ktfmt coverage to the root build scripts and the two samples, and shares the main repo's version catalog so Kotlin/ktfmt versions stay in lock-step.

Before this PR, only `:gradle-plugin` had ktfmt configured. The root `build.gradle.kts`, `settings.gradle.kts`, and every sample build script could drift from kotlinlang style without `task fmt:check` catching it.

## What

### Coverage

| Project | Before | After |
|---|---|---|
| Root build (`build.gradle.kts`, `settings.gradle.kts`) | ❌ | ✅ |
| `:gradle-plugin` | ✅ | ✅ |
| `samples/hello-world` (root + 7 subprojects) | ❌ | ✅ |
| `samples/isolated-projects` (root + 2 subprojects) | ❌ | ✅ |

### Wiring

- **Root**: applies `ktfmt` directly. Needs `kotlin.jvm apply false` on the buildscript classpath because ktfmt's plugin class references `KotlinSourceSet` and refuses to load without it.
- **`samples/hello-world`**: applies ktfmt at the sample root and propagates via `subprojects { … }`. Config-cache-compatible.
- **`samples/isolated-projects`**: can't use `subprojects { … }` — Isolated Projects forbids cross-project configuration — so its two subprojects (`:lib`, `:app`) apply ktfmt directly in their own `plugins` blocks. The intentional contrast is itself instructive: the IP-safe pattern is right there in the sample.

### Shared version catalog

Both samples now import the main repo's `gradle/libs.versions.toml` via:

```kotlin
// samples/<name>/settings.gradle.kts
dependencyResolutionManagement {
    versionCatalogs {
        create("libs") { from(files("../../gradle/libs.versions.toml")) }
    }
}
```

Then in each sample root:

```kotlin
plugins {
    kotlin("multiplatform") version libs.versions.kotlin.get() apply false
    id("com.ncorti.ktfmt.gradle") version libs.versions.ktfmt.get()
    base
}
```

The Kotlin and ktfmt versions stay in lock-step with the plugin under test — when `libs.versions.toml` is bumped, the samples bump too. The `0.1.0-SNAPSHOT` of `kmp-targets` itself remains hardcoded in each sample subproject — that's the version a real consumer would type, so the sample shows it verbatim.

### Taskfile

`task fmt` and `task fmt:check` now drive ktfmt across the main build and both samples:

```yaml
fmt:check:
  cmds:
    - "./gradlew ktfmtCheck"
    - "./gradlew -p samples/hello-world ktfmtCheck"
    - "./gradlew -p samples/isolated-projects ktfmtCheck"
```

So CI guards the new coverage.

## Test plan

- [x] `task fmt:check` — green across root + both samples
- [x] `task ci` — full local CI green end-to-end (build + test + sample + sample:build + sample:isolated)
- [x] `git diff main` — no semantic changes to any sample; only formatting + version-catalog wiring + comment cleanup where ktfmt's 100-col limit triggered awkward wraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
