### PR TITLE
refactor!: unify config keys under kmptargets.* and add dedicated root config files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,14 +12,14 @@ body:
     attributes:
       label: What happened?
       description: A clear and concise description of the bug.
-      placeholder: When I set KMP_TARGETS=... I expected ... but got ...
+      placeholder: When I set kmptargets.targets=... I expected ... but got ...
     validations:
       required: true
 
   - type: input
     id: kmp-targets-value
     attributes:
-      label: KMP_TARGETS value
+      label: kmptargets.targets value
       description: The value you passed (in local.properties, -P, or env var). Leave blank if unset.
       placeholder: android,iosArm64
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -17,7 +17,7 @@ body:
       description: |
         If applicable, sketch the property syntax, plugin DSL, or task surface you'd want.
       placeholder: |
-        KMP_TARGETS=android,iosAll,wasm
+        kmptargets.targets=android,iosAll,wasm
         # or
         kmpTargets {
             require("android")

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ out/
 # Local Configuration
 # ================================
 local.properties
+kmp-targets.local.properties
 gradle.properties.local
 secrets.properties
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project is pre-1.0, so breaking
+changes may land in any release.
+
+## [Unreleased]
+
+### Changed (BREAKING)
+
+- **Unified property naming under the `kmptargets.` namespace** ([#31]). The selection key is
+  renamed; the hierarchy key was already on-convention and stays. This is a hard break — the old
+  names are **not read at all** (no deprecated alias): a build still setting only `KMP_TARGETS`
+  falls through to `defaultSelection` / the plugin default.
+
+  | Concern | Before | After |
+  |---|---|---|
+  | Selection (`gradle.properties` / files / `local.properties`) | `KMP_TARGETS=...` | `kmptargets.targets=...` |
+  | Selection (CLI) | `-PKMP_TARGETS=...` | `-Pkmptargets.targets=...` |
+  | Selection (env) | `ORG_GRADLE_PROJECT_KMP_TARGETS` or bare `KMP_TARGETS` | `ORG_GRADLE_PROJECT_kmptargets.targets` |
+  | Hierarchy template | `kmptargets.hierarchyTemplate` | `kmptargets.hierarchyTemplate` (unchanged) |
+
+- The bare `KMP_TARGETS` **environment variable** is no longer read; the env surface is Gradle's
+  native `ORG_GRADLE_PROJECT_<key>` mapping only (which now also works for
+  `kmptargets.hierarchyTemplate`, which previously had no env form).
+
+### Added
+
+- **Dedicated root config files** ([#30]): `kmp-targets.properties` (committed, team-shared) and
+  `kmp-targets.local.properties` (git-ignored personal override, Bazel `try-import` semantics) are
+  the consolidation point for global configuration. Full precedence chain (highest first): CLI `-P`
+  → `ORG_GRADLE_PROJECT_<key>` env → personal file → committed file → root `gradle.properties` →
+  `local.properties` → `defaultSelection` → built-in. Both global keys
+  (`kmptargets.targets`, `kmptargets.hierarchyTemplate`) read through the same chain.
+- **Fail-loud key validation**: an unknown key in either dedicated file fails the build at
+  configuration time with a "did you mean …?" suggestion.
+- Both dedicated files are tracked configuration-cache inputs: edits invalidate the cache,
+  untouched files keep cache hits.
+
+[#30]: https://github.com/rsicarelli/kmp-targets/issues/30
+[#31]: https://github.com/rsicarelli/kmp-targets/issues/31

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ All tests use **GIVEN-WHEN-THEN** naming:
 
 ```kotlin
 @Test
-fun `given supported mobile and KMP_TARGETS iosArm64 when evaluated then iosArm64 registers`() { ... }
+fun `given supported mobile and kmptargets targets iosArm64 when evaluated then iosArm64 registers`() { ... }
 ```
 
 This is enforced by convention, not tooling (yet). It makes test failures self-documenting and matches the testing standard in the broader `rsicarelli` open-source ecosystem.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 `kmp-targets` is a Gradle plugin for Kotlin Multiplatform projects that lets each developer (and each CI runner) choose which KMP targets to build, via a single Gradle property:
 
 ```properties
-# local.properties, gradle.properties, or -P
-KMP_TARGETS=jvm,iosArm64
+# kmp-targets.properties (committed), kmp-targets.local.properties (personal), gradle.properties, or -P
+kmptargets.targets=jvm,iosArm64
 ```
 
 Targets you don't select are never registered with KGP, so their compile/link/KSP/publish tasks never run — cutting Gradle sync and build times when you only need a subset.
@@ -20,7 +20,7 @@ feature builds only Android + iOS, a tooling module builds only the JVM. `kmp-ta
 facts:
 
 - **What a module *can* build** — its *supported* set, declared per-module via the type-safe DSL.
-- **What you *want* to build now** — the global `KMP_TARGETS` *selection*.
+- **What you *want* to build now** — the global `kmptargets.targets` *selection*.
 
 The plugin registers `selection ∩ supported` for each module. A module never builds a target outside
 its supported set, and the global selection narrows that further.
@@ -51,12 +51,13 @@ Targets are **explicit**: a module that never calls `supports` registers nothing
 KGP where every target is declared by hand. `supports` registers eagerly — the moment it runs — so
 call it before anything reads `kotlin.targets`, and calling it more than once **unions** (an
 already-registered target can't be retracted). To build whatever the developer is currently
-targeting, opt in explicitly with `supports { all }` — then the global `KMP_TARGETS` alone decides
-what registers.
+targeting, opt in explicitly with `supports { all }` — then the global `kmptargets.targets` alone
+decides what registers.
 
-The selection itself is **global** (the `KMP_TARGETS` property, see below) — there is no per-module
-selection block. A project-wide default for when `KMP_TARGETS` is unset can be set from build-logic
-via the `defaultSelection` property; a global `KMP_TARGETS` always overrides it.
+The selection itself is **global** (the `kmptargets.targets` property, see below) — there is no
+per-module selection block. A project-wide default for when `kmptargets.targets` is unset can be set
+from build-logic via the `defaultSelection` property; a global `kmptargets.targets` always overrides
+it.
 
 ### Seeing the DSL docs on hover (IntelliJ)
 
@@ -102,27 +103,59 @@ This is how a team centralizes per-module shape vocabulary in their own naming, 
 vocabulary baked into this plugin's artifact. The DSL stays the primitive; convention plugins are an
 optional layer you own.
 
+### Configuration files
+
+Global `kmp-targets` configuration lives in a **dedicated, committed root config file** —
+`kmp-targets.properties` — so there is one discoverable place to see what the plugin is configured
+to do, instead of loose keys buried among unrelated daemon/cache settings in `gradle.properties`:
+
+```properties
+# kmp-targets.properties — committed, team-shared
+kmptargets.targets=jvm,iosArm64
+kmptargets.hierarchyTemplate=true
+```
+
+An optional **personal override file** — `kmp-targets.local.properties`, git-ignored — mirrors
+Bazel's `try-import user.bazelrc`: absent it is ignored; present, its keys override the committed
+file's. Both files accept only the known `kmptargets.*` keys — an unknown key **fails the build**
+with a "did you mean …?" suggestion, so a typo can't silently no-op.
+
+Both files are read as tracked configuration-cache inputs: editing one invalidates the cache,
+leaving them untouched keeps cache hits.
+
 ### Selecting targets
 
 The selection is **global** — one switch narrows the whole build. Set it via any of these sources
 (priority order, highest first):
 
-1. `-PKMP_TARGETS=...` on the CLI
-2. `ORG_GRADLE_PROJECT_KMP_TARGETS` environment variable
-3. the **root** `gradle.properties` (a *subproject's* `gradle.properties` is **not** a source —
+1. `-Pkmptargets.targets=...` on the CLI
+2. `ORG_GRADLE_PROJECT_kmptargets.targets` environment variable
+3. `kmp-targets.local.properties` (per-developer, gitignored)
+4. `kmp-targets.properties` (committed, team-shared)
+5. the **root** `gradle.properties` (a *subproject's* `gradle.properties` is **not** a source —
    Gradle only reads root-level project properties)
-4. `local.properties` (per-developer, gitignored)
-5. a project-wide `defaultSelection` set from build-logic (overridden by all of the above)
-6. Plugin default — every target the plugin currently knows about
+6. `local.properties` (per-developer, gitignored)
+7. a project-wide `defaultSelection` set from build-logic (overridden by all of the above)
+8. Plugin default — every target the plugin currently knows about
+
+The dedicated files beat `gradle.properties` deliberately: once a team adopts the consolidation
+point, a stale key left behind in `gradle.properties` can't silently override it. One nuance: the
+rarer `-Dorg.gradle.project.kmptargets.targets` and `~/.gradle/gradle.properties` forms resolve at
+the `gradle.properties` layer, i.e. below the dedicated files.
+
+> **Breaking rename (pre-1.0):** the selection key used to be `KMP_TARGETS` (env:
+> `ORG_GRADLE_PROJECT_KMP_TARGETS` or bare `KMP_TARGETS`). It is now `kmptargets.targets` — the old
+> key is **not read at all**; a build still setting only `KMP_TARGETS` falls through to
+> `defaultSelection` / the plugin default. See [CHANGELOG.md](./CHANGELOG.md).
 
 ### Selection grammar
 
 ```properties
-KMP_TARGETS=android,iosArm64        # explicit list
-KMP_TARGETS=appleMobile             # preset (iosArm64 + iosSimulatorArm64)
-KMP_TARGETS=appleMobile,-iosArm64   # preset minus a leaf
-KMP_TARGETS=apple,+android          # preset plus an addition
-KMP_TARGETS=ANDROID, ios-arm64      # aliases + case-insensitive
+kmptargets.targets=android,iosArm64        # explicit list
+kmptargets.targets=appleMobile             # preset (iosArm64 + iosSimulatorArm64)
+kmptargets.targets=appleMobile,-iosArm64   # preset minus a leaf
+kmptargets.targets=apple,+android          # preset plus an addition
+kmptargets.targets=ANDROID, ios-arm64      # aliases + case-insensitive
 ```
 
 Available presets:
@@ -180,10 +213,11 @@ hierarchy instead — collapsing every redundant single-child group:
 | iOS + Linux | `nativeMain` over `iosMain` + `linuxMain` — no `appleMain` |
 
 It's **on by default** and applied automatically — no configuration needed. To opt out (and let KGP
-apply its own default), set the Gradle property globally or override per project (project wins):
+apply its own default), set the global key or override per project (project wins):
 
 ```properties
-# root gradle.properties — global default
+# kmp-targets.properties — global default (also accepted via -P, env, gradle.properties,
+# local.properties — same precedence chain as kmptargets.targets)
 kmptargets.hierarchyTemplate=false
 ```
 
@@ -192,7 +226,7 @@ kmptargets.hierarchyTemplate=false
 kmpTargets { hierarchyTemplate.set(false) }
 ```
 
-Precedence is **project DSL > global property > built-in default (`true`)**. Opt out when a module
+Precedence is **project DSL > global key > built-in default (`true`)**. Opt out when a module
 supplies its own `applyHierarchyTemplate { … }`, so the plugin stays out of the way.
 
 ## Installation

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -14,6 +14,10 @@ java { withSourcesJar() }
 
 ktfmt { kotlinLangStyle() }
 
+val testKitPluginClasspath: Configuration by configurations.creating
+
+tasks.pluginUnderTestMetadata { pluginClasspath.from(testKitPluginClasspath) }
+
 dependencies {
     compileOnly(libs.kotlin.gradlePlugin)
 
@@ -21,6 +25,11 @@ dependencies {
     testImplementation(libs.kotlin.gradlePlugin)
     testImplementation(libs.junit.jupiter)
     testImplementation(kotlin("test-junit5"))
+
+    // KGP is compileOnly above (consumers bring their own), but TestKit child builds resolve the
+    // plugin classpath from the plugin-under-test metadata — without KGP there, Gradle cannot even
+    // decorate KmpTargetsPlugin. Funnel it in through a dedicated resolvable configuration.
+    testKitPluginClasspath(libs.kotlin.gradlePlugin)
 }
 
 gradlePlugin {
@@ -32,7 +41,7 @@ gradlePlugin {
             implementationClass = "com.rsicarelli.kmptargets.KmpTargetsPlugin"
             displayName = "KMP Targets"
             description =
-                "Dynamically select which Kotlin Multiplatform targets to build via the KMP_TARGETS Gradle property."
+                "Dynamically select which Kotlin Multiplatform targets to build via the kmptargets.targets Gradle property."
             tags.set(listOf("kotlin", "kmp", "multiplatform", "build", "ios", "android"))
         }
     }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsDsl.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsDsl.kt
@@ -23,8 +23,8 @@ import com.rsicarelli.kmptargets.model.KmpTargetSet
  * ```
  *
  * Names mirror the canonical KGP target ids ([KmpTarget.id]) and the [KmpTargetSet] presets
- * exactly, so what you read in build files matches the `KMP_TARGETS` string grammar and the docs.
- * Build-logic that needs a raw value can call the [KmpTargetsExtension.supports] overload:
+ * exactly, so what you read in build files matches the `kmptargets.targets` string grammar and the
+ * docs. Build-logic that needs a raw value can call the [KmpTargetsExtension.supports] overload:
  * `supports(KmpTargetSet.mobile + KmpTargetSet.web)`.
  */
 @KmpTargetsDslMarker

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -15,9 +15,9 @@ import org.gradle.api.provider.Property
  *   registers no targets at all (just like plain KGP, where every target is declared by hand).
  *   [resolvedSupported] returns [KmpTargetSet.empty] until something declares it.
  * - **selection** — what the user wants to build *now*. It is **global**: resolved from
- *   `KMP_TARGETS` (`-P`, env, root `gradle.properties`, or `local.properties`) and the same value
- *   for every module. When no global is provided, it falls back to [defaultSelection] (itself
- *   defaulting to [KmpTargetSet.all]).
+ *   `kmptargets.targets` (`-P`, env, the dedicated `kmp-targets(.local).properties` files, root
+ *   `gradle.properties`, or `local.properties`) and the same value for every module. When no global
+ *   is provided, it falls back to [defaultSelection] (itself defaulting to [KmpTargetSet.all]).
  *
  * The plugin registers `selection ∩ supported`. Registration is **eager**: calling [supports] from
  * the build-script body registers the matching targets immediately (no deferred/after-evaluate
@@ -28,10 +28,10 @@ import org.gradle.api.provider.Property
 public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFactory) {
 
     /**
-     * The selection used when no global `KMP_TARGETS` is provided. Defaults to [KmpTargetSet.all].
-     * Public so build-logic can set a project-wide default lazily; a global `KMP_TARGETS` always
-     * wins over it. Set it **before** [supports], since [supports] registers eagerly off the
-     * resolved selection.
+     * The selection used when no global `kmptargets.targets` is provided. Defaults to
+     * [KmpTargetSet.all]. Public so build-logic can set a project-wide default lazily; a global
+     * `kmptargets.targets` always wins over it. Set it **before** [supports], since [supports]
+     * registers eagerly off the resolved selection.
      */
     public abstract val defaultSelection: Property<KmpTargetSet>
 
@@ -82,15 +82,15 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     }
 
     /**
-     * The global selection resolved from `KMP_TARGETS` at apply time, or `null` when no global
-     * source provided one. When present it wins over [defaultSelection] (and an explicit empty set
-     * is honored — see issue #9), which is what keeps the global switch authoritative. Stored as an
-     * immutable [KmpTargetSet], so it stays configuration-cache safe.
+     * The global selection resolved from `kmptargets.targets` at apply time, or `null` when no
+     * global source provided one. When present it wins over [defaultSelection] (and an explicit
+     * empty set is honored — see issue #9), which is what keeps the global switch authoritative.
+     * Stored as an immutable [KmpTargetSet], so it stays configuration-cache safe.
      */
     internal var globalSelection: KmpTargetSet? = null
 
     /**
-     * The selection actually used to register targets: the global `KMP_TARGETS` if present,
+     * The selection actually used to register targets: the global `kmptargets.targets` if present,
      * otherwise [defaultSelection] (which itself defaults to [KmpTargetSet.all]). Public so
      * build-logic can read the resolved set (e.g. for conditional configuration).
      */

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -6,7 +6,10 @@ import com.rsicarelli.kmptargets.hierarchy.toTemplate
 import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
 import com.rsicarelli.kmptargets.parser.ParseResult
+import com.rsicarelli.kmptargets.parser.didYouMean
 import com.rsicarelli.kmptargets.parser.parseKmpTargets
+import com.rsicarelli.kmptargets.source.ConfigFileValueSource
+import com.rsicarelli.kmptargets.source.ConfigKeys
 import com.rsicarelli.kmptargets.source.EnvironmentVariableSource
 import com.rsicarelli.kmptargets.source.GradlePropertySource
 import com.rsicarelli.kmptargets.source.LocalPropertyValueSource
@@ -23,19 +26,28 @@ public class KmpTargetsPlugin : Plugin<Project> {
         val ext = target.extensions.create("kmpTargets", KmpTargetsExtension::class.java)
         ext.defaultSelection.convention(KmpTargetSet.all)
 
+        // Dedicated config files, each read once as a whole map (tracked config-cache inputs) and
+        // validated against the key registry — a typo fails the build instead of silently no-oping
+        // (Bazel-style, issue #30).
+        val personal: Map<String, String>? = configFile(target, ConfigKeys.LOCAL_FILE)
+        val committed: Map<String, String>? = configFile(target, ConfigKeys.COMMITTED_FILE)
+        validateKnownKeys(personal, ConfigKeys.LOCAL_FILE)
+        validateKnownKeys(committed, ConfigKeys.COMMITTED_FILE)
+
         // Global selection: what the user wants to build now. A blank/absent property means "not
         // overriding" → defer to `defaultSelection`. A non-blank property that
         // resolves to an empty set via minus operators (e.g. `jvm,-jvm`) is an explicit "build
         // nothing" and must be honored, not silently treated as the default-all selection (issue
         // #9). Keying off `isNotBlank` (rather than the parsed set's emptiness) is what
         // distinguishes the two cases.
-        val raw: String? = selectionSources(target).read()
+        val raw: String? = configSources(target, ConfigKeys.TARGETS, personal, committed).read()
         if (raw != null && raw.isNotBlank()) {
-            ext.globalSelection = parseOrThrow(raw, KMP_TARGETS)
+            ext.globalSelection = parseOrThrow(raw, ConfigKeys.TARGETS)
         }
 
         // Global default for the hierarchy template, read once at apply time as a primitive.
-        val globalHierarchyEnabled: Boolean? = hierarchyTemplateEnabledGlobally(target)
+        val globalHierarchyEnabled: Boolean? =
+            hierarchyTemplateEnabledGlobally(target, personal, committed)
 
         // Eager registration: `supports { … }` in the build-script body registers `selection ∩
         // supported` immediately — no deferred (after-evaluate) pass, no timing wall. We hook it
@@ -52,32 +64,85 @@ public class KmpTargetsPlugin : Plugin<Project> {
     }
 
     internal companion object {
-        const val KMP_TARGETS: String = "KMP_TARGETS"
-        const val HIERARCHY_TEMPLATE_PROPERTY: String = "kmptargets.hierarchyTemplate"
         const val KGP_ID: String = "org.jetbrains.kotlin.multiplatform"
     }
 
-    private fun selectionSources(target: Project): SelectionSource =
-        composeSelectionSources(
-            GradlePropertySource(target.providers, KMP_TARGETS),
-            EnvironmentVariableSource(target.providers, KMP_TARGETS),
-            localPropertiesSource(target, KMP_TARGETS),
+    /**
+     * The full precedence chain for one global config key (highest first): CLI `-P` →
+     * `ORG_GRADLE_PROJECT_<key>` env → personal file → committed file → `gradle.properties` →
+     * `local.properties`. Both global knobs read through this one chain, so they always share the
+     * same precedence.
+     *
+     * The top of the chain is decomposed by hand: `providers.gradleProperty` fuses CLI, env, and
+     * `gradle.properties` into one provider with no origin information, but the dedicated files
+     * must slot *between* env and `gradle.properties` (the consolidation point beats legacy loose
+     * keys, issue #30). So CLI is read eagerly from the start parameter (a config-cache input — any
+     * `-P` change invalidates the entry) and env explicitly via Gradle's native
+     * `ORG_GRADLE_PROJECT_` mapping; `gradleProperty` then serves as the `gradle.properties` layer.
+     * It still re-matches CLI/env values, but the first-non-null composition has already caught
+     * those above, so the overlap is harmless. Documented nuance: `-Dorg.gradle.project.<key>` and
+     * `~/.gradle/gradle.properties` resolve at that layer too, i.e. below the dedicated files.
+     */
+    private fun configSources(
+        target: Project,
+        key: String,
+        personal: Map<String, String>?,
+        committed: Map<String, String>?,
+    ): SelectionSource {
+        val cli: String? = target.gradle.startParameter.projectProperties[key]
+        return composeSelectionSources(
+            SelectionSource { cli },
+            EnvironmentVariableSource(target.providers, ConfigKeys.ENV_PREFIX + key),
+            SelectionSource { personal?.get(key) },
+            SelectionSource { committed?.get(key) },
+            GradlePropertySource(target.providers, key),
+            localPropertiesSource(target, key),
         )
+    }
 
     /**
-     * Reads the global `kmptargets.hierarchyTemplate` flag (Gradle property or `local.properties`).
-     * `null` means "not set — use the built-in default"; anything other than `true`/`false`
+     * Reads the global `kmptargets.hierarchyTemplate` flag through the standard [configSources]
+     * chain. `null` means "not set — use the built-in default"; anything other than `true`/`false`
      * (case-insensitive) is treated as unset.
      */
-    private fun hierarchyTemplateEnabledGlobally(target: Project): Boolean? =
-        composeSelectionSources(
-                GradlePropertySource(target.providers, HIERARCHY_TEMPLATE_PROPERTY),
-                localPropertiesSource(target, HIERARCHY_TEMPLATE_PROPERTY),
-            )
+    private fun hierarchyTemplateEnabledGlobally(
+        target: Project,
+        personal: Map<String, String>?,
+        committed: Map<String, String>?,
+    ): Boolean? =
+        configSources(target, ConfigKeys.HIERARCHY_TEMPLATE, personal, committed)
             .read()
             ?.trim()
             ?.lowercase()
             ?.toBooleanStrictOrNull()
+
+    /** The parsed entries of a dedicated config file in the root directory, or `null` if absent. */
+    private fun configFile(target: Project, fileName: String): Map<String, String>? =
+        target.providers
+            .of(ConfigFileValueSource::class.java) {
+                it.parameters.rootDir.set(target.rootDir)
+                it.parameters.fileName.set(fileName)
+            }
+            .orNull
+
+    /**
+     * Fails the build when a dedicated config file carries a key outside [ConfigKeys.ALL] — a typo
+     * must not silently no-op (Bazel's "fail loud on unknown key" parity, issue #30).
+     */
+    private fun validateKnownKeys(entries: Map<String, String>?, fileName: String) {
+        if (entries == null) return
+        val unknown = entries.keys - ConfigKeys.ALL
+        if (unknown.isEmpty()) return
+        val described =
+            unknown.sorted().joinToString(", ") { key ->
+                val suggestion = didYouMean(key, ConfigKeys.ALL)
+                if (suggestion != null) "'$key' (did you mean '$suggestion'?)" else "'$key'"
+            }
+        throw GradleException(
+            "$fileName: unknown key(s) $described. " +
+                "Known keys: ${ConfigKeys.ALL.sorted().joinToString(", ")}"
+        )
+    }
 
     private fun localPropertiesSource(target: Project, propertyName: String): SelectionSource {
         val provider =

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParser.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParser.kt
@@ -4,7 +4,7 @@ import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
 
 /**
- * Parses a `KMP_TARGETS` value into a [KmpTargetSet].
+ * Parses a `kmptargets.targets` value into a [KmpTargetSet].
  *
  * Grammar (informal):
  * ```
@@ -32,7 +32,7 @@ public fun parseKmpTargets(raw: String, registry: Set<KmpTarget> = KmpTarget.all
     if (tokens.isEmpty()) {
         return ParseResult.Ok(
             KmpTargetSet.empty,
-            warnings = listOf("KMP_TARGETS is empty; using the default selection"),
+            warnings = listOf("kmptargets.targets is empty; using the default selection"),
         )
     }
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/ParseResult.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/ParseResult.kt
@@ -3,7 +3,7 @@ package com.rsicarelli.kmptargets.parser
 import com.rsicarelli.kmptargets.model.KmpTargetSet
 
 /**
- * Outcome of parsing a `KMP_TARGETS` string into a [KmpTargetSet].
+ * Outcome of parsing a `kmptargets.targets` string into a [KmpTargetSet].
  *
  * [Ok] carries the resolved selection plus any non-fatal warnings (empty input, redundant tokens,
  * etc). [Err] carries a human-readable message and the offending token (when applicable) so the

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigFileSource.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigFileSource.kt
@@ -1,0 +1,54 @@
+package com.rsicarelli.kmptargets.source
+
+import java.io.File
+import java.util.Properties
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+
+/**
+ * Reads a dedicated kmp-targets config file ([ConfigKeys.COMMITTED_FILE] or the personal
+ * [ConfigKeys.LOCAL_FILE]) in [rootDir] as a whole key→value map.
+ *
+ * Returns `null` when the file is absent — the whole layer defers. When the file exists, a key
+ * missing from the map means **absent** (defer to the next layer) while a blank value means
+ * **present but blank** ("not overriding"), preserving the [SelectionSource] contract per key.
+ * Reading the whole file (rather than one key) is what lets the plugin validate that every key is
+ * known and fail loud on typos.
+ *
+ * This implementation reads the file directly; the plugin wraps it in [ConfigFileValueSource] so
+ * the file is tracked as a configuration-cache input. Used directly (without that wrapper) only in
+ * tests.
+ */
+public class ConfigPropertiesSource(private val rootDir: File, private val fileName: String) {
+
+    public fun read(): Map<String, String>? {
+        val file = rootDir.resolve(fileName)
+        if (!file.exists()) return null
+        val properties = Properties()
+        file.inputStream().use(properties::load)
+        return properties.entries.associate { (key, value) -> key.toString() to value.toString() }
+    }
+}
+
+/**
+ * Gradle [ValueSource] wrapper around [ConfigPropertiesSource] so the plugin's read of a dedicated
+ * config file is tracked as a configuration-cache input: unchanged content lets the cache be
+ * reused, an edit invalidates it. Mirrors [LocalPropertyValueSource].
+ */
+internal abstract class ConfigFileValueSource :
+    ValueSource<Map<String, String>, ConfigFileValueSource.Params> {
+
+    interface Params : ValueSourceParameters {
+        val rootDir: DirectoryProperty
+        val fileName: Property<String>
+    }
+
+    override fun obtain(): Map<String, String>? =
+        ConfigPropertiesSource(
+                rootDir = parameters.rootDir.asFile.get(),
+                fileName = parameters.fileName.get(),
+            )
+            .read()
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
@@ -1,0 +1,27 @@
+package com.rsicarelli.kmptargets.source
+
+/**
+ * Registry of every global configuration key the plugin reads, plus the dedicated config files that
+ * may carry them. Single source of truth for the `kmptargets.` key namespace: adding a future
+ * global knob means adding a key here (and to [ALL]), not inventing a new loose Gradle property.
+ */
+internal object ConfigKeys {
+
+    /** Global selection — which targets to build now (comma grammar, see `parseKmpTargets`). */
+    const val TARGETS: String = "kmptargets.targets"
+
+    /** Global opt-out for the minimal hierarchy template (`true`/`false`). */
+    const val HIERARCHY_TEMPLATE: String = "kmptargets.hierarchyTemplate"
+
+    /** Every key the dedicated config files may legally contain (unknown keys fail the build). */
+    val ALL: Set<String> = setOf(TARGETS, HIERARCHY_TEMPLATE)
+
+    /** Committed, team-shared config file at the root of the build. */
+    const val COMMITTED_FILE: String = "kmp-targets.properties"
+
+    /** Git-ignored personal override file; its keys win over [COMMITTED_FILE]'s. */
+    const val LOCAL_FILE: String = "kmp-targets.local.properties"
+
+    /** Gradle's native env-var prefix for project properties (`ORG_GRADLE_PROJECT_<key>`). */
+    const val ENV_PREFIX: String = "ORG_GRADLE_PROJECT_"
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/SelectionSource.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/SelectionSource.kt
@@ -1,8 +1,8 @@
 package com.rsicarelli.kmptargets.source
 
 /**
- * A source that can produce a raw `KMP_TARGETS` string (e.g. from a Gradle property, an environment
- * variable, or a `local.properties` file).
+ * A source that can produce a raw `kmptargets.targets` string (e.g. from a Gradle property, an
+ * environment variable, or a `local.properties` file).
  *
  * Implementations return `null` to mean **absent**; an empty string means **present but blank**
  * (the parser will treat that as "use the default selection" and emit a warning). The distinction

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/SelectionSources.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/SelectionSources.kt
@@ -14,7 +14,7 @@ public fun composeSelectionSources(vararg sources: SelectionSource): SelectionSo
     }
 
 /**
- * Reads `KMP_TARGETS` from a Gradle property (`-P<name>=...` or `gradle.properties`).
+ * Reads `kmptargets.targets` from a Gradle property (`-P<name>=...` or `gradle.properties`).
  *
  * The [providers] reference is captured at construction and the property value is fetched lazily on
  * each [read] call, so the Gradle configuration cache treats the property as a tracked input via
@@ -29,7 +29,7 @@ public class GradlePropertySource(
 }
 
 /**
- * Reads `KMP_TARGETS` from an environment variable. Same configuration-cache contract as
+ * Reads `kmptargets.targets` from an environment variable. Same configuration-cache contract as
  * [GradlePropertySource].
  */
 public class EnvironmentVariableSource(
@@ -41,7 +41,7 @@ public class EnvironmentVariableSource(
 }
 
 /**
- * Reads `KMP_TARGETS` from a `local.properties` file in [rootDir].
+ * Reads `kmptargets.targets` from a `local.properties` file in [rootDir].
  *
  * This implementation reads the file directly; the plugin wraps it in a Gradle `ValueSource` so the
  * file is tracked as a configuration-cache input. Used directly (without that wrapper) only in

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/EnvPropertyMappingFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/EnvPropertyMappingFunctionalTest.kt
@@ -1,0 +1,66 @@
+package com.rsicarelli.kmptargets
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Functional (TestKit) proof that the dotted `kmptargets.targets` key survives Gradle's *launcher*
+ * paths, which in-process `ProjectBuilder` tests cannot exercise:
+ * - the `ORG_GRADLE_PROJECT_<name>` env→project-property mapping accepts a dotted name, and
+ * - the `-P<name>=` CLI form resolves through the plugin's top precedence layer.
+ *
+ * Kept to the minimum (no KGP, one task) because TestKit forks a real build per case.
+ */
+class EnvPropertyMappingFunctionalTest {
+
+    @Test
+    fun `given ORG_GRADLE_PROJECT env var with dotted key when build runs then selection resolves from it`(
+        @TempDir dir: Path
+    ) {
+        writeFixture(dir)
+        val result =
+            runner(dir)
+                .withEnvironment(mapOf("ORG_GRADLE_PROJECT_kmptargets.targets" to "jvm"))
+                .build()
+        assertTrue("SELECTION=jvm" in result.output, result.output)
+    }
+
+    @Test
+    fun `given dotted key passed via -P when build runs then selection resolves from it`(
+        @TempDir dir: Path
+    ) {
+        // The committed file is also present, so this doubles as a launcher-level proof that the
+        // CLI layer outranks the dedicated config file.
+        writeFixture(dir)
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.targets=android\n")
+        val result =
+            runner(dir).withArguments("printSelection", "-q", "-Pkmptargets.targets=jvm").build()
+        assertTrue("SELECTION=jvm" in result.output, result.output)
+    }
+
+    private fun writeFixture(dir: Path) {
+        dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
+        dir.resolve("build.gradle.kts")
+            .writeText(
+                """
+                plugins { id("com.rsicarelli.kmptargets") }
+
+                val selection = kmpTargets.resolvedSelection().members.map { it.id }.sorted()
+                tasks.register("printSelection") {
+                    doLast { println("SELECTION=" + selection.joinToString(",")) }
+                }
+                """
+                    .trimIndent()
+            )
+    }
+
+    private fun runner(dir: Path): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(dir.toFile())
+            .withPluginClasspath()
+            .withArguments("printSelection", "-q")
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslTest.kt
@@ -25,7 +25,7 @@ class KmpTargetsDslTest {
     fun `given supports declared via DSL after KGP when evaluated then only the DSL set registers`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm,iosArm64,linuxX64\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,iosArm64,linuxX64\n")
         val project = newEvaluatedProject(dir) { ext -> ext.supports { jvm + linuxX64 } }
         // selection (jvm,iosArm64,linuxX64) ∩ supported (jvm,linuxX64) = jvm,linuxX64.
         assertRegisteredTargets(project, "jvm", "linuxX64")
@@ -35,7 +35,7 @@ class KmpTargetsDslTest {
     fun `given supports leaves composed via DSL when evaluated then the union registers`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=all\n")
         val project =
             newEvaluatedProject(dir) { ext -> ext.supports { iosArm64 + iosSimulatorArm64 + jvm } }
         assertRegisteredTargets(project, "iosArm64", "iosSimulatorArm64", "jvm")
@@ -56,10 +56,10 @@ class KmpTargetsDslTest {
     }
 
     @Test
-    fun `given a defaultSelection and a global KMP_TARGETS when evaluated then global wins`(
+    fun `given a defaultSelection and a global kmptargets targets when evaluated then global wins`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
         val project =
             newEvaluatedProject(dir) { ext ->
                 ext.defaultSelection.set(KmpTargetSet.appleMobile) // ignored: global wins
@@ -72,7 +72,7 @@ class KmpTargetsDslTest {
     fun `given supports via DSL value overload when evaluated then it registers`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=all\n")
         val project =
             newEvaluatedProject(dir) { ext -> ext.supports(KmpTargetSet.web + KmpTargetSet.linux) }
         assertRegisteredTargets(project, "js", "wasmJs", "wasmWasi", "linuxX64", "linuxArm64")
@@ -82,7 +82,7 @@ class KmpTargetsDslTest {
     fun `given supports block with subtraction when evaluated then the removed leaf does not register`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=all\n")
         val project = newEvaluatedProject(dir) { ext -> ext.supports { appleMobile - iosX64 } }
         assertRegisteredTargets(project, "iosArm64", "iosSimulatorArm64")
     }
@@ -91,8 +91,9 @@ class KmpTargetsDslTest {
     fun `given a blank global and a defaultSelection when evaluated then the default applies`(
         @TempDir dir: Path
     ) {
-        // A blank KMP_TARGETS means "not overriding" — the project-wide defaultSelection stands.
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=\n")
+        // A blank kmptargets.targets means "not overriding" — the project-wide defaultSelection
+        // stands.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=\n")
         val project =
             newEvaluatedProject(dir) { ext ->
                 ext.defaultSelection.set(
@@ -119,31 +120,33 @@ class KmpTargetsDslTest {
     fun `given a supports set disjoint from the selection when evaluated then nothing registers`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=wasmJs\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=wasmJs\n")
         val project = newEvaluatedProject(dir) { ext -> ext.supports { jvm + linuxX64 } }
         assertRegisteredTargets(project /* none — selection ∩ supported is empty */)
     }
 
     @Test
-    fun `given no supports declared and a global KMP_TARGETS when evaluated then nothing registers`(
+    fun `given no supports declared and a global kmptargets targets when evaluated then nothing registers`(
         @TempDir dir: Path
     ) {
         // Targets are explicit: with no `supports { … }` there is nothing to register, regardless
         // of
-        // KMP_TARGETS. This is the floor of the API contract under eager registration — there is no
+        // kmptargets.targets. This is the floor of the API contract under eager registration —
+        // there is no
         // implicit default-all supported set.
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm,iosArm64\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,iosArm64\n")
         val project = newEvaluatedProject(dir) { /* no extension configuration */ }
         assertRegisteredTargets(project /* none — supported was never declared */)
     }
 
     @Test
-    fun `given an explicit supports all and a global KMP_TARGETS when evaluated then the selection registers`(
+    fun `given an explicit supports all and a global kmptargets targets when evaluated then the selection registers`(
         @TempDir dir: Path
     ) {
-        // `supports { all }` is the explicit opt-in to "build everything KMP_TARGETS selects": with
+        // `supports { all }` is the explicit opt-in to "build everything kmptargets.targets
+        // selects": with
         // supported = all, the global selection alone decides what registers.
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm,iosArm64\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,iosArm64\n")
         val project = newEvaluatedProject(dir) { ext -> ext.supports { all } }
         assertRegisteredTargets(project, "jvm", "iosArm64")
     }
@@ -154,7 +157,7 @@ class KmpTargetsDslTest {
     ) {
         // Eager registration is idempotent and unions: the second call registers only the delta
         // (iosArm64); jvm, already registered, is not re-added and KGP does not throw.
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=all\n")
         val project =
             newEvaluatedProject(dir) { ext ->
                 ext.supports { jvm }
@@ -164,13 +167,13 @@ class KmpTargetsDslTest {
     }
 
     @Test
-    fun `given supports mobile plus web and a narrowing global KMP_TARGETS when evaluated then exactly the overlap registers`(
+    fun `given supports mobile plus web and a narrowing global kmptargets targets when evaluated then exactly the overlap registers`(
         @TempDir dir: Path
     ) {
         // Composition test: the DSL takes the place of stacking two convention plugin ids (e.g.
         // `.mobile` + `.web`). `supports { mobile + web }` is the equivalent declaration; with a
         // selection that hits one leaf from each preset, only those leaves register.
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=iosArm64,wasmJs\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64,wasmJs\n")
         val project = newEvaluatedProject(dir) { ext -> ext.supports { mobile + web } }
         assertRegisteredTargets(project, "iosArm64", "wasmJs")
     }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslVocabularyTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDslVocabularyTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
  * Pure, Gradle-free coverage of the [KmpTargetsDsl] receiver vocabulary used inside `kmpTargets {
  * supports { … } }`. Every preset and every leaf must map to exactly the same `KmpTargetSet` the
  * string grammar and the public model produce — otherwise the type-safe DSL would silently disagree
- * with `KMP_TARGETS=…` and the docs.
+ * with `kmptargets.targets=…` and the docs.
  */
 class KmpTargetsDslVocabularyTest {
 

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionDslTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionDslTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 /**
  * Extension-level coverage of the type-safe `supports { … }` block, its raw value overload, and the
- * [KmpTargetsExtension.resolvedSelection] precedence (a global `KMP_TARGETS` wins over
+ * [KmpTargetsExtension.resolvedSelection] precedence (a global `kmptargets.targets` wins over
  * [KmpTargetsExtension.defaultSelection]). These assert the pure DSL → property wiring without
  * applying KGP; the in-process registration is covered by [KmpTargetsDslTest].
  */
@@ -90,7 +90,8 @@ class KmpTargetsExtensionDslTest {
     fun `given a global selection narrowed to empty when resolvedSelection then it is empty not the default`() {
         val ext = newExtension()
         ext.defaultSelection.set(KmpTargetSet.of(KmpTarget.Jvm.Desktop))
-        // An explicit "build nothing" global (e.g. KMP_TARGETS=jvm,-jvm) must win over the default.
+        // An explicit "build nothing" global (e.g. kmptargets.targets=jvm,-jvm) must win over the
+        // default.
         ext.globalSelection = KmpTargetSet.empty
         assertEquals(KmpTargetSet.empty, ext.resolvedSelection())
     }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
@@ -37,10 +37,10 @@ class KmpTargetsPluginTest {
     }
 
     @Test
-    fun `given KMP_TARGETS gradle property is set when selection is read then it reflects the parsed value`(
+    fun `given kmptargets targets gradle property is set when selection is read then it reflects the parsed value`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=android,iosArm64\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=android,iosArm64\n")
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
@@ -51,10 +51,10 @@ class KmpTargetsPluginTest {
     }
 
     @Test
-    fun `given KMP_TARGETS gradle property is appleMobile when selection is read then it equals KmpTargetSet appleMobile`(
+    fun `given kmptargets targets gradle property is appleMobile when selection is read then it equals KmpTargetSet appleMobile`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=appleMobile\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=appleMobile\n")
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
@@ -73,10 +73,10 @@ class KmpTargetsPluginTest {
     }
 
     @Test
-    fun `given KMP_TARGETS is invalid when plugin is applied then a GradleException surfaces in the failure chain`(
+    fun `given kmptargets targets is invalid when plugin is applied then a GradleException surfaces in the failure chain`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=iosArm65\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm65\n")
         val project = newProject(dir)
         val ex =
             assertFailsWith<Exception> { project.pluginManager.apply("com.rsicarelli.kmptargets") }
@@ -84,14 +84,17 @@ class KmpTargetsPluginTest {
         // message.
         val rootCause =
             generateSequence(ex as Throwable?) { it.cause }
-                .firstOrNull { it.message?.contains("KMP_TARGETS") == true }
-        assertNotNull(rootCause, "expected KMP_TARGETS-tagged cause in chain, root: ${ex.message}")
+                .firstOrNull { it.message?.contains("kmptargets.targets") == true }
+        assertNotNull(
+            rootCause,
+            "expected kmptargets.targets-tagged cause in chain, root: ${ex.message}",
+        )
         assertTrue(
             rootCause.message!!.contains("iosArm65"),
             "expected message to include offending token, got: ${rootCause.message}",
         )
         assertTrue(
-            !rootCause.message!!.contains("KMP_TARGETS: KMP_TARGETS"),
+            !rootCause.message!!.contains("kmptargets.targets: kmptargets.targets"),
             "expected a single property prefix, got: ${rootCause.message}",
         )
         assertTrue(
@@ -101,10 +104,10 @@ class KmpTargetsPluginTest {
     }
 
     @Test
-    fun `given KMP_TARGETS in local properties when plugin applied then selection reflects that value`(
+    fun `given kmptargets targets in local properties when plugin applied then selection reflects that value`(
         @TempDir dir: Path
     ) {
-        dir.resolve("local.properties").writeText("KMP_TARGETS=android\n")
+        dir.resolve("local.properties").writeText("kmptargets.targets=android\n")
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
@@ -112,11 +115,11 @@ class KmpTargetsPluginTest {
     }
 
     @Test
-    fun `given KMP_TARGETS in both gradle properties and local properties when plugin applied then gradle property wins`(
+    fun `given kmptargets targets in both gradle properties and local properties when plugin applied then gradle property wins`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=iosArm64\n")
-        dir.resolve("local.properties").writeText("KMP_TARGETS=android\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        dir.resolve("local.properties").writeText("kmptargets.targets=android\n")
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
@@ -124,10 +127,10 @@ class KmpTargetsPluginTest {
     }
 
     @Test
-    fun `given KMP_TARGETS is blank when plugin applied then selection falls back to default`(
+    fun `given kmptargets targets is blank when plugin applied then selection falls back to default`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=\n")
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
@@ -137,15 +140,114 @@ class KmpTargetsPluginTest {
     }
 
     @Test
-    fun `given KMP_TARGETS narrows to nothing via minus when selection is read then it is empty not the default`(
+    fun `given kmptargets targets narrows to nothing via minus when selection is read then it is empty not the default`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=jvm,-jvm\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,-jvm\n")
         val project = newProject(dir)
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
         // An explicit selection narrowed to nothing means "build nothing", not "build everything".
         assertEquals(KmpTargetSet.empty, ext.resolvedSelection())
+    }
+
+    @Test
+    fun `given committed config file with targets key when plugin applied then selection reflects it`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.targets=android\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Android), ext.resolvedSelection())
+    }
+
+    @Test
+    fun `given personal and committed config files when plugin applied then the personal file wins`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.targets=android\n")
+        dir.resolve("kmp-targets.local.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop), ext.resolvedSelection())
+    }
+
+    @Test
+    fun `given committed config file and gradle properties when plugin applied then the committed file wins`(
+        @TempDir dir: Path
+    ) {
+        // The dedicated file is the consolidation point: once a team adopts it, a stale key left
+        // behind in gradle.properties must not silently override it (issue #30).
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.targets=android\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Android), ext.resolvedSelection())
+    }
+
+    @Test
+    fun `given cli property and personal config file when plugin applied then the cli value wins`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.local.properties").writeText("kmptargets.targets=android\n")
+        val project = newProject(dir)
+        project.gradle.startParameter.projectProperties = mapOf("kmptargets.targets" to "jvm")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop), ext.resolvedSelection())
+    }
+
+    @Test
+    fun `given committed config file with blank targets value when plugin applied then selection falls back to default`(
+        @TempDir dir: Path
+    ) {
+        // Blank is "present but not overriding" — it falls through to the default selection, and
+        // shadows lower layers rather than deferring to them (same contract as gradle.properties).
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.targets=\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=android\n")
+        val project = newProject(dir)
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        assertEquals(KmpTargetSet.all, ext.resolvedSelection())
+    }
+
+    @Test
+    fun `given committed config file with unknown key when plugin applied then the build fails with a suggestion`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.tagets=jvm\n")
+        val project = newProject(dir)
+        val ex =
+            assertFailsWith<Exception> { project.pluginManager.apply("com.rsicarelli.kmptargets") }
+        val rootCause =
+            generateSequence(ex as Throwable?) { it.cause }
+                .firstOrNull { it.message?.contains("kmp-targets.properties") == true }
+        assertNotNull(rootCause, "expected file-tagged cause in chain, root: ${ex.message}")
+        assertTrue(
+            rootCause.message!!.contains("did you mean 'kmptargets.targets'?"),
+            "expected suggestion, got: ${rootCause.message}",
+        )
+    }
+
+    @Test
+    fun `given personal config file with unknown key when plugin applied then the build fails naming that file`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.local.properties").writeText("kmptargets.hierachyTemplate=false\n")
+        val project = newProject(dir)
+        val ex =
+            assertFailsWith<Exception> { project.pluginManager.apply("com.rsicarelli.kmptargets") }
+        val rootCause =
+            generateSequence(ex as Throwable?) { it.cause }
+                .firstOrNull { it.message?.contains("kmp-targets.local.properties") == true }
+        assertNotNull(rootCause, "expected file-tagged cause in chain, root: ${ex.message}")
+        assertTrue(
+            rootCause.message!!.contains("did you mean 'kmptargets.hierarchyTemplate'?"),
+            "expected suggestion, got: ${rootCause.message}",
+        )
     }
 
     @Test

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
@@ -87,6 +87,28 @@ class HierarchyTemplateInProcessTest {
     }
 
     @Test
+    fun `given hierarchy template false in committed config file and iOS only when applied then KGP default applies`(
+        @TempDir dir: Path
+    ) {
+        // The dedicated config file carries the hierarchy key with the same precedence chain as the
+        // selection key (issue #30).
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.hierarchyTemplate=false\n")
+        val sourceSets = sourceSetsOf(dir, "iosArm64,iosX64,iosSimulatorArm64")
+        assertTrue("appleMain" in sourceSets, "file off should keep KGP default: $sourceSets")
+    }
+
+    @Test
+    fun `given hierarchy template false in committed but true in personal file when applied then minimal template wins`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.hierarchyTemplate=false\n")
+        dir.resolve("kmp-targets.local.properties").writeText("kmptargets.hierarchyTemplate=true\n")
+        val sourceSets = sourceSetsOf(dir, "iosArm64,iosX64,iosSimulatorArm64")
+        assertTrue("iosMain" in sourceSets, sourceSets.toString())
+        assertFalse("appleMain" in sourceSets, "personal file should win: $sourceSets")
+    }
+
+    @Test
     fun `given global property false but project override true when applied then minimal template wins`(
         @TempDir dir: Path
     ) {
@@ -146,9 +168,9 @@ class HierarchyTemplateInProcessTest {
     ) {
         // Proves the active-set -> spec wiring uses selection ∩ resolvedSupported. Materialization
         // is asserted by the source-set tests above; here we pin the pure decision on a real
-        // extension fed by a real KMP_TARGETS property.
+        // extension fed by a real kmptargets.targets property.
         dir.resolve("gradle.properties")
-            .writeText("KMP_TARGETS=iosArm64,iosX64,iosSimulatorArm64\n")
+            .writeText("kmptargets.targets=iosArm64,iosX64,iosSimulatorArm64\n")
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
@@ -164,13 +186,13 @@ class HierarchyTemplateInProcessTest {
         extraProps: String = "",
         configure: (Project) -> Unit = {},
     ): Set<String> {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=$kmpTargets\n$extraProps")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=$kmpTargets\n$extraProps")
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
         // `configure` sets hierarchyTemplate, which must hold before the eager `supports` call that
         // registers targets and applies the template. `supports { all }` keeps the active set equal
-        // to the KMP_TARGETS selection.
+        // to the kmptargets.targets selection.
         configure(project)
         project.extensions.getByType(KmpTargetsExtension::class.java).supports(KmpTargetSet.all)
         (project as ProjectInternal).evaluate()
@@ -183,7 +205,7 @@ class HierarchyTemplateInProcessTest {
 
     /** Direct `dependsOn` source-set names of [sourceSet] after the minimal template is applied. */
     private fun dependsOnOf(dir: Path, kmpTargets: String, sourceSet: String): Set<String> {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=$kmpTargets\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=$kmpTargets\n")
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/source/ConfigPropertiesSourceTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/source/ConfigPropertiesSourceTest.kt
@@ -1,0 +1,85 @@
+package com.rsicarelli.kmptargets.source
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class ConfigPropertiesSourceTest {
+
+    @Test
+    fun `given no config file when read then returns null`(@TempDir dir: Path) {
+        assertNull(ConfigPropertiesSource(dir.toFile(), ConfigKeys.COMMITTED_FILE).read())
+    }
+
+    @Test
+    fun `given config file with known keys when read then returns every entry`(@TempDir dir: Path) {
+        dir.resolve("kmp-targets.properties")
+            .writeText("kmptargets.targets=jvm,iosArm64\nkmptargets.hierarchyTemplate=false\n")
+        assertEquals(
+            mapOf(
+                "kmptargets.targets" to "jvm,iosArm64",
+                "kmptargets.hierarchyTemplate" to "false",
+            ),
+            ConfigPropertiesSource(dir.toFile(), ConfigKeys.COMMITTED_FILE).read(),
+        )
+    }
+
+    @Test
+    fun `given empty config file when read then returns an empty map not null`(@TempDir dir: Path) {
+        // File present but empty is not the same as file absent: absent defers the whole layer,
+        // present-but-empty just contributes no keys.
+        dir.resolve("kmp-targets.properties").writeText("")
+        assertEquals(
+            emptyMap(),
+            ConfigPropertiesSource(dir.toFile(), ConfigKeys.COMMITTED_FILE).read(),
+        )
+    }
+
+    @Test
+    fun `given blank value for a key when read then the entry is present and empty`(
+        @TempDir dir: Path
+    ) {
+        // Preserves the absent-vs-blank contract per key: "" = present but not overriding.
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.targets=\n")
+        assertEquals(
+            mapOf("kmptargets.targets" to ""),
+            ConfigPropertiesSource(dir.toFile(), ConfigKeys.COMMITTED_FILE).read(),
+        )
+    }
+
+    @Test
+    fun `given comments and blank lines when read then they are ignored`(@TempDir dir: Path) {
+        dir.resolve("kmp-targets.properties")
+            .writeText("# team-wide selection\n\nkmptargets.targets=jvm\n")
+        assertEquals(
+            mapOf("kmptargets.targets" to "jvm"),
+            ConfigPropertiesSource(dir.toFile(), ConfigKeys.COMMITTED_FILE).read(),
+        )
+    }
+
+    @Test
+    fun `given leading whitespace around a value when read then it is stripped`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.targets=  jvm\n")
+        assertEquals(
+            mapOf("kmptargets.targets" to "jvm"),
+            ConfigPropertiesSource(dir.toFile(), ConfigKeys.COMMITTED_FILE).read(),
+        )
+    }
+
+    @Test
+    fun `given the personal file name when read then that file is read instead`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.local.properties").writeText("kmptargets.targets=android\n")
+        assertEquals(
+            mapOf("kmptargets.targets" to "android"),
+            ConfigPropertiesSource(dir.toFile(), ConfigKeys.LOCAL_FILE).read(),
+        )
+        assertNull(ConfigPropertiesSource(dir.toFile(), ConfigKeys.COMMITTED_FILE).read())
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/source/LocalPropertiesSourceTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/source/LocalPropertiesSourceTest.kt
@@ -11,21 +11,21 @@ class LocalPropertiesSourceTest {
 
     @Test
     fun `given local properties with the key when read then returns the value`(@TempDir dir: Path) {
-        dir.resolve("local.properties").writeText("KMP_TARGETS=android,iosArm64\n")
-        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        dir.resolve("local.properties").writeText("kmptargets.targets=android,iosArm64\n")
+        val source = LocalPropertiesSource(dir.toFile(), "kmptargets.targets")
         assertEquals("android,iosArm64", source.read())
     }
 
     @Test
     fun `given local properties without the key when read then returns null`(@TempDir dir: Path) {
         dir.resolve("local.properties").writeText("OTHER_KEY=value\n")
-        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        val source = LocalPropertiesSource(dir.toFile(), "kmptargets.targets")
         assertNull(source.read())
     }
 
     @Test
     fun `given no local properties file when read then returns null`(@TempDir dir: Path) {
-        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        val source = LocalPropertiesSource(dir.toFile(), "kmptargets.targets")
         assertNull(source.read())
     }
 
@@ -34,8 +34,8 @@ class LocalPropertiesSourceTest {
         @TempDir dir: Path
     ) {
         // java.util.Properties strips leading whitespace from values but keeps trailing
-        dir.resolve("local.properties").writeText("KMP_TARGETS=  android\n")
-        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        dir.resolve("local.properties").writeText("kmptargets.targets=  android\n")
+        val source = LocalPropertiesSource(dir.toFile(), "kmptargets.targets")
         assertEquals("android", source.read())
     }
 
@@ -43,8 +43,8 @@ class LocalPropertiesSourceTest {
     fun `given local properties with empty value when read then returns empty string`(
         @TempDir dir: Path
     ) {
-        dir.resolve("local.properties").writeText("KMP_TARGETS=\n")
-        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        dir.resolve("local.properties").writeText("kmptargets.targets=\n")
+        val source = LocalPropertiesSource(dir.toFile(), "kmptargets.targets")
         assertEquals("", source.read())
     }
 
@@ -55,12 +55,12 @@ class LocalPropertiesSourceTest {
         dir.resolve("local.properties")
             .writeText(
                 """
-                # set KMP_TARGETS to override the default selection
-                KMP_TARGETS=appleMobile
+                # set kmptargets.targets to override the default selection
+                kmptargets.targets=appleMobile
                 """
                     .trimIndent()
             )
-        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        val source = LocalPropertiesSource(dir.toFile(), "kmptargets.targets")
         assertEquals("appleMobile", source.read())
     }
 
@@ -72,12 +72,12 @@ class LocalPropertiesSourceTest {
             .writeText(
                 """
                 sdk.dir=/Users/foo/Library/Android/sdk
-                KMP_TARGETS=android
+                kmptargets.targets=android
                 org.gradle.jvmargs=-Xmx2g
                 """
                     .trimIndent()
             )
-        val source = LocalPropertiesSource(dir.toFile(), "KMP_TARGETS")
+        val source = LocalPropertiesSource(dir.toFile(), "kmptargets.targets")
         assertEquals("android", source.read())
     }
 

--- a/samples/hello-world/build.gradle.kts
+++ b/samples/hello-world/build.gradle.kts
@@ -1,6 +1,6 @@
 // Root of the multi-module sample.
 // Each subproject applies KGP + the `com.rsicarelli.kmptargets` base plugin and declares its
-// supported set via the `kmpTargets { supports { … } }` DSL. The global KMP_TARGETS
+// supported set via the `kmpTargets { supports { … } }` DSL. The global kmptargets.targets
 // (gradle.properties) is intersected against each module's supported set.
 //
 // Kotlin Multiplatform is declared here once with `apply false` so every subproject shares a single

--- a/samples/hello-world/core-and-apple/build.gradle.kts
+++ b/samples/hello-world/core-and-apple/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    // Composition: supported = apple ∪ jvm. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 this
+    // Composition: supported = apple ∪ jvm. With kmptargets.targets=jvm,iosArm64,iosSimulatorArm64
+    // this
     // registers jvm + both iOS leaves — more than `apple` alone (all Apple platforms) or `jvm`
     // alone
     // (jvm only). The DSL takes the place of stacking two convention ids: the supported set is just

--- a/samples/hello-world/eager-conventions/build.gradle.kts
+++ b/samples/hello-world/eager-conventions/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 // EAGER PROOF. `kmpModule` declares the supported set and then reads `kotlin.targets`
 // synchronously,
-// wiring one task per registered target. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64
+// wiring one task per registered target. With kmptargets.targets=jvm,iosArm64,iosSimulatorArm64
 // intersected
 // against supports { jvm + iosArm64 }, the convention sees exactly [iosArm64, jvm] — at
 // configuration

--- a/samples/hello-world/escape-hatch-dsl/build.gradle.kts
+++ b/samples/hello-world/escape-hatch-dsl/build.gradle.kts
@@ -8,7 +8,8 @@ plugins {
 }
 
 kmpTargets {
-    // Supports JVM + Linux only. With the sample's KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64,
+    // Supports JVM + Linux only. With the sample's
+    // kmptargets.targets=jvm,iosArm64,iosSimulatorArm64,
     // selection ∩ supported = jvm — so only `jvm` registers (linuxX64 is supported but unselected;
     // the iOS leaves are selected but unsupported). `supports` registers eagerly, the moment this
     // line runs.

--- a/samples/hello-world/feature-mobile/build.gradle.kts
+++ b/samples/hello-world/feature-mobile/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     // Supports Android + all iOS (the `mobile` preset). With
-    // KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64
+    // kmptargets.targets=jvm,iosArm64,iosSimulatorArm64
     // the jvm is dropped (not supported here) and the two selected iOS leaves register and share a
     // single `iosMain` — with NO `appleMain`/`nativeMain`. Android isn't selected, so no AGP. The
     // starkest collapse: KGP's default would add 3 redundant intermediates here; the template adds

--- a/samples/hello-world/gradle.properties
+++ b/samples/hello-world/gradle.properties
@@ -1,8 +1,6 @@
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 
-# Default target selection for this sample. Two iOS leaves are selected so the minimal hierarchy
-# template has something to collapse: iOS-supporting modules get a single `iosMain` (no redundant
-# `appleMain`/`nativeMain`), which is the whole point of the feature. Developers override locally via
-# local.properties or `-PKMP_TARGETS=...`.
-KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64
+# The target selection lives in kmp-targets.properties — the dedicated, committed home for global
+# kmp-targets configuration. Developers override locally via kmp-targets.local.properties
+# (git-ignored) or `-Pkmptargets.targets=...`.

--- a/samples/hello-world/jvm-tools/build.gradle.kts
+++ b/samples/hello-world/jvm-tools/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    // Supports JVM only. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 the iOS targets are
+    // Supports JVM only. With kmptargets.targets=jvm,iosArm64,iosSimulatorArm64 the iOS targets are
     // dropped
     // and only `jvm` registers.
     kotlin("multiplatform")

--- a/samples/hello-world/kmp-targets.properties
+++ b/samples/hello-world/kmp-targets.properties
@@ -1,0 +1,9 @@
+# Committed, team-shared kmp-targets configuration — the one place to see what the plugin is
+# configured to do in this build. A git-ignored kmp-targets.local.properties next to this file
+# overrides these keys per developer; CLI `-P` and ORG_GRADLE_PROJECT_* env beat both. Unknown
+# keys fail the build (typos can't silently no-op).
+
+# Default target selection for this sample. Two iOS leaves are selected so the minimal hierarchy
+# template has something to collapse: iOS-supporting modules get a single `iosMain` (no redundant
+# `appleMain`/`nativeMain`), which is the whole point of the feature.
+kmptargets.targets=jvm,iosArm64,iosSimulatorArm64

--- a/samples/hello-world/legacy-default/build.gradle.kts
+++ b/samples/hello-world/legacy-default/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    // Same DSL flow and same KMP_TARGETS as :shared-core, but this module opts OUT of the minimal
+    // Same DSL flow and same kmptargets.targets as :shared-core, but this module opts OUT of the
+    // minimal
     // template. KGP then applies its default hierarchy, so the two iOS leaves get the full
     // redundant
     // chain — `iosMain` + `appleMain` + `nativeMain` — instead of just `iosMain`. This is the

--- a/samples/hello-world/settings.gradle.kts
+++ b/samples/hello-world/settings.gradle.kts
@@ -29,8 +29,9 @@ rootProject.name = "hello-world"
 // Heterogeneous modules, each declaring its supported shape via `kmpTargets { supports { … } }` in
 // its build script. Targets are explicit — a module with no `supports` registers nothing. The
 // global
-// KMP_TARGETS (see gradle.properties) is intersected against each module's set, then a minimal
-// hierarchy template is applied. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64:
+// kmptargets.targets (see kmp-targets.properties) is intersected against each module's set, then a
+// minimal
+// hierarchy template is applied. With kmptargets.targets=jvm,iosArm64,iosSimulatorArm64:
 
 // supports{all} → jvm + iosMain (the 2 iOS leaves share iosMain; no appleMain)
 include(":shared-core")

--- a/samples/hello-world/shared-core/build.gradle.kts
+++ b/samples/hello-world/shared-core/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     // Apply KGP + the base kmp-targets id, then declare `supports { all }` to build everything the
-    // global KMP_TARGETS selects. With KMP_TARGETS=jvm,iosArm64,iosSimulatorArm64 this registers
+    // global kmptargets.targets selects. With kmptargets.targets=jvm,iosArm64,iosSimulatorArm64
+    // this registers
     // those three; the minimal template shares the two iOS leaves under a single `iosMain` (no
     // redundant `appleMain`/`nativeMain`). Compare with :legacy-default, which opts out and keeps
     // both.
@@ -9,5 +10,5 @@ plugins {
 }
 
 // Targets are explicit: with no `supports` nothing would register. `supports { all }` is the opt-in
-// to "build whatever KMP_TARGETS selects".
+// to "build whatever kmptargets.targets selects".
 kmpTargets { supports { all } }

--- a/samples/isolated-projects/README.md
+++ b/samples/isolated-projects/README.md
@@ -13,7 +13,7 @@ goes red.
 
 ## Layout
 
-| Module | DSL | Supported | Registered with `KMP_TARGETS=jvm` |
+| Module | DSL | Supported | Registered with `kmptargets.targets=jvm` |
 |---|---|---|---|
 | `:lib` | _(no `supports` block — defaults to `all`)_ | all targets | `jvm` |
 | `:app` | `kmpTargets { supports { jvm } }` | `jvm` | `jvm` |

--- a/samples/isolated-projects/app/build.gradle.kts
+++ b/samples/isolated-projects/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    // Supports jvm only; registers jvm under KMP_TARGETS=jvm. Depends on :lib through a project
+    // Supports jvm only; registers jvm under kmptargets.targets=jvm. Depends on :lib through a
+    // project
     // dependency — a real cross-project edge that Isolated Projects must wire while keeping each
     // project's configuration isolated.
     kotlin("multiplatform")

--- a/samples/isolated-projects/gradle.properties
+++ b/samples/isolated-projects/gradle.properties
@@ -5,7 +5,5 @@
 org.gradle.unsafe.isolated-projects=true
 org.gradle.caching=true
 
-# Build only the JVM target so CI needs no Android SDK or Apple toolchain. The .library module
-# supports all targets and the .jvm module supports jvm; intersected with this selection both
-# register jvm only.
-KMP_TARGETS=jvm
+# The target selection lives in kmp-targets.properties — reading the dedicated config file under
+# Isolated Projects also guards the plugin's ValueSource-based file access.

--- a/samples/isolated-projects/kmp-targets.properties
+++ b/samples/isolated-projects/kmp-targets.properties
@@ -1,0 +1,5 @@
+# Committed, team-shared kmp-targets configuration (see samples/hello-world for the full tour).
+# Build only the JVM target so CI needs no Android SDK or Apple toolchain. The .library module
+# supports all targets and the .jvm module supports jvm; intersected with this selection both
+# register jvm only.
+kmptargets.targets=jvm

--- a/samples/isolated-projects/lib/build.gradle.kts
+++ b/samples/isolated-projects/lib/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     // Supports all targets via the explicit `supports { all }` below. Intersected with the global
-    // KMP_TARGETS=jvm (see ../gradle.properties) it registers jvm only. Configured under Isolated
+    // kmptargets.targets=jvm (see ../kmp-targets.properties) it registers jvm only. Configured
+    // under Isolated
     // Projects — proof the plugin applies without reaching across projects.
     kotlin("multiplatform")
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"

--- a/samples/isolated-projects/settings.gradle.kts
+++ b/samples/isolated-projects/settings.gradle.kts
@@ -27,7 +27,7 @@ rootProject.name = "isolated-projects"
 // the plugin keeps touching nothing but the project it is applied to — making it the executable
 // guard for that contract.
 
-// default-all → supports every target; with KMP_TARGETS=jvm registers jvm only
+// default-all → supports every target; with kmptargets.targets=jvm registers jvm only
 include(":lib")
 
 // supports{jvm} → registers jvm; depends on :lib through a project dependency


### PR DESCRIPTION
**Roadmap — Selection Ergonomics · Phase 1 (Config surface).** #30 and #31 implemented together, as both issues recommend: the dedicated file is born with the unified key names and a key registry — no two rounds of key churn.

Closes #30
Closes #31

## What changed

### #31 — one naming convention (hard break, no alias)

| Concern | Before | After |
|---|---|---|
| Selection (files / `gradle.properties` / `local.properties`) | `KMP_TARGETS=...` | `kmptargets.targets=...` |
| Selection (CLI) | `-PKMP_TARGETS=...` | `-Pkmptargets.targets=...` |
| Selection (env) | `ORG_GRADLE_PROJECT_KMP_TARGETS` *(docs)* / bare `KMP_TARGETS` *(code)* | `ORG_GRADLE_PROJECT_kmptargets.targets` |
| Hierarchy template | `kmptargets.hierarchyTemplate` | unchanged |

- Key constants centralized in the new `ConfigKeys` registry (`source/ConfigKeys.kt`); `parseOrThrow` error prefix and the parser's empty-input warning name the new key.
- The bare `KMP_TARGETS` **env var** is no longer read — the env surface is Gradle's native `ORG_GRADLE_PROJECT_<key>` mapping only. This also fixes a pre-existing mismatch (README documented `ORG_GRADLE_PROJECT_KMP_TARGETS`, code read bare `KMP_TARGETS`).
- Hard break: a build still setting only `KMP_TARGETS` falls through to `defaultSelection`/built-in. Documented in README + new `CHANGELOG.md`.

### #30 — dedicated root config files

- `kmp-targets.properties` (committed, team-shared) + `kmp-targets.local.properties` (git-ignored personal override, Bazel `try-import user.bazelrc` semantics).
- Each file is read **once as a whole map** through a new `ConfigFileValueSource` (mirrors `LocalPropertyValueSource`), so both files are tracked configuration-cache inputs. Per-key absent-vs-blank contract preserved (`null` = defer, `""` = present-but-blank).
- **Fail loud:** an unknown key in either file fails the build at configuration time with a did-you-mean suggestion (reuses `parser/DidYouMean.kt`).
- **Precedence** (highest first): `-P` CLI → `ORG_GRADLE_PROJECT_<key>` env → personal file → committed file → `gradle.properties` → `local.properties` → `defaultSelection` → built-in.
- Both global knobs read through one `configSources()` chain — the hierarchy key gains the CLI/env/file layers it never had, with identical precedence.

### The precedence wrinkle, resolved

`providers.gradleProperty` fuses CLI `-P`, `ORG_GRADLE_PROJECT_*` env, and `gradle.properties` into one provider with no origin information, so the new files could not slot between env and `gradle.properties` by composition order alone. The top of the chain is decomposed by hand: CLI is read eagerly from `startParameter.projectProperties` (stable public API; `-P` values are config-cache inputs, and the isolated-projects sample guards the access), env explicitly via the `ORG_GRADLE_PROJECT_` mapping, and `gradleProperty` then serves as the `gradle.properties` layer (its re-match of CLI/env is harmless under first-non-null composition). Documented nuance: `-Dorg.gradle.project.<key>` and `~/.gradle/gradle.properties` resolve at that layer, i.e. below the dedicated files.

## Acceptance criteria — #30

- [x] Committed file's value used with no CLI/env override — `given committed config file with targets key…` (ProjectBuilder)
- [x] Personal override beats committed — `given personal and committed config files…`
- [x] CLI/env beat the dedicated file — `given cli property and personal config file…` (ProjectBuilder) + TestKit `-P` case + manual env run against the sample
- [x] Dedicated file beats root `gradle.properties` — `given committed config file and gradle properties…`
- [x] No files → behavior identical to today (existing `gradle.properties`/`local.properties` tests untouched in intent, all green)
- [x] Cache **reuse**: second unchanged hello-world run → `Reusing configuration cache.`
- [x] Cache **invalidation**: editing `kmp-targets.properties` → `configuration cache cannot be reused because a build logic input of type 'ConfigFileValueSource' has changed` (+ selection effect verified via task list)
- [x] Hierarchy key honored from the file with same precedence — two new in-process tests (committed-file off → KGP default; personal `true` beats committed `false`)
- [x] New `SelectionSource`-composed reader; reads via `ValueSource` only (no raw config-time `File.readText`)
- [x] README precedence/Bazel-semantics docs; sample demonstrates the file; GIVEN-WHEN-THEN naming

## Acceptance criteria — #31

- [x] `-Pkmptargets.targets=jvm` resolves exactly as before — TestKit launcher test
- [x] Unified key in root `gradle.properties` resolves — migrated ProjectBuilder tests
- [x] Gradle-native env form resolves — TestKit test with `ORG_GRADLE_PROJECT_kmptargets.targets=jvm` proves the **dotted name** survives the env→property mapping
- [x] Both knobs under `kmptargets.` — one documented convention
- [x] Hard break documented: old-key-only build falls through to default (README callout + CHANGELOG table)
- [x] Config cache reused with unified keys (sample runs)
- [x] Constants centralized (`ConfigKeys`); README + CHANGELOG + sample + every test fixture migrated; `refactor!:` commit

## Verification

- `task ci` green: check + publish-local + hello-world (incl. `verifyEagerTargets` + `build-logic`) + isolated-projects (guards the `startParameter` read and ValueSource access under project isolation)
- `task dod` green; 220 tests (9 new ProjectBuilder/in-process, 7 unit, 2 TestKit functional)
- `grep -rn afterEvaluate gradle-plugin/src/main` → empty (#29 gate intact)

Note: TestKit child builds need KGP on the plugin classpath (it's `compileOnly`), funneled in via a dedicated configuration feeding `pluginUnderTestMetadata` — test-scoped only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)