### PR TITLE
feat: warn when selected native targets cannot compile on the current host

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,27 @@ kmpTargets { hierarchyTemplate.set(false) }
 Precedence is **project DSL > global property > built-in default (`true`)**. Opt out when a module
 supplies its own `applyHierarchyTemplate { … }`, so the plugin stays out of the way.
 
+### Host compatibility
+
+The registered target set is **host-blind by design**: selecting `iosArm64` registers `iosArm64` on
+macOS, Linux, and Windows alike, so configuration-cache keys, task graphs, and published metadata
+stay identical across CI agents. But not every host can *compile* every native target — `iosArm64`
+needs a macOS host.
+
+When the selection includes a native target the current host cannot compile, the plugin logs a
+configuration-time **warning** naming the target(s) and the host (e.g. `LINUX_X64`) — and **still
+registers them**. Nothing is silently dropped; your explicit selection is honored deterministically,
+and Kotlin/Native's compile/link tasks for those targets simply won't succeed on that host:
+
+```
+kmp-targets: ':shared' selects [iosArm64] which cannot be compiled on this host (LINUX_X64) —
+still registered (selection is host-independent), but compile/link tasks for them will fail or
+be skipped here.
+```
+
+The warning is purely advisory and fires at most once per target per module. JVM and Web targets
+(`androidTarget`, `jvm`, `js`, `wasmJs`, `wasmWasi`) are host-agnostic and never warned.
+
 ## Installation
 
 The plugin is not yet published to the Gradle Plugin Portal or Maven Central. Track progress in the issues / releases. Locally:

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -99,6 +99,9 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     /** Leaves already registered with KGP, so repeated registration stays idempotent. */
     internal val registered: MutableSet<KmpTarget> = mutableSetOf()
 
+    /** Leaves already named in a host-impossible warning, so each is warned at most once. */
+    internal val hostWarned: MutableSet<KmpTarget> = mutableSetOf()
+
     /** True once the minimal hierarchy template has been applied, so it is applied at most once. */
     internal var hierarchyTemplateApplied: Boolean = false
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -3,6 +3,8 @@ package com.rsicarelli.kmptargets
 import com.rsicarelli.kmptargets.hierarchy.computeHierarchySpec
 import com.rsicarelli.kmptargets.hierarchy.resolveHierarchyTemplateEnabled
 import com.rsicarelli.kmptargets.hierarchy.toTemplate
+import com.rsicarelli.kmptargets.host.hostImpossibleWarning
+import com.rsicarelli.kmptargets.host.impossibleOnHost
 import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
 import com.rsicarelli.kmptargets.parser.ParseResult
@@ -16,6 +18,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.konan.target.HostManager
 
 public class KmpTargetsPlugin : Plugin<Project> {
 
@@ -95,9 +98,10 @@ public class KmpTargetsPlugin : Plugin<Project> {
         }
 
     /**
-     * Registers `selection ∩ supported`, emits the empty-overlap advisory, and applies the minimal
-     * hierarchy template — all off the cumulative supported set, so repeated `supports` calls only
-     * register the delta (idempotent) and the template still applies at most once.
+     * Registers `selection ∩ supported`, emits the empty-overlap and host-impossible advisories,
+     * and applies the minimal hierarchy template — all off the cumulative supported set, so
+     * repeated `supports` calls only register the delta (idempotent), each host warning names a
+     * leaf at most once, and the template still applies at most once.
      */
     private fun register(
         project: Project,
@@ -118,6 +122,24 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // message can never name a token present in both lists (issue #10).
         if (shouldWarnEmptyOverlap(selection, supported)) {
             project.logger.warn(emptyOverlapWarning(project.path, selection, supported))
+        }
+
+        // Host-awareness (#32): advisory only — names registered native targets this host cannot
+        // compile, never changing what registers (the set stays identical across hosts).
+        // HostManager is touched only here, inside `withPlugin(KGP_ID)` at configuration time, so
+        // its classes never load when KGP is absent and nothing host-derived is held by a task
+        // action. Deduped per leaf via `hostWarned`, so a later `supports` union that introduces a
+        // new impossible leaf still warns — for that leaf only.
+        val fresh = impossibleOnHost(active, HostManager().enabled.toSet()).members - ext.hostWarned
+        if (fresh.isNotEmpty()) {
+            project.logger.warn(
+                hostImpossibleWarning(
+                    project.path,
+                    HostManager.host,
+                    KmpTargetSet.of(*fresh.toTypedArray()),
+                )
+            )
+            ext.hostWarned += fresh
         }
 
         maybeApplyHierarchyTemplate(project, ext, active, globalHierarchyEnabled)

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/host/HostCompatibility.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/host/HostCompatibility.kt
@@ -1,0 +1,65 @@
+package com.rsicarelli.kmptargets.host
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import org.jetbrains.kotlin.konan.target.KonanTarget
+
+/**
+ * The [KonanTarget] a native [target] compiles to, or `null` for the host-agnostic JVM/Web leaves.
+ *
+ * Exhaustive over every leaf (mirroring `registerTarget`), so adding a new target forces a
+ * compile-time decision here about its host story.
+ */
+internal fun konanTargetOf(target: KmpTarget): KonanTarget? =
+    when (target) {
+        KmpTarget.Native.Apple.Ios.Arm64 -> KonanTarget.IOS_ARM64
+        KmpTarget.Native.Apple.Ios.SimulatorArm64 -> KonanTarget.IOS_SIMULATOR_ARM64
+        KmpTarget.Native.Apple.Ios.X64 -> KonanTarget.IOS_X64
+        KmpTarget.Native.Apple.Macos.Arm64 -> KonanTarget.MACOS_ARM64
+        KmpTarget.Native.Apple.Macos.X64 -> KonanTarget.MACOS_X64
+        KmpTarget.Native.Apple.Watchos.Arm64 -> KonanTarget.WATCHOS_ARM64
+        KmpTarget.Native.Apple.Watchos.Arm32 -> KonanTarget.WATCHOS_ARM32
+        KmpTarget.Native.Apple.Watchos.X64 -> KonanTarget.WATCHOS_X64
+        KmpTarget.Native.Apple.Watchos.SimulatorArm64 -> KonanTarget.WATCHOS_SIMULATOR_ARM64
+        KmpTarget.Native.Apple.Watchos.DeviceArm64 -> KonanTarget.WATCHOS_DEVICE_ARM64
+        KmpTarget.Native.Apple.Tvos.Arm64 -> KonanTarget.TVOS_ARM64
+        KmpTarget.Native.Apple.Tvos.X64 -> KonanTarget.TVOS_X64
+        KmpTarget.Native.Apple.Tvos.SimulatorArm64 -> KonanTarget.TVOS_SIMULATOR_ARM64
+        KmpTarget.Native.Linux.X64 -> KonanTarget.LINUX_X64
+        KmpTarget.Native.Linux.Arm64 -> KonanTarget.LINUX_ARM64
+        KmpTarget.Native.Mingw.X64 -> KonanTarget.MINGW_X64
+        KmpTarget.Native.AndroidNative.Arm32 -> KonanTarget.ANDROID_ARM32
+        KmpTarget.Native.AndroidNative.Arm64 -> KonanTarget.ANDROID_ARM64
+        KmpTarget.Native.AndroidNative.X86 -> KonanTarget.ANDROID_X86
+        KmpTarget.Native.AndroidNative.X64 -> KonanTarget.ANDROID_X64
+        KmpTarget.Jvm.Android,
+        KmpTarget.Jvm.Desktop,
+        KmpTarget.Web.Js,
+        KmpTarget.Web.WasmJs,
+        KmpTarget.Web.WasmWasi -> null
+    }
+
+/**
+ * The subset of [active] whose [KonanTarget] is missing from [enabled] — the host's compilable
+ * targets. Host-agnostic leaves (JVM/Web) are never impossible; an empty [active] is vacuously
+ * possible everywhere. Callers inject [enabled], so the decision is testable against any simulated
+ * host. Strict mode (#34) reuses this as its failure predicate.
+ */
+internal fun impossibleOnHost(active: KmpTargetSet, enabled: Set<KonanTarget>): KmpTargetSet =
+    active
+        .filter { leaf -> konanTargetOf(leaf)?.let { it !in enabled } ?: false }
+        .fold(KmpTargetSet.empty, KmpTargetSet::plus)
+
+/**
+ * Single aggregated advisory naming the [impossible] target ids (sorted) and the current [host].
+ * The targets stay registered — selection is host-independent by design — so the message says
+ * exactly that. Strict mode (#34) reuses this as its failure-message base.
+ */
+internal fun hostImpossibleWarning(
+    path: String,
+    host: KonanTarget,
+    impossible: KmpTargetSet,
+): String =
+    "kmp-targets: '$path' selects ${impossible.members.map { it.id }.sorted()} which cannot be " +
+        "compiled on this host (${host.name.uppercase()}) — still registered (selection is " +
+        "host-independent), but compile/link tasks for them will fail or be skipped here."

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/host/HostAwarenessInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/host/HostAwarenessInProcessTest.kt
@@ -1,0 +1,81 @@
+package com.rsicarelli.kmptargets.host
+
+import com.rsicarelli.kmptargets.KmpTargetsExtension
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Proves the host-awareness advisory is wired into eager registration without changing it: the real
+ * `HostManager` call path runs during `supports { … }` and the registered set is exactly `selection
+ * ∩ supported` no matter what the running host can compile. Host-*policy* outcomes (which leaves
+ * warn on which host) are covered by [HostCompatibilityTest] with simulated enabled-sets — nothing
+ * here may assert a host-specific value.
+ */
+class HostAwarenessInProcessTest {
+
+    @Test
+    fun `given native targets impossible on some host when configured then they still register and configuration succeeds`(
+        @TempDir dir: Path
+    ) {
+        // appleMobile + linux + mingw cannot all be compilable on any single host, so whatever
+        // machine runs this test exercises the warning path for at least zero leaves — and the
+        // registered set must be the full selection regardless.
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        val project =
+            newEvaluatedProject(dir) { ext -> ext.supports { appleMobile + linux + mingw } }
+        assertRegisteredTargets(
+            project,
+            "iosArm64",
+            "iosSimulatorArm64",
+            "iosX64",
+            "linuxX64",
+            "linuxArm64",
+            "mingwX64",
+        )
+    }
+
+    @Test
+    fun `given supports called twice when configured then hostWarned stays a subset of the active set`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        lateinit var ext: KmpTargetsExtension
+        val project =
+            newEvaluatedProject(dir) {
+                ext = it
+                it.supports { linux }
+                it.supports { linux + iosArm64 }
+            }
+        // The union registers exactly once per leaf, and only registered leaves can have been
+        // named in a host warning — never JVM/Web, never something outside the active set.
+        assertRegisteredTargets(project, "linuxX64", "linuxArm64", "iosArm64")
+        val active = ext.resolvedSelection() intersect ext.resolvedSupported()
+        assertTrue(
+            ext.hostWarned.all { it in active },
+            "hostWarned ${ext.hostWarned} must be a subset of active ${active.members}",
+        )
+    }
+
+    private fun newEvaluatedProject(dir: Path, configure: (KmpTargetsExtension) -> Unit): Project {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        configure(project.extensions.getByType(KmpTargetsExtension::class.java))
+        (project as ProjectInternal).evaluate()
+        return project
+    }
+
+    private fun assertRegisteredTargets(project: Project, vararg expected: String) {
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        val actual = kotlin.targets.names.filter { it != "metadata" }.toSet()
+        assertEquals(expected.toSet(), actual)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/host/HostCompatibilityTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/host/HostCompatibilityTest.kt
@@ -1,0 +1,160 @@
+package com.rsicarelli.kmptargets.host
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure host-compatibility policy: the decision ([impossibleOnHost]) and message
+ * ([hostImpossibleWarning]) take the host's enabled-target set as a parameter, so every test here
+ * simulates a host — none depends on the machine actually running the suite.
+ */
+class HostCompatibilityTest {
+
+    /** A Linux x64 host: Linux, MinGW and Android NDK cross-compile; Apple does not. */
+    private val linuxEnabled: Set<KonanTarget> =
+        setOf(
+            KonanTarget.LINUX_X64,
+            KonanTarget.LINUX_ARM64,
+            KonanTarget.MINGW_X64,
+            KonanTarget.ANDROID_ARM32,
+            KonanTarget.ANDROID_ARM64,
+            KonanTarget.ANDROID_X86,
+            KonanTarget.ANDROID_X64,
+        )
+
+    /** A macOS host: every Kotlin/Native target compiles. */
+    private val macEnabled: Set<KonanTarget> =
+        KmpTargetSet.native.members.mapNotNull(::konanTargetOf).toSet()
+
+    // -- mapping -------------------------------------------------------------------------------
+
+    @Test
+    fun `given every leaf when mapped to KonanTarget then native leaves resolve and jvm and web map to null`() {
+        val (native, hostAgnostic) = KmpTarget.all.partition { konanTargetOf(it) != null }
+        assertEquals(KmpTargetSet.native.members, native.toSet())
+        assertEquals(
+            KmpTargetSet.jvmFamily.members + KmpTargetSet.web.members,
+            hostAgnostic.toSet(),
+        )
+    }
+
+    @Test
+    fun `given the twenty native leaves when mapped then each resolves to a distinct KonanTarget`() {
+        val konanTargets = KmpTargetSet.native.members.mapNotNull(::konanTargetOf)
+        assertEquals(KmpTargetSet.native.size, konanTargets.toSet().size)
+    }
+
+    // -- decision ------------------------------------------------------------------------------
+
+    @Test
+    fun `given iosArm64 active when computing impossible on a simulated linux host then iosArm64 is impossible`() {
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64),
+            impossibleOnHost(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), linuxEnabled),
+        )
+    }
+
+    @Test
+    fun `given iosArm64 active when computing impossible on a simulated mac host then nothing is impossible`() {
+        assertEquals(
+            KmpTargetSet.empty,
+            impossibleOnHost(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), macEnabled),
+        )
+    }
+
+    @Test
+    fun `given linuxX64 and iosArm64 active when computing impossible on a simulated linux host then only iosArm64 is named`() {
+        val active = KmpTargetSet.of(KmpTarget.Native.Linux.X64, KmpTarget.Native.Apple.Ios.Arm64)
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64),
+            impossibleOnHost(active, linuxEnabled),
+        )
+    }
+
+    @Test
+    fun `given only host-agnostic targets active when computing impossible on any simulated host then nothing is impossible`() {
+        val active = KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Web.Js, KmpTarget.Web.WasmJs)
+        // The empty enabled-set is the harshest possible host — JVM/Web must still never warn.
+        assertEquals(KmpTargetSet.empty, impossibleOnHost(active, emptySet()))
+    }
+
+    @Test
+    fun `given an empty active set when computing impossible on any simulated host then nothing is impossible`() {
+        assertEquals(KmpTargetSet.empty, impossibleOnHost(KmpTargetSet.empty, emptySet()))
+    }
+
+    // -- determinism guardrail -----------------------------------------------------------------
+
+    @Test
+    fun `given the same active set when computing impossible on two simulated hosts then only the impossible subset differs`() {
+        val active = KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64, KmpTarget.Native.Linux.X64)
+        val onLinux = impossibleOnHost(active, linuxEnabled)
+        val onMac = impossibleOnHost(active, macEnabled)
+        // The registered set is `active` itself — registration never consumes the host decision,
+        // so it is byte-identical across hosts; the advisory subset is the only difference.
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), onLinux)
+        assertEquals(KmpTargetSet.empty, onMac)
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64, KmpTarget.Native.Linux.X64),
+            active,
+        )
+    }
+
+    // -- dedup across repeated supports calls ----------------------------------------------------
+
+    @Test
+    fun `given iosArm64 already warned when a later union adds tvosArm64 impossible then only tvosArm64 is newly warned`() {
+        // Mirrors the register(...) dedup: a second `supports { }` call unions in a new impossible
+        // leaf after the first already warned — only the fresh leaf is named again.
+        val active =
+            KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64, KmpTarget.Native.Apple.Tvos.Arm64)
+        val alreadyWarned = setOf<KmpTarget>(KmpTarget.Native.Apple.Ios.Arm64)
+        val fresh = impossibleOnHost(active, linuxEnabled).members - alreadyWarned
+        assertEquals(setOf<KmpTarget>(KmpTarget.Native.Apple.Tvos.Arm64), fresh)
+    }
+
+    // -- message -------------------------------------------------------------------------------
+
+    @Test
+    fun `given impossible targets when building the warning then it names the target ids and the host`() {
+        val message =
+            hostImpossibleWarning(
+                path = ":lib",
+                host = KonanTarget.LINUX_X64,
+                impossible = KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64),
+            )
+        assertTrue("iosArm64" in message, "expected target id in: $message")
+        assertTrue("LINUX_X64" in message, "expected host in: $message")
+        assertTrue(":lib" in message, "expected project path in: $message")
+    }
+
+    @Test
+    fun `given impossible targets when building the warning then it states they stay registered`() {
+        val message =
+            hostImpossibleWarning(
+                path = ":lib",
+                host = KonanTarget.LINUX_X64,
+                impossible = KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64),
+            )
+        assertTrue("still registered" in message, "expected advisory wording in: $message")
+    }
+
+    @Test
+    fun `given several impossible targets when building the warning then it names all ids sorted`() {
+        val message =
+            hostImpossibleWarning(
+                path = ":lib",
+                host = KonanTarget.LINUX_X64,
+                impossible =
+                    KmpTargetSet.of(
+                        KmpTarget.Native.Apple.Tvos.Arm64,
+                        KmpTarget.Native.Apple.Ios.Arm64,
+                    ),
+            )
+        assertTrue("[iosArm64, tvosArm64]" in message, "expected sorted ids in: $message")
+    }
+}


### PR DESCRIPTION
Closes #32

**Roadmap — Selection Ergonomics · Phase 2 (Diagnostics).** Builds on #29 (eager registration).

## What

At configuration time, co-located with the empty-overlap advisory inside `register(...)`, the plugin now detects which members of the registered set (`selection ∩ supported`) cannot be **compiled** on the current host (via KGP's `HostManager`) and emits a single aggregated `logger.warn` naming the target ids and the host:

```
kmp-targets: ':shared' selects [iosArm64, iosSimulatorArm64] which cannot be compiled on this host (LINUX_X64) — still registered (selection is host-independent), but compile/link tasks for them will fail or be skipped here.
```

**Deliberate semantics: warn, but still register.** No silent filtering (the registered set stays byte-identical across hosts — determinism for config-cache keys, task graphs, metadata) and no hard error (that's opt-in strict mode, #34). The warning is the only host-dependent observable.

## How

- **New `host/` package** with pure, injectable functions mirroring the `shouldWarnEmptyOverlap`/`emptyOverlapWarning` pair:
  - `konanTargetOf(KmpTarget): KonanTarget?` — exhaustive `when` over all 26 leaves (compile error on new leaves), JVM/Web → `null` (host-agnostic, never warned)
  - `impossibleOnHost(active, enabled): KmpTargetSet` — decision; callers inject the host's enabled-set, so tests simulate any host. Reused by #34 as its failure predicate.
  - `hostImpossibleWarning(path, host, impossible): String` — aggregated message; reused by #34 as its failure-message base.
- **Per-leaf dedup** via `ext.hostWarned` (mirroring `ext.registered`): repeated `supports {}` calls don't re-warn, but a later union that introduces a *new* impossible leaf still warns — for that leaf only.
- **Config-cache / classpath safety:** `HostManager` is touched only inside `withPlugin(KGP)` at configuration time — its classes never load when KGP is absent, and nothing host-derived is held by a task action (the plugin creates none). No `afterEvaluate` (gate stays empty).

## Acceptance criteria → tests

| Criterion | Test |
|---|---|
| iosArm64 on non-Mac host → warned, still registered | `given iosArm64 active when computing impossible on a simulated linux host…` + in-process `…still register and configuration succeeds` |
| Same module on macOS → no warning | `…on a simulated mac host then nothing is impossible` |
| Host-agnostic-only selection → never warned | `given only host-agnostic targets active…` (vs the empty enabled-set) |
| Empty active set → only empty-overlap warning | `given an empty active set…` (impossible ⊆ active, vacuously silent) |
| linuxX64 + iosArm64 on Linux → only iosArm64 named | `given linuxX64 and iosArm64 active…then only iosArm64 is named` |
| Simulated-host unit coverage, GIVEN-WHEN-THEN | all of `HostCompatibilityTest` injects enabled-sets — zero real-host dependency |
| Config-cache HIT on second run | verified on `samples/hello-world`: `Configuration cache entry reused.` |

Plus a determinism guardrail (`…then only the impossible subset differs`) and dedup-semantics test.

## Cross-host validation

CI runs on `ubuntu-latest` and builds `samples/hello-world` with `KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64` — the host warning should appear in the sample-build step logs (LINUX_X64 can't compile the iOS leaves) while the build stays green, proving warn-but-register on a real non-Mac host. On macOS dev machines the same build emits nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)