### PR TITLE
refactor!: register KMP targets eagerly, drop afterEvaluate (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ Every preset (`all`, `mobile`, `apple`, `web`, `jvmFamily`, …) and every leaf 
 `linuxX64`, …) is available inside the block. Build-logic and consumers needing a raw value can use
 the overload: `supports(KmpTargetSet.mobile + KmpTargetSet.web)`.
 
-If you omit the `supports` block, the module defaults to **all** targets — the global
-`KMP_TARGETS` alone decides what registers. That's the right default for a generic library that
-wants to build whatever the developer is currently targeting.
+Targets are **explicit**: a module that never calls `supports` registers nothing, just like plain
+KGP where every target is declared by hand. `supports` registers eagerly — the moment it runs — so
+call it before anything reads `kotlin.targets`, and calling it more than once **unions** (an
+already-registered target can't be retracted). To build whatever the developer is currently
+targeting, opt in explicitly with `supports { all }` — then the global `KMP_TARGETS` alone decides
+what registers.
 
 The selection itself is **global** (the `KMP_TARGETS` property, see below) — there is no per-module
 selection block. A project-wide default for when `KMP_TARGETS` is unset can be set from build-logic

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -11,24 +11,27 @@ import org.gradle.api.provider.Property
  *
  * The plugin separates two facts:
  * - **supported** — what *this module* can build, declared per-module by the type-safe [supports]
- *   block (or its raw value overload). When nothing declares it, [resolvedSupported] defaults to
- *   [KmpTargetSet.all].
+ *   block (or its raw value overload). It is **explicit**: a module that never calls [supports]
+ *   registers no targets at all (just like plain KGP, where every target is declared by hand).
+ *   [resolvedSupported] returns [KmpTargetSet.empty] until something declares it.
  * - **selection** — what the user wants to build *now*. It is **global**: resolved from
  *   `KMP_TARGETS` (`-P`, env, root `gradle.properties`, or `local.properties`) and the same value
  *   for every module. When no global is provided, it falls back to [defaultSelection] (itself
  *   defaulting to [KmpTargetSet.all]).
  *
- * The plugin registers `selection ∩ supported`. [supports] is written from the build-script body; a
- * single deferred (after-evaluate) registration pass picks up whatever the body set. The extension
- * only ever holds immutable `KmpTargetSet`s of `data object` leaves, so it is configuration-cache
- * safe — no `Project` or task state is captured.
+ * The plugin registers `selection ∩ supported`. Registration is **eager**: calling [supports] from
+ * the build-script body registers the matching targets immediately (no deferred/after-evaluate
+ * pass), so anything that reads `kotlin.targets` afterwards sees them. The extension only ever
+ * holds immutable `KmpTargetSet`s of `data object` leaves, so it is configuration-cache safe — no
+ * `Project` or task state is captured.
  */
 public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFactory) {
 
     /**
      * The selection used when no global `KMP_TARGETS` is provided. Defaults to [KmpTargetSet.all].
      * Public so build-logic can set a project-wide default lazily; a global `KMP_TARGETS` always
-     * wins over it.
+     * wins over it. Set it **before** [supports], since [supports] registers eagerly off the
+     * resolved selection.
      */
     public abstract val defaultSelection: Property<KmpTargetSet>
 
@@ -39,42 +42,50 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
      * `applyDefaultHierarchyTemplate()` — also the escape hatch for a module that supplies its own
      * `applyHierarchyTemplate { … }`.
      *
-     * Readable from the build-script body: the template is applied in a deferred pass (after
-     * evaluation), by which point the DSL value has been set.
+     * Set it **before** [supports]: the template is applied as part of the eager registration that
+     * [supports] triggers, so it must already hold its value by then.
      */
     public abstract val hierarchyTemplate: Property<Boolean>
 
     /**
-     * What this module can build. Unset means "not declared"; [resolvedSupported] treats that as
-     * [KmpTargetSet.all]. Written by the [supports] block (or its raw overload).
+     * What this module can build. Unset means "not declared" → no targets register, and
+     * [resolvedSupported] returns [KmpTargetSet.empty]. Written by the [supports] block (or its raw
+     * overload), which unions on each call.
      */
     internal val supportsProperty: Property<KmpTargetSet> =
         objects.property(KmpTargetSet::class.java)
 
     /**
-     * Declares this module's supported set with the type-safe target vocabulary:
+     * Fired by [supports]; the plugin wires this to eager registration. Null until the plugin runs.
+     */
+    internal var onSupports: (() -> Unit)? = null
+
+    /**
+     * Declares this module's supported set with the type-safe target vocabulary and **registers**
+     * `selection ∩ supported` immediately:
      * ```kotlin
      * kmpTargets { supports { mobile + web - iosX64 } }
      * ```
      *
-     * Assigns the supported set; calling more than once replaces. If you want union semantics,
-     * write the union inside the block (`supports { mobile + web }`).
+     * Must be called before anything reads `kotlin.targets` (registration is eager). Calling more
+     * than once **unions** the sets — KGP target registration is one-way, so an already-registered
+     * target cannot be retracted. To narrow, write the final set inside a single block.
      */
     public fun supports(block: KmpTargetsDsl.() -> KmpTargetSet) {
-        supportsProperty.set(KmpTargetsDsl.block())
+        supports(KmpTargetsDsl.block())
     }
 
     /** Raw overload for build-logic: `supports(KmpTargetSet.mobile + KmpTargetSet.web)`. */
     public fun supports(value: KmpTargetSet) {
-        supportsProperty.set(value)
+        supportsProperty.set((supportsProperty.orNull ?: KmpTargetSet.empty) + value)
+        onSupports?.invoke()
     }
 
     /**
      * The global selection resolved from `KMP_TARGETS` at apply time, or `null` when no global
      * source provided one. When present it wins over [defaultSelection] (and an explicit empty set
      * is honored — see issue #9), which is what keeps the global switch authoritative. Stored as an
-     * immutable [KmpTargetSet], so capturing it in deferred closures stays configuration-cache
-     * safe.
+     * immutable [KmpTargetSet], so it stays configuration-cache safe.
      */
     internal var globalSelection: KmpTargetSet? = null
 
@@ -85,15 +96,16 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
      */
     public fun resolvedSelection(): KmpTargetSet = globalSelection ?: defaultSelection.get()
 
-    /** Leaves already registered with KGP, so repeated registration passes are idempotent. */
+    /** Leaves already registered with KGP, so repeated registration stays idempotent. */
     internal val registered: MutableSet<KmpTarget> = mutableSetOf()
 
     /** True once the minimal hierarchy template has been applied, so it is applied at most once. */
     internal var hierarchyTemplateApplied: Boolean = false
 
     /**
-     * The resolved supported set: the declared value, or [KmpTargetSet.all] if none. Public so
-     * build-logic (and consumers) can read what this module ended up declaring.
+     * The resolved supported set: the declared value (unioned across [supports] calls), or
+     * [KmpTargetSet.empty] if none was declared. Public so build-logic (and consumers) can read
+     * what this module ended up declaring.
      */
-    public fun resolvedSupported(): KmpTargetSet = supportsProperty.orNull ?: KmpTargetSet.all
+    public fun resolvedSupported(): KmpTargetSet = supportsProperty.orNull ?: KmpTargetSet.empty
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -34,29 +34,20 @@ public class KmpTargetsPlugin : Plugin<Project> {
             ext.globalSelection = parseOrThrow(raw, KMP_TARGETS)
         }
 
-        // Global default for the hierarchy template, read at apply time and pulled out as a
-        // primitive so the afterEvaluate closure below never captures `Project` (config-cache
-        // safe).
+        // Global default for the hierarchy template, read once at apply time as a primitive.
         val globalHierarchyEnabled: Boolean? = hierarchyTemplateEnabledGlobally(target)
 
-        // All work waits for the build-script body to run: target registration, the empty-overlap
-        // warning, and the hierarchy template are functions of the final `supports` set declared
-        // via the DSL. The closure captures only `ext` (immutable sets + booleans) and the
-        // primitive flag, so it stays configuration-cache safe.
-        target.afterEvaluate { p ->
-            if (!p.plugins.hasPlugin(KGP_ID)) return@afterEvaluate
-            registerResolved(p, ext)
-            val selection = ext.resolvedSelection()
-            val active = selection intersect ext.resolvedSupported()
-
-            // Advisory only: the selection is non-empty yet genuinely disjoint from the supported
-            // set, so nothing registers. Keyed off the actual overlap (not "nothing registered"),
-            // so the message can never name a token present in both lists (issue #10).
-            if (shouldWarnEmptyOverlap(selection, ext.resolvedSupported())) {
-                p.logger.warn(emptyOverlapWarning(p.path, selection, ext.resolvedSupported()))
+        // Eager registration: `supports { … }` in the build-script body registers `selection ∩
+        // supported` immediately — no deferred (after-evaluate) pass, no timing wall. We hook it
+        // via
+        // `withPlugin(KGP)` so registration fires the moment both KGP and a `supports` declaration
+        // are present (in either order); if KGP is never applied, nothing registers. This runs at
+        // configuration time and is never held by a Task, so no `Project` leaks into the config
+        // cache.
+        ext.onSupports = {
+            target.pluginManager.withPlugin(KGP_ID) {
+                register(target, ext, globalHierarchyEnabled)
             }
-
-            maybeApplyHierarchyTemplate(p, ext, active, globalHierarchyEnabled)
         }
     }
 
@@ -103,14 +94,33 @@ public class KmpTargetsPlugin : Plugin<Project> {
             is ParseResult.Err -> throw GradleException("$propertyName: ${r.message}")
         }
 
-    /** Registers `selection ∩ supported`, skipping leaves already registered (idempotent). */
-    private fun registerResolved(project: Project, ext: KmpTargetsExtension) {
+    /**
+     * Registers `selection ∩ supported`, emits the empty-overlap advisory, and applies the minimal
+     * hierarchy template — all off the cumulative supported set, so repeated `supports` calls only
+     * register the delta (idempotent) and the template still applies at most once.
+     */
+    private fun register(
+        project: Project,
+        ext: KmpTargetsExtension,
+        globalHierarchyEnabled: Boolean?,
+    ) {
         val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
-        val effective = ext.resolvedSelection() intersect ext.resolvedSupported()
-        (effective.members - ext.registered).forEach { leaf ->
+        val selection = ext.resolvedSelection()
+        val supported = ext.resolvedSupported()
+        val active = selection intersect supported
+        (active.members - ext.registered).forEach { leaf ->
             registerTarget(kotlin, leaf)
             ext.registered.add(leaf)
         }
+
+        // Advisory only: the selection is non-empty yet genuinely disjoint from the supported set,
+        // so nothing registers. Keyed off the actual overlap (not "nothing registered"), so the
+        // message can never name a token present in both lists (issue #10).
+        if (shouldWarnEmptyOverlap(selection, supported)) {
+            project.logger.warn(emptyOverlapWarning(project.path, selection, supported))
+        }
+
+        maybeApplyHierarchyTemplate(project, ext, active, globalHierarchyEnabled)
     }
 
     /**

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslTest.kt
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.io.TempDir
 
 /**
  * Proves the type-safe `kmpTargets { … }` DSL set during the build-script body (the escape-hatch
- * flow: KGP applied first, then the base plugin, then a narrowing `supports { … }`). This is the
- * case the old "timing wall" silently dropped: registration is deferred to the after-evaluate pass,
- * so a `supports` set declared in the body is honored. `(project as ProjectInternal).evaluate()`
- * fires that pass in-process.
+ * flow: KGP applied first, then the base plugin, then a narrowing `supports { … }`). Registration
+ * is **eager** — it fires the moment `supports { … }` runs, so targets exist before `(project as
+ * ProjectInternal).evaluate()` is pumped (the pump only drives KGP's own hierarchy lifecycle).
+ * `defaultSelection`/`hierarchyTemplate` must therefore be set *before* `supports`.
  */
 class KmpTargetsDslTest {
 
@@ -47,10 +47,10 @@ class KmpTargetsDslTest {
     ) {
         val project =
             newEvaluatedProject(dir) { ext ->
-                ext.supports { all }
                 ext.defaultSelection.set(
                     KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64)
                 )
+                ext.supports { all }
             }
         assertRegisteredTargets(project, "jvm", "iosArm64")
     }
@@ -62,8 +62,8 @@ class KmpTargetsDslTest {
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm\n")
         val project =
             newEvaluatedProject(dir) { ext ->
-                ext.supports { all }
                 ext.defaultSelection.set(KmpTargetSet.appleMobile) // ignored: global wins
+                ext.supports { all }
             }
         assertRegisteredTargets(project, "jvm")
     }
@@ -95,10 +95,10 @@ class KmpTargetsDslTest {
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=\n")
         val project =
             newEvaluatedProject(dir) { ext ->
-                ext.supports { all }
                 ext.defaultSelection.set(
                     KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Linux.X64)
                 )
+                ext.supports { all }
             }
         assertRegisteredTargets(project, "jvm", "linuxX64")
     }
@@ -109,8 +109,8 @@ class KmpTargetsDslTest {
     ) {
         val project =
             newEvaluatedProject(dir) { ext ->
-                ext.supports { all }
                 ext.defaultSelection.set(KmpTargetSet.empty) // explicit "build nothing"
+                ext.supports { all }
             }
         assertRegisteredTargets(project /* none */)
     }
@@ -125,15 +125,41 @@ class KmpTargetsDslTest {
     }
 
     @Test
-    fun `given no DSL body and a global KMP_TARGETS when evaluated then selection registers under default-all supported`(
+    fun `given no supports declared and a global KMP_TARGETS when evaluated then nothing registers`(
         @TempDir dir: Path
     ) {
-        // No `kmpTargets { … }` body at all — supported is undeclared, so `resolvedSupported`
-        // returns its default of `all`. The global selection alone decides what registers. This is
-        // the floor of the API contract: applying the base plugin with no configuration must still
-        // honor KMP_TARGETS as the single switch.
+        // Targets are explicit: with no `supports { … }` there is nothing to register, regardless
+        // of
+        // KMP_TARGETS. This is the floor of the API contract under eager registration — there is no
+        // implicit default-all supported set.
         dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm,iosArm64\n")
         val project = newEvaluatedProject(dir) { /* no extension configuration */ }
+        assertRegisteredTargets(project /* none — supported was never declared */)
+    }
+
+    @Test
+    fun `given an explicit supports all and a global KMP_TARGETS when evaluated then the selection registers`(
+        @TempDir dir: Path
+    ) {
+        // `supports { all }` is the explicit opt-in to "build everything KMP_TARGETS selects": with
+        // supported = all, the global selection alone decides what registers.
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm,iosArm64\n")
+        val project = newEvaluatedProject(dir) { ext -> ext.supports { all } }
+        assertRegisteredTargets(project, "jvm", "iosArm64")
+    }
+
+    @Test
+    fun `given supports called twice when evaluated then each target registers at most once`(
+        @TempDir dir: Path
+    ) {
+        // Eager registration is idempotent and unions: the second call registers only the delta
+        // (iosArm64); jvm, already registered, is not re-added and KGP does not throw.
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        val project =
+            newEvaluatedProject(dir) { ext ->
+                ext.supports { jvm }
+                ext.supports { jvm + iosArm64 }
+            }
         assertRegisteredTargets(project, "jvm", "iosArm64")
     }
 
@@ -151,7 +177,8 @@ class KmpTargetsDslTest {
 
     /**
      * Escape-hatch order: user applies KGP, then the base plugin, then configures the extension in
-     * the body. The deferred registration runs only on [ProjectInternal.evaluate].
+     * the body — where `supports { … }` registers eagerly. [ProjectInternal.evaluate] is pumped
+     * only to drive KGP's own source-set hierarchy lifecycle.
      */
     private fun newEvaluatedProject(dir: Path, configure: (KmpTargetsExtension) -> Unit): Project {
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionDslTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionDslTest.kt
@@ -44,19 +44,19 @@ class KmpTargetsExtensionDslTest {
     }
 
     @Test
-    fun `given supports block called twice when resolvedSupported then the last assignment wins`() {
+    fun `given supports block called twice when resolvedSupported then the sets union`() {
         val ext = newExtension()
         ext.supports { mobile }
         ext.supports { web }
-        // The DSL block is an assignment, not an accumulator — to union, write `supports { mobile +
-        // web }`.
-        assertEquals(KmpTargetSet.web, ext.resolvedSupported())
+        // Registration is one-way (an already-registered target can't be retracted), so repeated
+        // calls union rather than replace. To narrow, write the final set in a single block.
+        assertEquals(KmpTargetSet.mobile + KmpTargetSet.web, ext.resolvedSupported())
     }
 
     @Test
-    fun `given supports never declared when resolvedSupported then defaults to all`() {
+    fun `given supports never declared when resolvedSupported then defaults to empty`() {
         val ext = newExtension()
-        assertEquals(KmpTargetSet.all, ext.resolvedSupported())
+        assertEquals(KmpTargetSet.empty, ext.resolvedSupported())
     }
 
     @Test

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
@@ -22,9 +22,9 @@ class KmpTargetsExtensionTest {
     }
 
     @Test
-    fun `given supports unset when resolvedSupported then defaults to all`() {
+    fun `given supports unset when resolvedSupported then defaults to empty`() {
         val ext = newExtension()
-        assertEquals(KmpTargetSet.all, ext.resolvedSupported())
+        assertEquals(KmpTargetSet.empty, ext.resolvedSupported())
     }
 
     @Test

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
@@ -168,7 +168,11 @@ class HierarchyTemplateInProcessTest {
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        // `configure` sets hierarchyTemplate, which must hold before the eager `supports` call that
+        // registers targets and applies the template. `supports { all }` keeps the active set equal
+        // to the KMP_TARGETS selection.
         configure(project)
+        project.extensions.getByType(KmpTargetsExtension::class.java).supports(KmpTargetSet.all)
         (project as ProjectInternal).evaluate()
         return project.extensions
             .getByType(KotlinMultiplatformExtension::class.java)
@@ -183,6 +187,7 @@ class HierarchyTemplateInProcessTest {
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.extensions.getByType(KmpTargetsExtension::class.java).supports(KmpTargetSet.all)
         (project as ProjectInternal).evaluate()
         return project.extensions
             .getByType(KotlinMultiplatformExtension::class.java)

--- a/samples/hello-world/build-logic/build.gradle.kts
+++ b/samples/hello-world/build-logic/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins { `kotlin-dsl` }
+
+dependencies {
+    // The kmp-targets plugin under test (from mavenLocal). `implementation` so it reaches the
+    // consuming module's plugin classpath (the convention applies it by id) and so this build can
+    // reference its DSL types. kmp-targets declares KGP `compileOnly`, so this does NOT drag a second
+    // copy of KGP onto the consumer.
+    implementation("com.rsicarelli:kmp-targets-gradle-plugin:0.1.0-SNAPSHOT")
+    // KGP types for compile only. KGP itself is applied by each consuming module's
+    // `kotlin("multiplatform")`, keeping a single shared KGP classloader in the sample.
+    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}")
+}
+
+gradlePlugin {
+    plugins {
+        create("kmptargetsModule") {
+            id = "kmptargets.module"
+            implementationClass = "KmpModulePlugin"
+        }
+    }
+}

--- a/samples/hello-world/build-logic/settings.gradle.kts
+++ b/samples/hello-world/build-logic/settings.gradle.kts
@@ -1,0 +1,23 @@
+// Included build that contributes the sample's own `kmptargets.module` convention plugin. Kept
+// separate from the consuming modules so the convention is compiled and published as a real plugin,
+// the way a team's `build-logic` would be.
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        google()
+    }
+    // Share the main repo's catalog so the Kotlin version matches the plugin under test.
+    versionCatalogs { create("libs") { from(files("../../../gradle/libs.versions.toml")) } }
+}
+
+rootProject.name = "build-logic"

--- a/samples/hello-world/build-logic/src/main/kotlin/KmpModule.kt
+++ b/samples/hello-world/build-logic/src/main/kotlin/KmpModule.kt
@@ -1,0 +1,28 @@
+import com.rsicarelli.kmptargets.KmpTargetsDsl
+import com.rsicarelli.kmptargets.KmpTargetsExtension
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+/**
+ * Declares this module's supported set, then reads `kotlin.targets` **synchronously** and hands the
+ * registered target names to [perTarget].
+ *
+ * This is the capability that removing the after-evaluate pass unlocks: because `supports`
+ * registers eagerly, the targets exist the instant this function reads them. Under the old deferred
+ * model the same read returned an empty set, which is why convention plugins that wired per-target
+ * behaviour right after declaration were fragile. The reactive `targets.configureEach { … }` in the
+ * `kmptargets.module` plugin is the ordering-immune alternative shown alongside it.
+ */
+fun Project.kmpModule(
+    supported: KmpTargetsDsl.() -> KmpTargetSet,
+    perTarget: (List<String>) -> Unit = {},
+) {
+    extensions.getByType<KmpTargetsExtension>().supports(supported)
+    val targets =
+        extensions.getByType<KotlinMultiplatformExtension>().targets.names.filter {
+            it != "metadata"
+        }
+    perTarget(targets)
+}

--- a/samples/hello-world/build-logic/src/main/kotlin/KmpModulePlugin.kt
+++ b/samples/hello-world/build-logic/src/main/kotlin/KmpModulePlugin.kt
@@ -1,0 +1,28 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+/**
+ * Sample convention plugin (`kmptargets.module`): wraps the kmp-targets base plugin so a consuming
+ * module applies one id and uses the `kmpModule { … }` DSL.
+ *
+ * Implemented as a binary plugin (not a precompiled `.gradle.kts`) so it is only ever applied to a
+ * real consuming project — where KGP is present via the consumer's own `kotlin("multiplatform")`.
+ * That keeps a single shared KGP classloader across the sample; this build never bundles its own KGP
+ * (it depends on KGP `compileOnly`, for types only).
+ */
+class KmpModulePlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+
+        // The ordering-immune counterpart to `kmpModule`'s eager read: react to each target as it is
+        // registered. Fires when the consumer's `supports { … }` runs, regardless of order.
+        val log = project.logger
+        project.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+            project.extensions.getByType<KotlinMultiplatformExtension>().targets.configureEach {
+                log.lifecycle("reactively configured target: $name")
+            }
+        }
+    }
+}

--- a/samples/hello-world/eager-conventions/build.gradle.kts
+++ b/samples/hello-world/eager-conventions/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    // Shared KGP classloader (the root build declares KGP `apply false`), plus the sample's own
+    // `kmptargets.module` convention from the `build-logic` included build.
+    kotlin("multiplatform")
+    id("kmptargets.module")
+}
+
+// EAGER PROOF. `kmpModule` declares the supported set and then reads `kotlin.targets`
+// synchronously,
+// wiring one task per registered target. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64
+// intersected
+// against supports { jvm + iosArm64 }, the convention sees exactly [iosArm64, jvm] — at
+// configuration
+// time, in the same pass. Under the old after-evaluate model this read would have been empty.
+kmpModule(supported = { jvm + iosArm64 }) { targets ->
+    targets.forEach { target ->
+        tasks.register("describe${target.replaceFirstChar(Char::uppercase)}") {
+            doLast { logger.lifecycle("eager-wired target: $target") }
+        }
+    }
+}
+
+// Regression gate, wired into `check` and run by `task ci`. Captures only a List<String> at
+// configuration time (config-cache safe), and fails if eager registration ever regresses to a
+// deferred pass — in which case this read would see no targets.
+val observedTargets = kotlin.targets.names.filter { it != "metadata" }.sorted()
+
+tasks.register("verifyEagerTargets") {
+    val observed = observedTargets
+    val expected = listOf("iosArm64", "jvm")
+    doLast {
+        check(observed == expected) {
+            "eager registration regressed: expected $expected at configuration time, saw $observed"
+        }
+    }
+}
+
+tasks.named("check") { dependsOn("verifyEagerTargets") }

--- a/samples/hello-world/eager-conventions/src/commonMain/kotlin/Greeting.kt
+++ b/samples/hello-world/eager-conventions/src/commonMain/kotlin/Greeting.kt
@@ -1,0 +1,1 @@
+fun greeting(): String = "hello from eager-conventions"

--- a/samples/hello-world/escape-hatch-dsl/build.gradle.kts
+++ b/samples/hello-world/escape-hatch-dsl/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 kmpTargets {
     // Supports JVM + Linux only. With the sample's KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64,
     // selection ∩ supported = jvm — so only `jvm` registers (linuxX64 is supported but unselected;
-    // the iOS leaves are selected but unsupported). This declaration is read from the build-script
-    // body and honored by the deferred registration pass — the old "timing wall" used to drop it.
+    // the iOS leaves are selected but unsupported). `supports` registers eagerly, the moment this
+    // line runs.
     supports { jvm + linuxX64 }
 }

--- a/samples/hello-world/legacy-default/build.gradle.kts
+++ b/samples/hello-world/legacy-default/build.gradle.kts
@@ -3,12 +3,15 @@ plugins {
     // template. KGP then applies its default hierarchy, so the two iOS leaves get the full
     // redundant
     // chain — `iosMain` + `appleMain` + `nativeMain` — instead of just `iosMain`. This is the
-    // side-by-side proof of what the feature removes. `supported` is left at its default of `all`.
+    // side-by-side proof of what the feature removes. It still `supports { all }`, like
+    // :shared-core.
     kotlin("multiplatform")
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
 }
 
 kmpTargets {
     // Project-level override (wins over the global `kmptargets.hierarchyTemplate` default of true).
+    // Set before `supports`, since `supports` applies the template as part of eager registration.
     hierarchyTemplate.set(false)
+    supports { all }
 }

--- a/samples/hello-world/settings.gradle.kts
+++ b/samples/hello-world/settings.gradle.kts
@@ -1,4 +1,7 @@
 pluginManagement {
+    // The sample's own convention plugin lives in an included build so its `kmptargets.module` id
+    // resolves during plugin resolution (used by :eager-conventions).
+    includeBuild("build-logic")
     repositories {
         mavenLocal()
         gradlePluginPortal()
@@ -24,11 +27,12 @@ dependencyResolutionManagement {
 rootProject.name = "hello-world"
 
 // Heterogeneous modules, each declaring its supported shape via `kmpTargets { supports { … } }` in
-// its build script (or leaving it unset for the default-all). The global KMP_TARGETS (see
-// gradle.properties) is intersected against each module's set, then a minimal hierarchy template is
-// applied. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64:
+// its build script. Targets are explicit — a module with no `supports` registers nothing. The
+// global
+// KMP_TARGETS (see gradle.properties) is intersected against each module's set, then a minimal
+// hierarchy template is applied. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64:
 
-// default-all → jvm + iosMain (the 2 iOS leaves share iosMain; no appleMain)
+// supports{all} → jvm + iosMain (the 2 iOS leaves share iosMain; no appleMain)
 include(":shared-core")
 
 // supports{mobile} → iosMain only (jvm unsupported here, Android unselected)
@@ -40,7 +44,7 @@ include(":jvm-tools")
 // supports{apple+jvm} → jvm + iosMain
 include(":core-and-apple")
 
-// default-all, opts OUT → KGP default: iosMain + appleMain + nativeMain
+// supports{all}, opts OUT → KGP default: iosMain + appleMain + nativeMain
 include(":legacy-default")
 
 // no kmp-targets at all → KGP default, untouched (non-interference)
@@ -48,3 +52,7 @@ include(":plain-kmp")
 
 // supports{jvm+linuxX64} → jvm only (linuxX64 unselected, iOS unsupported)
 include(":escape-hatch-dsl")
+
+// build-logic convention (`kmptargets.module`) that declares `supports` then reads `kotlin.targets`
+// synchronously — proves eager registration. `verifyEagerTargets` fails the build if it regresses.
+include(":eager-conventions")

--- a/samples/hello-world/shared-core/build.gradle.kts
+++ b/samples/hello-world/shared-core/build.gradle.kts
@@ -1,11 +1,13 @@
 plugins {
-    // Apply KGP + the base kmp-targets id; the supported set defaults to `all` when no
-    // `kmpTargets { supports { … } }` block is declared. With
-    // KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64
-    // this registers those three; the minimal template shares the two iOS leaves under a single
-    // `iosMain` (no redundant `appleMain`/`nativeMain`). Compare with :legacy-default, which opts
-    // out
-    // and keeps both.
+    // Apply KGP + the base kmp-targets id, then declare `supports { all }` to build everything the
+    // global KMP_TARGETS selects. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 this registers
+    // those three; the minimal template shares the two iOS leaves under a single `iosMain` (no
+    // redundant `appleMain`/`nativeMain`). Compare with :legacy-default, which opts out and keeps
+    // both.
     kotlin("multiplatform")
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
 }
+
+// Targets are explicit: with no `supports` nothing would register. `supports { all }` is the opt-in
+// to "build whatever KMP_TARGETS selects".
+kmpTargets { supports { all } }

--- a/samples/isolated-projects/lib/build.gradle.kts
+++ b/samples/isolated-projects/lib/build.gradle.kts
@@ -1,11 +1,13 @@
 plugins {
-    // Supports all targets (default when no `kmpTargets { supports { … } }` block is declared);
-    // intersected with KMP_TARGETS=jvm (see ../gradle.properties) it registers jvm only. Configured
-    // under Isolated Projects — proof the plugin applies without reaching across projects.
+    // Supports all targets via the explicit `supports { all }` below. Intersected with the global
+    // KMP_TARGETS=jvm (see ../gradle.properties) it registers jvm only. Configured under Isolated
+    // Projects — proof the plugin applies without reaching across projects.
     kotlin("multiplatform")
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
     id("com.ncorti.ktfmt.gradle")
 }
+
+kmpTargets { supports { all } }
 
 ktfmt { kotlinLangStyle() }
 


### PR DESCRIPTION
Closes #29.

## Why

Target registration lived inside `Project.afterEvaluate` purely to learn each module's per-module `supports { … }` set at end-of-evaluation. That deferral violated the project's own no-`afterEvaluate` rule, was ordering-fragile against other plugins, and forced config-cache bookkeeping that existed only to defer.

I validated against the local Kotlin source (KGP **2.3.21**): there is **no public lifecycle hook** — `KotlinPluginLifecycle`, `Stage`, `Project.launchInStage`, `KotlinProjectSetupAction` are all `internal`/`@InternalKotlinGradlePluginApi`, and `KotlinGradlePluginExtensionPoint`'s factory is `internal`. So a "defer to a KGP-owned phase" approach isn't available without reaching into internals (out of scope). The fix is to stop deferring: register the moment `supports` runs.

## Breaking changes (pre-1.0)

- **A module that never calls `supports` registers nothing** — targets are explicit, like plain KGP. To build everything `KMP_TARGETS` selects, opt in with `supports { all }`.
- **`supports` registers eagerly** — call it before anything reads `kotlin.targets`.
- **Calling `supports` more than once unions** (was replace) — KGP registration is one-way, so a registered target can't be retracted.
- **`resolvedSupported()` defaults to `empty`** (was `all`) when undeclared.

## What changed

- **`KmpTargetsPlugin`** — delete the `afterEvaluate` block + `registerResolved`; `supports` triggers eager `register(...)` via `pluginManager.withPlugin(KGP_ID)`, computed off the cumulative supported set (idempotent; hierarchy template still applied at most once).
- **`KmpTargetsExtension`** — `supports()` unions + fires the trigger; `resolvedSupported()` defaults to `empty`; KDoc rewritten for the eager model.
- **Tests** — order `defaultSelection`/`hierarchyTemplate` before `supports`; rewrite the no-body test; add explicit-default + idempotence tests; thread `supports { all }` through the hierarchy helpers; flip the two extension-unit tests (union, empty-default).
- **Samples** — `shared-core` / `legacy-default` / `isolated-projects:lib` declare `supports { all }`; **new** `build-logic` included build (`kmptargets.module` convention + `kmpModule { }` DSL) and an `eager-conventions` module whose `verifyEagerTargets` gate proves the synchronous post-`supports` `kotlin.targets` read — the capability eager registration unlocks (it would read empty under `afterEvaluate`).
- **README** — rewrite the "omit `supports` → all" paragraph for explicit targets.

## Verification

- Acceptance gate: `grep -rn afterEvaluate gradle-plugin/src/main` → empty.
- `:gradle-plugin:test`, `build`, `test` — green (incl. new no-body / explicit-default / idempotence tests).
- `samples/hello-world` and `samples/isolated-projects` build; **config-cache reuse** confirmed on a second run.
- `:eager-conventions:verifyEagerTargets` passes — the convention reads `[iosArm64, jvm]` synchronously right after `supports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)