### PR TITLE
docs: publish sources jar + document DSL leaf vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ kmpTargets {
 }
 ```
 
+### Seeing the DSL docs on hover (IntelliJ)
+
+The plugin ships a sources jar, so every preset, leaf, and extension member carries KDoc you can
+read on hover (`F1` / Quick Documentation). But `kmpTargets { … }` resolves through the **build-script
+(plugin) classpath**, and IntelliJ does **not** attach sources for build-script dependencies by
+default — so out of the box you'll only see the bare signature. Turn it on once:
+
+1. **Settings → Advanced Settings → Build Tools. Gradle** → enable **"Attach scripts dependencies
+   sources"** (also enable **"Download sources"**).
+2. Reload the Gradle project (Gradle tool window → 🔄). A sync is required for the setting to take
+   effect.
+
+After the sync, hovering `supported`, `mobile`, `apple`, `iosArm64`, … shows their documentation.
+
 ### Build-logic conventions
 
 The plugin ships just one extension (`KmpTargetsExtension`) and one set of public types

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -7,6 +7,11 @@ plugins {
 
 kotlin { jvmToolchain(23) }
 
+// Publish a -sources.jar alongside the plugin so IntelliJ can render the DSL's KDoc on hover.
+// `java-gradle-plugin` builds the `pluginMaven` publication from `components["java"]`; attaching
+// the sources artifact to that component is all the wiring maven-publish needs.
+java { withSourcesJar() }
+
 ktfmt { kotlinLangStyle() }
 
 dependencies {

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsDsl.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsDsl.kt
@@ -80,41 +80,82 @@ public object KmpTargetsDsl {
 
     // --- Leaves --------------------------------------------------------------------------------
 
+    /**
+     * Android (the JVM-backed `androidTarget`); registers only when AGP is applied to the module.
+     */
     public val androidTarget: KmpTargetSet = leaf(KmpTarget.Jvm.Android)
 
     /** `jvm` — the JVM desktop target. */
     public val jvm: KmpTargetSet = leaf(KmpTarget.Jvm.Desktop)
 
+    /** iOS on a physical 64-bit device. */
     public val iosArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Ios.Arm64)
+
+    /** iOS Simulator on Apple-silicon hosts. */
     public val iosSimulatorArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Ios.SimulatorArm64)
+
+    /** iOS Simulator on Intel hosts. */
     public val iosX64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Ios.X64)
 
+    /** macOS on Apple-silicon. */
     public val macosArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Macos.Arm64)
+
+    /** macOS on Intel. */
     public val macosX64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Macos.X64)
 
+    /** watchOS on a 64-bit device. */
     public val watchosArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Watchos.Arm64)
+
+    /** watchOS on an older 32-bit device. */
     public val watchosArm32: KmpTargetSet = leaf(KmpTarget.Native.Apple.Watchos.Arm32)
+
+    /** watchOS Simulator on Intel hosts. */
     public val watchosX64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Watchos.X64)
+
+    /** watchOS Simulator on Apple-silicon hosts. */
     public val watchosSimulatorArm64: KmpTargetSet =
         leaf(KmpTarget.Native.Apple.Watchos.SimulatorArm64)
+
+    /** watchOS on a 64-bit device using the modern arm64 ABI. */
     public val watchosDeviceArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Watchos.DeviceArm64)
 
+    /** tvOS on a physical 64-bit device. */
     public val tvosArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Tvos.Arm64)
+
+    /** tvOS Simulator on Intel hosts. */
     public val tvosX64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Tvos.X64)
+
+    /** tvOS Simulator on Apple-silicon hosts. */
     public val tvosSimulatorArm64: KmpTargetSet = leaf(KmpTarget.Native.Apple.Tvos.SimulatorArm64)
 
+    /** Linux on x86-64. */
     public val linuxX64: KmpTargetSet = leaf(KmpTarget.Native.Linux.X64)
+
+    /** Linux on arm64 (e.g. aarch64 servers, Raspberry Pi). */
     public val linuxArm64: KmpTargetSet = leaf(KmpTarget.Native.Linux.Arm64)
 
+    /** Windows on x86-64, via the MinGW toolchain. */
     public val mingwX64: KmpTargetSet = leaf(KmpTarget.Native.Mingw.X64)
 
+    /** Android NDK native on 32-bit ARM. */
     public val androidNativeArm32: KmpTargetSet = leaf(KmpTarget.Native.AndroidNative.Arm32)
+
+    /** Android NDK native on 64-bit ARM. */
     public val androidNativeArm64: KmpTargetSet = leaf(KmpTarget.Native.AndroidNative.Arm64)
+
+    /** Android NDK native on 32-bit x86. */
     public val androidNativeX86: KmpTargetSet = leaf(KmpTarget.Native.AndroidNative.X86)
+
+    /** Android NDK native on x86-64. */
     public val androidNativeX64: KmpTargetSet = leaf(KmpTarget.Native.AndroidNative.X64)
 
+    /** JavaScript, compiled to run on Node.js and browsers. */
     public val js: KmpTargetSet = leaf(KmpTarget.Web.Js)
+
+    /** WebAssembly for the browser/JS host (`wasm-js`). */
     public val wasmJs: KmpTargetSet = leaf(KmpTarget.Web.WasmJs)
+
+    /** WebAssembly for standalone WASI runtimes (`wasm-wasi`). */
     public val wasmWasi: KmpTargetSet = leaf(KmpTarget.Web.WasmWasi)
 
     private fun leaf(target: KmpTarget): KmpTargetSet = KmpTargetSet.of(target)

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTarget.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTarget.kt
@@ -19,6 +19,7 @@ public sealed interface KmpTarget {
 
     public val aliases: Set<String>
 
+    /** JVM-backed targets: Android and the desktop JVM. */
     public sealed interface Jvm : KmpTarget {
 
         public data object Android : Jvm {
@@ -32,10 +33,13 @@ public sealed interface KmpTarget {
         }
     }
 
+    /** Kotlin/Native targets: Apple, Linux, MinGW (Windows), and Android NDK native. */
     public sealed interface Native : KmpTarget {
 
+        /** Apple platforms: iOS, macOS, watchOS, tvOS. */
         public sealed interface Apple : Native {
 
+            /** iOS — physical device and the two simulator architectures. */
             public sealed interface Ios : Apple {
 
                 public data object Arm64 : Ios {
@@ -43,18 +47,21 @@ public sealed interface KmpTarget {
                     override val aliases: Set<String> = setOf("ios-arm64")
                 }
 
+                /** iOS Simulator on Apple-silicon hosts. */
                 public data object SimulatorArm64 : Ios {
                     override val id: String = "iosSimulatorArm64"
                     override val aliases: Set<String> =
                         setOf("ios-sim-arm64", "ios-simulator-arm64")
                 }
 
+                /** iOS Simulator on Intel hosts. */
                 public data object X64 : Ios {
                     override val id: String = "iosX64"
                     override val aliases: Set<String> = setOf("ios-x64")
                 }
             }
 
+            /** macOS — Apple-silicon and Intel. */
             public sealed interface Macos : Apple {
 
                 public data object Arm64 : Macos {
@@ -68,6 +75,7 @@ public sealed interface KmpTarget {
                 }
             }
 
+            /** watchOS — devices (arm32/arm64) and the simulator architectures. */
             public sealed interface Watchos : Apple {
 
                 public data object Arm64 : Watchos {
@@ -80,11 +88,13 @@ public sealed interface KmpTarget {
                     override val aliases: Set<String> = setOf("watchos-arm32")
                 }
 
+                /** watchOS Simulator on Intel hosts. */
                 public data object X64 : Watchos {
                     override val id: String = "watchosX64"
                     override val aliases: Set<String> = setOf("watchos-x64")
                 }
 
+                /** watchOS Simulator on Apple-silicon hosts. */
                 public data object SimulatorArm64 : Watchos {
                     override val id: String = "watchosSimulatorArm64"
                     override val aliases: Set<String> =
@@ -97,6 +107,7 @@ public sealed interface KmpTarget {
                 }
             }
 
+            /** tvOS — physical device and the two simulator architectures. */
             public sealed interface Tvos : Apple {
 
                 public data object Arm64 : Tvos {
@@ -104,11 +115,13 @@ public sealed interface KmpTarget {
                     override val aliases: Set<String> = setOf("tvos-arm64")
                 }
 
+                /** tvOS Simulator on Intel hosts. */
                 public data object X64 : Tvos {
                     override val id: String = "tvosX64"
                     override val aliases: Set<String> = setOf("tvos-x64")
                 }
 
+                /** tvOS Simulator on Apple-silicon hosts. */
                 public data object SimulatorArm64 : Tvos {
                     override val id: String = "tvosSimulatorArm64"
                     override val aliases: Set<String> =
@@ -117,6 +130,7 @@ public sealed interface KmpTarget {
             }
         }
 
+        /** Linux — x86-64 and arm64. */
         public sealed interface Linux : Native {
 
             public data object X64 : Linux {
@@ -130,6 +144,7 @@ public sealed interface KmpTarget {
             }
         }
 
+        /** Windows via the MinGW toolchain. */
         public sealed interface Mingw : Native {
 
             public data object X64 : Mingw {
@@ -138,6 +153,7 @@ public sealed interface KmpTarget {
             }
         }
 
+        /** Android NDK native code, across the four supported ABIs. */
         public sealed interface AndroidNative : Native {
 
             public data object Arm32 : AndroidNative {
@@ -162,6 +178,7 @@ public sealed interface KmpTarget {
         }
     }
 
+    /** Web targets: JavaScript and the two WebAssembly flavours. */
     public sealed interface Web : KmpTarget {
 
         public data object Js : Web {

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSet.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTargetSet.kt
@@ -49,10 +49,13 @@ public value class KmpTargetSet private constructor(public val members: Set<KmpT
 
     public companion object {
 
+        /** No targets — a neutral starting point for building a set up with `+`. */
         public val empty: KmpTargetSet = KmpTargetSet(emptySet())
 
+        /** Every target the plugin ships. */
         public val all: KmpTargetSet = KmpTargetSet(KmpTarget.all)
 
+        /** The three iOS leaves: device arm64, simulator arm64, simulator x64. */
         public val appleMobile: KmpTargetSet =
             KmpTargetSet(
                 setOf(
@@ -62,11 +65,13 @@ public value class KmpTargetSet private constructor(public val members: Set<KmpT
                 )
             )
 
+        /** The two macOS leaves: arm64 and x64. */
         public val appleDesktop: KmpTargetSet =
             KmpTargetSet(
                 setOf(KmpTarget.Native.Apple.Macos.Arm64, KmpTarget.Native.Apple.Macos.X64)
             )
 
+        /** All five watchOS leaves. */
         public val appleWatch: KmpTargetSet =
             KmpTargetSet(
                 setOf(
@@ -78,6 +83,7 @@ public value class KmpTargetSet private constructor(public val members: Set<KmpT
                 )
             )
 
+        /** The three tvOS leaves: device arm64, simulator arm64, simulator x64. */
         public val appleTv: KmpTargetSet =
             KmpTargetSet(
                 setOf(
@@ -93,11 +99,14 @@ public value class KmpTargetSet private constructor(public val members: Set<KmpT
                 appleMobile.members + appleDesktop.members + appleWatch.members + appleTv.members
             )
 
+        /** The two Linux leaves: x64 and arm64. */
         public val linux: KmpTargetSet =
             KmpTargetSet(setOf(KmpTarget.Native.Linux.X64, KmpTarget.Native.Linux.Arm64))
 
+        /** Windows on x86-64, via the MinGW toolchain. */
         public val mingw: KmpTargetSet = KmpTargetSet(setOf(KmpTarget.Native.Mingw.X64))
 
+        /** The four Android NDK native leaves: arm32, arm64, x86, x64. */
         public val androidNative: KmpTargetSet =
             KmpTargetSet(
                 setOf(
@@ -114,9 +123,11 @@ public value class KmpTargetSet private constructor(public val members: Set<KmpT
         public val native: KmpTargetSet =
             KmpTargetSet(apple.members + linux.members + mingw.members + androidNative.members)
 
+        /** The three web leaves: `js`, `wasmJs`, `wasmWasi`. */
         public val web: KmpTargetSet =
             KmpTargetSet(setOf(KmpTarget.Web.Js, KmpTarget.Web.WasmJs, KmpTarget.Web.WasmWasi))
 
+        /** The two JVM-backed leaves: `androidTarget` and `jvm`. */
         public val jvmFamily: KmpTargetSet =
             KmpTargetSet(setOf(KmpTarget.Jvm.Android, KmpTarget.Jvm.Desktop))
 
@@ -128,6 +139,7 @@ public value class KmpTargetSet private constructor(public val members: Set<KmpT
         public val mobile: KmpTargetSet =
             KmpTargetSet(setOf<KmpTarget>(KmpTarget.Jvm.Android) + appleMobile.members)
 
+        /** Builds a set from explicit leaves — the low-level escape hatch behind the presets. */
         public fun of(vararg targets: KmpTarget): KmpTargetSet = KmpTargetSet(targets.toSet())
     }
 }


### PR DESCRIPTION
## Why

Applying `com.rsicarelli.kmptargets` and hovering on the DSL in IntelliJ showed **no useful documentation** — only Gradle-generated stubs / decompiled signatures. Two distinct root causes:

1. **No sources JAR was published.** `java-gradle-plugin` + `maven-publish` never called `withSourcesJar()`, so the mavenLocal artifact had a `.jar` but no `-sources.jar`. IntelliJ renders hover KDoc from a resolved *sources* JAR — without one, even the rich KDoc that **already existed** on `KmpTargetsExtension`, `apple`, `supported`, etc. was invisible to consumers. **This is the linchpin.**
2. **The leaf vocabulary was undocumented** — the 25 leaf vals + `androidTarget` on `KmpTargetsDsl`, plus several model-type members.

## What

- **`gradle-plugin/build.gradle.kts`** — add `java { withSourcesJar() }`. `java-gradle-plugin` builds `pluginMaven` from `components["java"]`, so this is all the wiring needed to ship a `-sources.jar`.
- **`KmpTargetsDsl.kt`** — KDoc on all 25 leaf vals + `androidTarget`, translating the bare KGP id into platform/arch/use (device vs simulator vs host-arch).
- **`KmpTargetSet.kt`** — KDoc on the bare companion presets (`empty`, `all`, `appleMobile`, …, `jvmFamily`) + `of()`. Self-evident set-algebra operators (`plus`/`minus`/`size`/`contains`/`iterator`) left undocumented per the `kmp-doc` skill.
- **`KmpTarget.kt`** — one-liners on each sealed branch (`Jvm`, `Native`, `Apple`, `Ios`, …, `Web`) and notes on the ambiguous Apple simulator/device leaves.

Style follows the `kmp-doc` skill (KDoc for what the name can't say; never restate the signature). The already-strong `KmpTargetsExtension` and preset KDoc is unchanged. Scope is sources-jar only — Dokka/HTML docs stay deferred.

> **Note:** the `kmpTargets { … }` accessor's own one-liner ("Configures the …KmpTargetsExtension extension.") is generated by Gradle in the *consumer's* build and cannot be overridden here. With sources published, hovering inside the block (and navigating to `KmpTargetsExtension`) now surfaces the rich class KDoc.

## Verification

- `task build`, `task fmt`, `task ci` — all green.
- Sources JAR confirmed published with all `.kt` sources:
  ```
  ~/.m2/repository/com/rsicarelli/kmp-targets-gradle-plugin/0.1.0-SNAPSHOT/
    kmp-targets-gradle-plugin-0.1.0-SNAPSHOT-sources.jar   ← new
  ```
- Manual: re-sync `samples/hello-world` in IntelliJ and hover `kmpTargets` / `supported` / `apple` / `iosArm64` — each now shows its KDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)