### PR TITLE
refactor!: reshape DSL — supports, drop selection block, defaultSelection

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@
 
 This is a **multi-module Gradle build**:
 
-- `:gradle-plugin` — the only plugin (`com.rsicarelli.kmptargets`). The DSL (`kmpTargets { supported { … } / selection { … } }`) is the sole public API; teams that want `apply by id, no body` ergonomics build their own conventions in `build-logic/`. Source under `gradle-plugin/src/`.
+- `:gradle-plugin` — the only plugin (`com.rsicarelli.kmptargets`). The DSL (`kmpTargets { supports { … } }`) is the sole public API; teams that want `apply by id, no body` ergonomics build their own conventions in `build-logic/`. Source under `gradle-plugin/src/`.
 - Future: `:cli` — companion CLI for driving target selection from outside Gradle. Reserved as a sibling subproject.
 
 Do **not** collapse into a single-module layout. The structure keeps adding siblings painless.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ its supported set, and the global selection narrows that further.
 ### Applying the plugin
 
 Apply KGP and the `com.rsicarelli.kmptargets` base id together, then declare the module's supported
-set with the type-safe `kmpTargets { supported { … } }` DSL — the whole target vocabulary is in scope
+set with the type-safe `kmpTargets { supports { … } }` DSL — the whole target vocabulary is in scope
 as set algebra (`+` / `-`), no imports, no strings:
 
 ```kotlin
@@ -39,27 +39,21 @@ plugins {
 }
 
 kmpTargets {
-    supported { mobile + web - iosX64 }     // presets and leaves compose freely
+    supports { mobile + web - iosX64 }      // presets and leaves compose freely
 }
 ```
 
 Every preset (`all`, `mobile`, `apple`, `web`, `jvmFamily`, …) and every leaf (`jvm`, `iosArm64`,
 `linuxX64`, …) is available inside the block. Build-logic and consumers needing a raw value can use
-the overload: `supported(KmpTargetSet.mobile + KmpTargetSet.web)`.
+the overload: `supports(KmpTargetSet.mobile + KmpTargetSet.web)`.
 
-If you omit the `supported` block, the module defaults to **all** targets — the global
+If you omit the `supports` block, the module defaults to **all** targets — the global
 `KMP_TARGETS` alone decides what registers. That's the right default for a generic library that
 wants to build whatever the developer is currently targeting.
 
-You can also set a per-module **default** selection with `selection { … }`; a global `KMP_TARGETS`
-(see below) always overrides it, so the global switch stays authoritative:
-
-```kotlin
-kmpTargets {
-    supported { mobile + web }
-    selection { jvm + iosArm64 }            // default when no global KMP_TARGETS is set
-}
-```
+The selection itself is **global** (the `KMP_TARGETS` property, see below) — there is no per-module
+selection block. A project-wide default for when `KMP_TARGETS` is unset can be set from build-logic
+via the `defaultSelection` property; a global `KMP_TARGETS` always overrides it.
 
 ### Seeing the DSL docs on hover (IntelliJ)
 
@@ -73,7 +67,7 @@ default — so out of the box you'll only see the bare signature. Turn it on onc
 2. Reload the Gradle project (Gradle tool window → 🔄). A sync is required for the setting to take
    effect.
 
-After the sync, hovering `supported`, `mobile`, `apple`, `iosArm64`, … shows their documentation.
+After the sync, hovering `supports`, `mobile`, `apple`, `iosArm64`, … shows their documentation.
 
 ### Build-logic conventions
 
@@ -92,7 +86,7 @@ plugins {
 }
 
 extensions.configure<KmpTargetsExtension> {
-    supported(KmpTargetSet.mobile)
+    supports(KmpTargetSet.mobile)
 }
 ```
 
@@ -115,7 +109,7 @@ The selection is **global** — one switch narrows the whole build. Set it via a
 3. the **root** `gradle.properties` (a *subproject's* `gradle.properties` is **not** a source —
    Gradle only reads root-level project properties)
 4. `local.properties` (per-developer, gitignored)
-5. a per-module `kmpTargets { selection { … } }` default (overridden by all of the above)
+5. a project-wide `defaultSelection` set from build-logic (overridden by all of the above)
 6. Plugin default — every target the plugin currently knows about
 
 ### Selection grammar

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsDsl.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsDsl.kt
@@ -4,29 +4,28 @@ import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
 
 /**
- * Marks the receiver of the type-safe `kmpTargets { supported { … } }` / `selection { … }` blocks
- * so the outer [KmpTargetsExtension] members are not accidentally in scope inside a target
- * expression.
+ * Marks the receiver of the type-safe `kmpTargets { supports { … } }` block so the outer
+ * [KmpTargetsExtension] members are not accidentally in scope inside a target expression.
  */
 @DslMarker public annotation class KmpTargetsDslMarker
 
 /**
- * Vocabulary in scope inside a `supported { … }` / `selection { … }` block.
+ * Vocabulary in scope inside a `supports { … }` block.
  *
  * Every preset and every leaf is exposed as a [KmpTargetSet], so the whole grammar is just set
  * algebra with `+` and `-`:
  * ```kotlin
  * kmpTargets {
- *     supported { mobile + web }              // two presets
- *     supported { apple + jvm - iosX64 }      // presets, leaf subtraction
- *     supported { iosArm64 + iosSimulatorArm64 } // bare leaves
+ *     supports { mobile + web }              // two presets
+ *     supports { apple + jvm - iosX64 }      // presets, leaf subtraction
+ *     supports { iosArm64 + iosSimulatorArm64 } // bare leaves
  * }
  * ```
  *
  * Names mirror the canonical KGP target ids ([KmpTarget.id]) and the [KmpTargetSet] presets
  * exactly, so what you read in build files matches the `KMP_TARGETS` string grammar and the docs.
- * Build-logic that needs a raw value can call the [KmpTargetsExtension.supported] overload:
- * `supported(KmpTargetSet.mobile + KmpTargetSet.web)`.
+ * Build-logic that needs a raw value can call the [KmpTargetsExtension.supports] overload:
+ * `supports(KmpTargetSet.mobile + KmpTargetSet.web)`.
  */
 @KmpTargetsDslMarker
 public object KmpTargetsDsl {

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -10,28 +10,27 @@ import org.gradle.api.provider.Property
  * Public DSL surface exposed by the plugin as the `kmpTargets` extension.
  *
  * The plugin separates two facts:
- * - **selection** — what the user wants to build *now*. Normally global, resolved from
- *   `KMP_TARGETS` (falling back to [fallback]), and the same value for every module. A per-module
- *   [selection] block sets the module's *default* desired set; a global `KMP_TARGETS` (`-P`, env,
- *   root `gradle.properties`, or `local.properties`) always overrides it, so CI stays
- *   authoritative.
- * - **supported** — what *this module* can build, declared per-module by the type-safe [supported]
- *   block (or its raw value overload). When nothing declares it, [effectiveSupported] defaults to
+ * - **supported** — what *this module* can build, declared per-module by the type-safe [supports]
+ *   block (or its raw value overload). When nothing declares it, [resolvedSupported] defaults to
  *   [KmpTargetSet.all].
+ * - **selection** — what the user wants to build *now*. It is **global**: resolved from
+ *   `KMP_TARGETS` (`-P`, env, root `gradle.properties`, or `local.properties`) and the same value
+ *   for every module. When no global is provided, it falls back to [defaultSelection] (itself
+ *   defaulting to [KmpTargetSet.all]).
  *
- * The plugin registers `selection ∩ supported`. Both [supported] and [selection] are written from
- * the build-script body via the type-safe blocks below: a single deferred (after-evaluate)
- * registration pass picks up whatever the body set. The extension only ever holds immutable
- * `KmpTargetSet`s of `data object` leaves, so it is configuration-cache safe — no `Project` or task
- * state is captured.
+ * The plugin registers `selection ∩ supported`. [supports] is written from the build-script body; a
+ * single deferred (after-evaluate) registration pass picks up whatever the body set. The extension
+ * only ever holds immutable `KmpTargetSet`s of `data object` leaves, so it is configuration-cache
+ * safe — no `Project` or task state is captured.
  */
 public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFactory) {
 
     /**
-     * The default selection used when no global `KMP_TARGETS` is provided. Defaults to
-     * [KmpTargetSet.all]. Public so build-logic can set a project-wide floor lazily.
+     * The selection used when no global `KMP_TARGETS` is provided. Defaults to [KmpTargetSet.all].
+     * Public so build-logic can set a project-wide default lazily; a global `KMP_TARGETS` always
+     * wins over it.
      */
-    public abstract val fallback: Property<KmpTargetSet>
+    public abstract val defaultSelection: Property<KmpTargetSet>
 
     /**
      * Per-project opt-out of the minimal custom hierarchy template. Unset defers to the global
@@ -46,71 +45,45 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     public abstract val hierarchyTemplate: Property<Boolean>
 
     /**
-     * What this module can build. Unset means "not declared"; [effectiveSupported] treats that as
-     * [KmpTargetSet.all]. Written by the [supported] block (or its raw overload).
+     * What this module can build. Unset means "not declared"; [resolvedSupported] treats that as
+     * [KmpTargetSet.all]. Written by the [supports] block (or its raw overload).
      */
-    internal val supportedProperty: Property<KmpTargetSet> =
-        objects.property(KmpTargetSet::class.java)
-
-    /**
-     * The per-module *default* desired selection. Its convention is [fallback]; a global
-     * `KMP_TARGETS` ([globalSelection]) overrides it in [resolvedSelection].
-     */
-    internal val selectionProperty: Property<KmpTargetSet> =
+    internal val supportsProperty: Property<KmpTargetSet> =
         objects.property(KmpTargetSet::class.java)
 
     /**
      * Declares this module's supported set with the type-safe target vocabulary:
      * ```kotlin
-     * kmpTargets { supported { mobile + web - iosX64 } }
+     * kmpTargets { supports { mobile + web - iosX64 } }
      * ```
      *
      * Assigns the supported set; calling more than once replaces. If you want union semantics,
-     * write the union inside the block (`supported { mobile + web }`).
+     * write the union inside the block (`supports { mobile + web }`).
      */
-    public fun supported(block: KmpTargetsDsl.() -> KmpTargetSet) {
-        supportedProperty.set(KmpTargetsDsl.block())
+    public fun supports(block: KmpTargetsDsl.() -> KmpTargetSet) {
+        supportsProperty.set(KmpTargetsDsl.block())
     }
 
-    /** Raw overload for build-logic: `supported(KmpTargetSet.mobile + KmpTargetSet.web)`. */
-    public fun supported(value: KmpTargetSet) {
-        supportedProperty.set(value)
-    }
-
-    /**
-     * Declares this module's *default* desired selection with the type-safe target vocabulary:
-     * ```kotlin
-     * kmpTargets { selection { jvm + iosArm64 } }
-     * ```
-     *
-     * A global `KMP_TARGETS` (CLI `-P`, environment variable, root `gradle.properties`, or
-     * `local.properties`) always overrides this, preserving the "one global switch wins" guarantee.
-     */
-    public fun selection(block: KmpTargetsDsl.() -> KmpTargetSet) {
-        selectionProperty.set(KmpTargetsDsl.block())
-    }
-
-    /** Raw overload for build-logic: `selection(KmpTargetSet.jvmFamily)`. */
-    public fun selection(value: KmpTargetSet) {
-        selectionProperty.set(value)
+    /** Raw overload for build-logic: `supports(KmpTargetSet.mobile + KmpTargetSet.web)`. */
+    public fun supports(value: KmpTargetSet) {
+        supportsProperty.set(value)
     }
 
     /**
      * The global selection resolved from `KMP_TARGETS` at apply time, or `null` when no global
-     * source provided one. When present it wins over the per-module [selection] block (and an
-     * explicit empty set is honored — see issue #9), which is what keeps the global switch
-     * authoritative. Stored as an immutable [KmpTargetSet], so capturing it in deferred closures
-     * stays configuration-cache safe.
+     * source provided one. When present it wins over [defaultSelection] (and an explicit empty set
+     * is honored — see issue #9), which is what keeps the global switch authoritative. Stored as an
+     * immutable [KmpTargetSet], so capturing it in deferred closures stays configuration-cache
+     * safe.
      */
     internal var globalSelection: KmpTargetSet? = null
 
     /**
-     * The selection actually used to register targets: the global override if present, otherwise
-     * the per-module selection (whose own convention is [fallback], defaulting to
-     * [KmpTargetSet.all]). Public so build-logic can read the resolved set (e.g. for conditional
-     * configuration).
+     * The selection actually used to register targets: the global `KMP_TARGETS` if present,
+     * otherwise [defaultSelection] (which itself defaults to [KmpTargetSet.all]). Public so
+     * build-logic can read the resolved set (e.g. for conditional configuration).
      */
-    public fun resolvedSelection(): KmpTargetSet = globalSelection ?: selectionProperty.get()
+    public fun resolvedSelection(): KmpTargetSet = globalSelection ?: defaultSelection.get()
 
     /** Leaves already registered with KGP, so repeated registration passes are idempotent. */
     internal val registered: MutableSet<KmpTarget> = mutableSetOf()
@@ -122,5 +95,5 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
      * The resolved supported set: the declared value, or [KmpTargetSet.all] if none. Public so
      * build-logic (and consumers) can read what this module ended up declaring.
      */
-    public fun effectiveSupported(): KmpTargetSet = supportedProperty.orNull ?: KmpTargetSet.all
+    public fun resolvedSupported(): KmpTargetSet = supportsProperty.orNull ?: KmpTargetSet.all
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -21,15 +21,12 @@ public class KmpTargetsPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         val ext = target.extensions.create("kmpTargets", KmpTargetsExtension::class.java)
-        ext.fallback.convention(KmpTargetSet.all)
-        // The per-module `selection { … }` block (if any) defaults to the fallback. A global
-        // `KMP_TARGETS` is stored separately and wins over it via `resolvedSelection()`.
-        ext.selectionProperty.convention(ext.fallback)
+        ext.defaultSelection.convention(KmpTargetSet.all)
 
         // Global selection: what the user wants to build now. A blank/absent property means "not
-        // overriding" → defer to the per-module selection/fallback. A non-blank property that
+        // overriding" → defer to `defaultSelection`. A non-blank property that
         // resolves to an empty set via minus operators (e.g. `jvm,-jvm`) is an explicit "build
-        // nothing" and must be honored, not silently treated as the default-all fallback (issue
+        // nothing" and must be honored, not silently treated as the default-all selection (issue
         // #9). Keying off `isNotBlank` (rather than the parsed set's emptiness) is what
         // distinguishes the two cases.
         val raw: String? = selectionSources(target).read()
@@ -43,20 +40,20 @@ public class KmpTargetsPlugin : Plugin<Project> {
         val globalHierarchyEnabled: Boolean? = hierarchyTemplateEnabledGlobally(target)
 
         // All work waits for the build-script body to run: target registration, the empty-overlap
-        // warning, and the hierarchy template are functions of the final `supported`/`selection`
-        // set declared via the DSL. The closure captures only `ext` (immutable sets + booleans)
-        // and the primitive flag, so it stays configuration-cache safe.
+        // warning, and the hierarchy template are functions of the final `supports` set declared
+        // via the DSL. The closure captures only `ext` (immutable sets + booleans) and the
+        // primitive flag, so it stays configuration-cache safe.
         target.afterEvaluate { p ->
             if (!p.plugins.hasPlugin(KGP_ID)) return@afterEvaluate
             registerResolved(p, ext)
             val selection = ext.resolvedSelection()
-            val active = selection intersect ext.effectiveSupported()
+            val active = selection intersect ext.resolvedSupported()
 
             // Advisory only: the selection is non-empty yet genuinely disjoint from the supported
             // set, so nothing registers. Keyed off the actual overlap (not "nothing registered"),
             // so the message can never name a token present in both lists (issue #10).
-            if (shouldWarnEmptyOverlap(selection, ext.effectiveSupported())) {
-                p.logger.warn(emptyOverlapWarning(p.path, selection, ext.effectiveSupported()))
+            if (shouldWarnEmptyOverlap(selection, ext.resolvedSupported())) {
+                p.logger.warn(emptyOverlapWarning(p.path, selection, ext.resolvedSupported()))
             }
 
             maybeApplyHierarchyTemplate(p, ext, active, globalHierarchyEnabled)
@@ -109,7 +106,7 @@ public class KmpTargetsPlugin : Plugin<Project> {
     /** Registers `selection ∩ supported`, skipping leaves already registered (idempotent). */
     private fun registerResolved(project: Project, ext: KmpTargetsExtension) {
         val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
-        val effective = ext.resolvedSelection() intersect ext.effectiveSupported()
+        val effective = ext.resolvedSelection() intersect ext.resolvedSupported()
         (effective.members - ext.registered).forEach { leaf ->
             registerTarget(kotlin, leaf)
             ext.registered.add(leaf)

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParser.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParser.kt
@@ -32,7 +32,7 @@ public fun parseKmpTargets(raw: String, registry: Set<KmpTarget> = KmpTarget.all
     if (tokens.isEmpty()) {
         return ParseResult.Ok(
             KmpTargetSet.empty,
-            warnings = listOf("KMP_TARGETS is empty; using fallback selection"),
+            warnings = listOf("KMP_TARGETS is empty; using the default selection"),
         )
     }
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/SelectionSource.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/SelectionSource.kt
@@ -5,7 +5,7 @@ package com.rsicarelli.kmptargets.source
  * variable, or a `local.properties` file).
  *
  * Implementations return `null` to mean **absent**; an empty string means **present but blank**
- * (the parser will treat that as "use the fallback selection" and emit a warning). The distinction
+ * (the parser will treat that as "use the default selection" and emit a warning). The distinction
  * matters for composition: a `null` source defers to the next source in priority order; an explicit
  * empty does not.
  *

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslTest.kt
@@ -1,5 +1,6 @@
 package com.rsicarelli.kmptargets
 
+import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
 import java.nio.file.Path
 import kotlin.io.path.writeText
@@ -13,122 +14,113 @@ import org.junit.jupiter.api.io.TempDir
 
 /**
  * Proves the type-safe `kmpTargets { … }` DSL set during the build-script body (the escape-hatch
- * flow: KGP applied first, then the base plugin, then a narrowing `supported { … }`). This is the
+ * flow: KGP applied first, then the base plugin, then a narrowing `supports { … }`). This is the
  * case the old "timing wall" silently dropped: registration is deferred to the after-evaluate pass,
- * so a `supported`/`selection` declared in the body is honored. `(project as ProjectInternal)
- * .evaluate()` fires that pass in-process.
+ * so a `supports` set declared in the body is honored. `(project as ProjectInternal).evaluate()`
+ * fires that pass in-process.
  */
 class KmpTargetsDslTest {
 
     @Test
-    fun `given supported declared via DSL after KGP when evaluated then only the DSL set registers`(
+    fun `given supports declared via DSL after KGP when evaluated then only the DSL set registers`(
         @TempDir dir: Path
     ) {
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm,iosArm64,linuxX64\n")
-        val project = newEvaluatedProject(dir) { ext -> ext.supported { jvm + linuxX64 } }
+        val project = newEvaluatedProject(dir) { ext -> ext.supports { jvm + linuxX64 } }
         // selection (jvm,iosArm64,linuxX64) ∩ supported (jvm,linuxX64) = jvm,linuxX64.
         assertRegisteredTargets(project, "jvm", "linuxX64")
     }
 
     @Test
-    fun `given supported leaves composed via DSL when evaluated then the union registers`(
+    fun `given supports leaves composed via DSL when evaluated then the union registers`(
         @TempDir dir: Path
     ) {
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
         val project =
-            newEvaluatedProject(dir) { ext -> ext.supported { iosArm64 + iosSimulatorArm64 + jvm } }
+            newEvaluatedProject(dir) { ext -> ext.supports { iosArm64 + iosSimulatorArm64 + jvm } }
         assertRegisteredTargets(project, "iosArm64", "iosSimulatorArm64", "jvm")
     }
 
     @Test
-    fun `given a per-module selection default and no global when evaluated then the default applies`(
+    fun `given a defaultSelection and no global when evaluated then the default applies`(
         @TempDir dir: Path
     ) {
         val project =
             newEvaluatedProject(dir) { ext ->
-                ext.supported { all }
-                ext.selection { jvm + iosArm64 }
+                ext.supports { all }
+                ext.defaultSelection.set(
+                    KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64)
+                )
             }
         assertRegisteredTargets(project, "jvm", "iosArm64")
     }
 
     @Test
-    fun `given a per-module selection default and a global KMP_TARGETS when evaluated then global wins`(
+    fun `given a defaultSelection and a global KMP_TARGETS when evaluated then global wins`(
         @TempDir dir: Path
     ) {
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm\n")
         val project =
             newEvaluatedProject(dir) { ext ->
-                ext.supported { all }
-                ext.selection { iosArm64 + iosSimulatorArm64 } // ignored: global wins
+                ext.supports { all }
+                ext.defaultSelection.set(KmpTargetSet.appleMobile) // ignored: global wins
             }
         assertRegisteredTargets(project, "jvm")
     }
 
     @Test
-    fun `given supported via DSL value overload when evaluated then it registers`(
+    fun `given supports via DSL value overload when evaluated then it registers`(
         @TempDir dir: Path
     ) {
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
         val project =
-            newEvaluatedProject(dir) { ext -> ext.supported(KmpTargetSet.web + KmpTargetSet.linux) }
+            newEvaluatedProject(dir) { ext -> ext.supports(KmpTargetSet.web + KmpTargetSet.linux) }
         assertRegisteredTargets(project, "js", "wasmJs", "wasmWasi", "linuxX64", "linuxArm64")
     }
 
     @Test
-    fun `given supported block with subtraction when evaluated then the removed leaf does not register`(
+    fun `given supports block with subtraction when evaluated then the removed leaf does not register`(
         @TempDir dir: Path
     ) {
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
-        val project = newEvaluatedProject(dir) { ext -> ext.supported { appleMobile - iosX64 } }
+        val project = newEvaluatedProject(dir) { ext -> ext.supports { appleMobile - iosX64 } }
         assertRegisteredTargets(project, "iosArm64", "iosSimulatorArm64")
     }
 
     @Test
-    fun `given a selection value default and a global KMP_TARGETS when evaluated then global wins`(
+    fun `given a blank global and a defaultSelection when evaluated then the default applies`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm\n")
-        val project =
-            newEvaluatedProject(dir) { ext ->
-                ext.supported { all }
-                ext.selection(KmpTargetSet.web) // ignored: global wins
-            }
-        assertRegisteredTargets(project, "jvm")
-    }
-
-    @Test
-    fun `given a blank global and a selection default when evaluated then the default applies`(
-        @TempDir dir: Path
-    ) {
-        // A blank KMP_TARGETS means "not overriding" — the per-module default selection stands.
+        // A blank KMP_TARGETS means "not overriding" — the project-wide defaultSelection stands.
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=\n")
         val project =
             newEvaluatedProject(dir) { ext ->
-                ext.supported { all }
-                ext.selection { jvm + linuxX64 }
+                ext.supports { all }
+                ext.defaultSelection.set(
+                    KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Linux.X64)
+                )
             }
         assertRegisteredTargets(project, "jvm", "linuxX64")
     }
 
     @Test
-    fun `given an empty selection default and no global when evaluated then nothing registers`(
+    fun `given an empty defaultSelection and no global when evaluated then nothing registers`(
         @TempDir dir: Path
     ) {
         val project =
             newEvaluatedProject(dir) { ext ->
-                ext.supported { all }
-                ext.selection { empty } // explicit "build nothing"
+                ext.supports { all }
+                ext.defaultSelection.set(KmpTargetSet.empty) // explicit "build nothing"
             }
         assertRegisteredTargets(project /* none */)
     }
 
     @Test
-    fun `given a supported set disjoint from the selection when evaluated then nothing registers`(
+    fun `given a supports set disjoint from the selection when evaluated then nothing registers`(
         @TempDir dir: Path
     ) {
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=wasmJs\n")
-        val project = newEvaluatedProject(dir) { ext -> ext.supported { jvm + linuxX64 } }
+        val project = newEvaluatedProject(dir) { ext -> ext.supports { jvm + linuxX64 } }
         assertRegisteredTargets(project /* none — selection ∩ supported is empty */)
     }
 
@@ -136,7 +128,7 @@ class KmpTargetsDslTest {
     fun `given no DSL body and a global KMP_TARGETS when evaluated then selection registers under default-all supported`(
         @TempDir dir: Path
     ) {
-        // No `kmpTargets { … }` body at all — supported is undeclared, so `effectiveSupported`
+        // No `kmpTargets { … }` body at all — supported is undeclared, so `resolvedSupported`
         // returns its default of `all`. The global selection alone decides what registers. This is
         // the floor of the API contract: applying the base plugin with no configuration must still
         // honor KMP_TARGETS as the single switch.
@@ -146,14 +138,14 @@ class KmpTargetsDslTest {
     }
 
     @Test
-    fun `given supported mobile plus web and a narrowing global KMP_TARGETS when evaluated then exactly the overlap registers`(
+    fun `given supports mobile plus web and a narrowing global KMP_TARGETS when evaluated then exactly the overlap registers`(
         @TempDir dir: Path
     ) {
         // Composition test: the DSL takes the place of stacking two convention plugin ids (e.g.
-        // `.mobile` + `.web`). `supported { mobile + web }` is the equivalent declaration; with a
+        // `.mobile` + `.web`). `supports { mobile + web }` is the equivalent declaration; with a
         // selection that hits one leaf from each preset, only those leaves register.
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=iosArm64,wasmJs\n")
-        val project = newEvaluatedProject(dir) { ext -> ext.supported { mobile + web } }
+        val project = newEvaluatedProject(dir) { ext -> ext.supports { mobile + web } }
         assertRegisteredTargets(project, "iosArm64", "wasmJs")
     }
 

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslVocabularyTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslVocabularyTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 /**
  * Pure, Gradle-free coverage of the [KmpTargetsDsl] receiver vocabulary used inside `kmpTargets {
- * supported { … } }`. Every preset and every leaf must map to exactly the same `KmpTargetSet` the
+ * supports { … } }`. Every preset and every leaf must map to exactly the same `KmpTargetSet` the
  * string grammar and the public model produce — otherwise the type-safe DSL would silently disagree
  * with `KMP_TARGETS=…` and the docs.
  */

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionDslTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionDslTest.kt
@@ -8,69 +8,70 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
 
 /**
- * Extension-level coverage of the type-safe `supported { … }` / `selection { … }` blocks, the raw
- * value overloads, and the [KmpTargetsExtension.resolvedSelection] precedence (global override wins
- * over a per-module selection). These assert the pure DSL → property wiring without applying KGP;
- * the in-process registration is covered by [KmpTargetsDslTest].
+ * Extension-level coverage of the type-safe `supports { … }` block, its raw value overload, and the
+ * [KmpTargetsExtension.resolvedSelection] precedence (a global `KMP_TARGETS` wins over
+ * [KmpTargetsExtension.defaultSelection]). These assert the pure DSL → property wiring without
+ * applying KGP; the in-process registration is covered by [KmpTargetsDslTest].
  */
 class KmpTargetsExtensionDslTest {
 
     @Test
-    fun `given supported block when effectiveSupported then equals the declared union`() {
+    fun `given supports block when resolvedSupported then equals the declared union`() {
         val ext = newExtension()
-        ext.supported { mobile + web }
-        assertEquals(KmpTargetSet.mobile + KmpTargetSet.web, ext.effectiveSupported())
+        ext.supports { mobile + web }
+        assertEquals(KmpTargetSet.mobile + KmpTargetSet.web, ext.resolvedSupported())
     }
 
     @Test
-    fun `given supported block with subtraction when effectiveSupported then the leaf is removed`() {
+    fun `given supports block with subtraction when resolvedSupported then the leaf is removed`() {
         val ext = newExtension()
-        ext.supported { appleMobile - iosX64 }
+        ext.supports { appleMobile - iosX64 }
         assertEquals(
             KmpTargetSet.appleMobile - KmpTarget.Native.Apple.Ios.X64,
-            ext.effectiveSupported(),
+            ext.resolvedSupported(),
         )
-        assertTrue(KmpTarget.Native.Apple.Ios.X64 !in ext.effectiveSupported())
+        assertTrue(KmpTarget.Native.Apple.Ios.X64 !in ext.resolvedSupported())
     }
 
     @Test
-    fun `given supported value overload when effectiveSupported then equals that value`() {
+    fun `given supports value overload when resolvedSupported then equals that value`() {
         val ext = newExtension()
-        ext.supported(KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Linux.X64))
+        ext.supports(KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Linux.X64))
         assertEquals(
             KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Linux.X64),
-            ext.effectiveSupported(),
+            ext.resolvedSupported(),
         )
     }
 
     @Test
-    fun `given supported block called twice when effectiveSupported then the last assignment wins`() {
+    fun `given supports block called twice when resolvedSupported then the last assignment wins`() {
         val ext = newExtension()
-        ext.supported { mobile }
-        ext.supported { web }
-        // The DSL block is an assignment, not an accumulator — to union, write `supported { mobile
-        // +
+        ext.supports { mobile }
+        ext.supports { web }
+        // The DSL block is an assignment, not an accumulator — to union, write `supports { mobile +
         // web }`.
-        assertEquals(KmpTargetSet.web, ext.effectiveSupported())
+        assertEquals(KmpTargetSet.web, ext.resolvedSupported())
     }
 
     @Test
-    fun `given supported never declared when effectiveSupported then defaults to all`() {
+    fun `given supports never declared when resolvedSupported then defaults to all`() {
         val ext = newExtension()
-        assertEquals(KmpTargetSet.all, ext.effectiveSupported())
+        assertEquals(KmpTargetSet.all, ext.resolvedSupported())
     }
 
     @Test
-    fun `given supported block declared when effectiveSupported then equals the block value`() {
+    fun `given supports block declared when resolvedSupported then equals the block value`() {
         val ext = newExtension()
-        ext.supported { jvm }
-        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop), ext.effectiveSupported())
+        ext.supports { jvm }
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop), ext.resolvedSupported())
     }
 
     @Test
-    fun `given selection block and no global when resolvedSelection then equals the block value`() {
+    fun `given defaultSelection set and no global when resolvedSelection then equals that value`() {
         val ext = newExtension()
-        ext.selection { jvm + iosArm64 }
+        ext.defaultSelection.set(
+            KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64)
+        )
         assertEquals(
             KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64),
             ext.resolvedSelection(),
@@ -78,25 +79,18 @@ class KmpTargetsExtensionDslTest {
     }
 
     @Test
-    fun `given selection value overload and no global when resolvedSelection then equals that value`() {
+    fun `given a global selection and a defaultSelection when resolvedSelection then global wins`() {
         val ext = newExtension()
-        ext.selection(KmpTargetSet.web)
-        assertEquals(KmpTargetSet.web, ext.resolvedSelection())
-    }
-
-    @Test
-    fun `given both a global selection and a selection block when resolvedSelection then global wins`() {
-        val ext = newExtension()
-        ext.selection { iosArm64 + iosSimulatorArm64 }
+        ext.defaultSelection.set(KmpTargetSet.appleMobile)
         ext.globalSelection = KmpTargetSet.of(KmpTarget.Jvm.Desktop)
         assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop), ext.resolvedSelection())
     }
 
     @Test
-    fun `given a global selection narrowed to empty when resolvedSelection then it is empty not the block`() {
+    fun `given a global selection narrowed to empty when resolvedSelection then it is empty not the default`() {
         val ext = newExtension()
-        ext.selection { jvm }
-        // An explicit "build nothing" global (e.g. KMP_TARGETS=jvm,-jvm) must win over the block.
+        ext.defaultSelection.set(KmpTargetSet.of(KmpTarget.Jvm.Desktop))
+        // An explicit "build nothing" global (e.g. KMP_TARGETS=jvm,-jvm) must win over the default.
         ext.globalSelection = KmpTargetSet.empty
         assertEquals(KmpTargetSet.empty, ext.resolvedSelection())
     }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
@@ -10,37 +10,29 @@ import org.junit.jupiter.api.Test
 class KmpTargetsExtensionTest {
 
     @Test
-    fun `given extension created when selection accessed then property is present and unset`() {
+    fun `given extension created when defaultSelection accessed then property is unset`() {
         val ext = newExtension()
-        assertFalse(ext.selectionProperty.isPresent)
+        assertFalse(ext.defaultSelection.isPresent)
     }
 
     @Test
-    fun `given extension created when fallback accessed then property is present and unset`() {
+    fun `given extension created when supports accessed then property is unset`() {
         val ext = newExtension()
-        assertFalse(ext.fallback.isPresent)
+        assertFalse(ext.supportsProperty.isPresent)
     }
 
     @Test
-    fun `given extension created when supported accessed then property is unset`() {
+    fun `given supports unset when resolvedSupported then defaults to all`() {
         val ext = newExtension()
-        assertFalse(ext.supportedProperty.isPresent)
+        assertEquals(KmpTargetSet.all, ext.resolvedSupported())
     }
 
     @Test
-    fun `given supported unset when effectiveSupported then defaults to all`() {
+    fun `given defaultSelection set when read then it holds that value`() {
         val ext = newExtension()
-        assertEquals(KmpTargetSet.all, ext.effectiveSupported())
-    }
-
-    @Test
-    fun `given fallback set when selection is read then selection still empty until plugin applied`() {
-        val ext = newExtension()
-        ext.fallback.set(KmpTargetSet.web)
-        // Setting fallback doesn't auto-populate selection — that's the plugin's job.
-        assertFalse(ext.selectionProperty.isPresent)
-        assertTrue(ext.fallback.isPresent)
-        assertEquals(KmpTargetSet.web, ext.fallback.get())
+        ext.defaultSelection.set(KmpTargetSet.web)
+        assertTrue(ext.defaultSelection.isPresent)
+        assertEquals(KmpTargetSet.web, ext.defaultSelection.get())
     }
 
     private fun newExtension(): KmpTargetsExtension {

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
@@ -27,7 +27,7 @@ class KmpTargetsPluginTest {
     }
 
     @Test
-    fun `given plugin applied without any property when selection is read then equals fallback default KmpTargetSet all`(
+    fun `given plugin applied without any property when selection is read then equals defaultSelection default KmpTargetSet all`(
         @TempDir dir: Path
     ) {
         val project = newProject(dir)
@@ -62,13 +62,13 @@ class KmpTargetsPluginTest {
     }
 
     @Test
-    fun `given user fallback override when plugin applied without property then selection equals that fallback`(
+    fun `given user defaultSelection override when plugin applied without property then selection equals that default`(
         @TempDir dir: Path
     ) {
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        ext.fallback.set(KmpTargetSet.web)
+        ext.defaultSelection.set(KmpTargetSet.web)
         assertEquals(KmpTargetSet.web, ext.resolvedSelection())
     }
 
@@ -131,12 +131,13 @@ class KmpTargetsPluginTest {
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
-        // A blank property is not "I want zero targets" — it's "I'm not overriding"; fallback wins.
+        // A blank property is not "I want zero targets" — it's "I'm not overriding"; the default
+        // wins.
         assertEquals(KmpTargetSet.all, ext.resolvedSelection())
     }
 
     @Test
-    fun `given KMP_TARGETS narrows to nothing via minus when selection is read then it is empty not fallback`(
+    fun `given KMP_TARGETS narrows to nothing via minus when selection is read then it is empty not the default`(
         @TempDir dir: Path
     ) {
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm,-jvm\n")

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
@@ -144,7 +144,7 @@ class HierarchyTemplateInProcessTest {
     fun `given core and KGP applied when reading the active set then the spec matches the minimal tree`(
         @TempDir dir: Path
     ) {
-        // Proves the active-set -> spec wiring uses selection ∩ effectiveSupported. Materialization
+        // Proves the active-set -> spec wiring uses selection ∩ resolvedSupported. Materialization
         // is asserted by the source-set tests above; here we pin the pure decision on a real
         // extension fed by a real KMP_TARGETS property.
         dir.resolve("gradle.properties")

--- a/samples/hello-world/build.gradle.kts
+++ b/samples/hello-world/build.gradle.kts
@@ -1,6 +1,6 @@
 // Root of the multi-module sample.
 // Each subproject applies KGP + the `com.rsicarelli.kmptargets` base plugin and declares its
-// supported set via the `kmpTargets { supported { … } }` DSL. The global KMP_TARGETS
+// supported set via the `kmpTargets { supports { … } }` DSL. The global KMP_TARGETS
 // (gradle.properties) is intersected against each module's supported set.
 //
 // Kotlin Multiplatform is declared here once with `apply false` so every subproject shares a single

--- a/samples/hello-world/core-and-apple/build.gradle.kts
+++ b/samples/hello-world/core-and-apple/build.gradle.kts
@@ -9,4 +9,4 @@ plugins {
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
 }
 
-kmpTargets { supported { apple + jvm } }
+kmpTargets { supports { apple + jvm } }

--- a/samples/hello-world/escape-hatch-dsl/build.gradle.kts
+++ b/samples/hello-world/escape-hatch-dsl/build.gradle.kts
@@ -12,5 +12,5 @@ kmpTargets {
     // selection ∩ supported = jvm — so only `jvm` registers (linuxX64 is supported but unselected;
     // the iOS leaves are selected but unsupported). This declaration is read from the build-script
     // body and honored by the deferred registration pass — the old "timing wall" used to drop it.
-    supported { jvm + linuxX64 }
+    supports { jvm + linuxX64 }
 }

--- a/samples/hello-world/feature-mobile/build.gradle.kts
+++ b/samples/hello-world/feature-mobile/build.gradle.kts
@@ -9,4 +9,4 @@ plugins {
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
 }
 
-kmpTargets { supported { mobile } }
+kmpTargets { supports { mobile } }

--- a/samples/hello-world/jvm-tools/build.gradle.kts
+++ b/samples/hello-world/jvm-tools/build.gradle.kts
@@ -6,4 +6,4 @@ plugins {
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
 }
 
-kmpTargets { supported { jvm } }
+kmpTargets { supports { jvm } }

--- a/samples/hello-world/settings.gradle.kts
+++ b/samples/hello-world/settings.gradle.kts
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
 
 rootProject.name = "hello-world"
 
-// Heterogeneous modules, each declaring its supported shape via `kmpTargets { supported { … } }` in
+// Heterogeneous modules, each declaring its supported shape via `kmpTargets { supports { … } }` in
 // its build script (or leaving it unset for the default-all). The global KMP_TARGETS (see
 // gradle.properties) is intersected against each module's set, then a minimal hierarchy template is
 // applied. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64:
@@ -31,13 +31,13 @@ rootProject.name = "hello-world"
 // default-all → jvm + iosMain (the 2 iOS leaves share iosMain; no appleMain)
 include(":shared-core")
 
-// supported{mobile} → iosMain only (jvm unsupported here, Android unselected)
+// supports{mobile} → iosMain only (jvm unsupported here, Android unselected)
 include(":feature-mobile")
 
-// supported{jvm} → jvm only, no intermediate source sets
+// supports{jvm} → jvm only, no intermediate source sets
 include(":jvm-tools")
 
-// supported{apple+jvm} → jvm + iosMain
+// supports{apple+jvm} → jvm + iosMain
 include(":core-and-apple")
 
 // default-all, opts OUT → KGP default: iosMain + appleMain + nativeMain
@@ -46,5 +46,5 @@ include(":legacy-default")
 // no kmp-targets at all → KGP default, untouched (non-interference)
 include(":plain-kmp")
 
-// supported{jvm+linuxX64} → jvm only (linuxX64 unselected, iOS unsupported)
+// supports{jvm+linuxX64} → jvm only (linuxX64 unselected, iOS unsupported)
 include(":escape-hatch-dsl")

--- a/samples/hello-world/shared-core/build.gradle.kts
+++ b/samples/hello-world/shared-core/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     // Apply KGP + the base kmp-targets id; the supported set defaults to `all` when no
-    // `kmpTargets { supported { … } }` block is declared. With
+    // `kmpTargets { supports { … } }` block is declared. With
     // KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64
     // this registers those three; the minimal template shares the two iOS leaves under a single
     // `iosMain` (no redundant `appleMain`/`nativeMain`). Compare with :legacy-default, which opts

--- a/samples/isolated-projects/README.md
+++ b/samples/isolated-projects/README.md
@@ -15,8 +15,8 @@ goes red.
 
 | Module | DSL | Supported | Registered with `KMP_TARGETS=jvm` |
 |---|---|---|---|
-| `:lib` | _(no `supported` block — defaults to `all`)_ | all targets | `jvm` |
-| `:app` | `kmpTargets { supported { jvm } }` | `jvm` | `jvm` |
+| `:lib` | _(no `supports` block — defaults to `all`)_ | all targets | `jvm` |
+| `:app` | `kmpTargets { supports { jvm } }` | `jvm` | `jvm` |
 
 `:app` depends on `:lib` via a `project(":lib")` dependency — a real cross-project edge that Isolated
 Projects must wire while keeping each project's configuration isolated. Only the JVM target is

--- a/samples/isolated-projects/app/build.gradle.kts
+++ b/samples/isolated-projects/app/build.gradle.kts
@@ -11,6 +11,6 @@ ktfmt { kotlinLangStyle() }
 
 tasks.named("check") { dependsOn("ktfmtCheck") }
 
-kmpTargets { supported { jvm } }
+kmpTargets { supports { jvm } }
 
 kotlin { sourceSets { commonMain.dependencies { implementation(project(":lib")) } } }

--- a/samples/isolated-projects/build.gradle.kts
+++ b/samples/isolated-projects/build.gradle.kts
@@ -2,7 +2,7 @@
 // Kotlin Multiplatform is declared once with `apply false` so every subproject shares a single KGP
 // classloader (mirrors samples/hello-world). Each subproject applies KGP + the
 // `com.rsicarelli.kmptargets` base plugin and declares its supported set via the
-// `kmpTargets { supported { … } }` DSL — all under Isolated Projects (see gradle.properties).
+// `kmpTargets { supports { … } }` DSL — all under Isolated Projects (see gradle.properties).
 //
 // ktfmt is applied here so the root scripts (this file + settings.gradle.kts) get formatted; each
 // subproject also applies it directly. Isolated Projects forbids `subprojects { … }` cross-project

--- a/samples/isolated-projects/lib/build.gradle.kts
+++ b/samples/isolated-projects/lib/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    // Supports all targets (default when no `kmpTargets { supported { … } }` block is declared);
+    // Supports all targets (default when no `kmpTargets { supports { … } }` block is declared);
     // intersected with KMP_TARGETS=jvm (see ../gradle.properties) it registers jvm only. Configured
     // under Isolated Projects — proof the plugin applies without reaching across projects.
     kotlin("multiplatform")

--- a/samples/isolated-projects/settings.gradle.kts
+++ b/samples/isolated-projects/settings.gradle.kts
@@ -30,5 +30,5 @@ rootProject.name = "isolated-projects"
 // default-all → supports every target; with KMP_TARGETS=jvm registers jvm only
 include(":lib")
 
-// supported{jvm} → registers jvm; depends on :lib through a project dependency
+// supports{jvm} → registers jvm; depends on :lib through a project dependency
 include(":app")


### PR DESCRIPTION
## Why

The per-module DSL had grown two knobs — `supported { … }` and `selection { … }` — and the second confused more than it helped. In practice you only declare a module's **capability**; the **selection** is driven globally by `KMP_TARGETS`. The per-module `selection { }` block existed only as a "default when no global is set," a corner case better served by a single project-wide default. This trims the API to what's used and renames the rest so it reads honestly.

## Breaking changes — migration

| Before | After |
|---|---|
| `supported { … }` / `supported(value)` | `supports { … }` / `supports(value)` |
| `selection { … }` / `selection(value)` | **removed** — `KMP_TARGETS` is the selection; project-wide default → `defaultSelection` |
| `fallback` | `defaultSelection` |
| `effectiveSupported()` | `resolvedSupported()` |
| `resolvedSelection()` | unchanged |

The block name `kmpTargets { }` is unchanged.

## What

- **Dead-code sweep:** removed `selectionProperty` + its `convention(fallback)` wiring. `resolvedSelection()` now reads `globalSelection ?: defaultSelection.get()`. The global `KMP_TARGETS` pipeline — incl. the explicit-empty case (issue #9) — is intact (`globalSelection` kept).
- **KDoc:** rewrote the extension class + member docs (dropped the inaccurate "floor" wording on `defaultSelection`); reviewed the changed public surface against the `kmp-doc` skill. Also aligned three English "fallback selection" mentions to "default selection".
- **Tests:** the `selection`-block tests now exercise `defaultSelection` — global-wins, blank-global, empty-default, default-applies all still proven; dropped the redundant block-vs-value duplicate. GIVEN-WHEN-THEN preserved.
- **Docs & samples:** README (applying section, removed `selection` block, reworked precedence list to `defaultSelection`, hover + build-logic examples), `.claude/CLAUDE.md`, all 5 sample build scripts + comments, isolated-projects README.

## Verification

- `task ci` (build + test + both samples) ✅
- `./gradlew :gradle-plugin:check` (tests + ktfmt) ✅
- `task sample:build` + `task sample:isolated` build against the republished renamed API ✅
- Grep gate: zero references to any removed/renamed symbol ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)