### PR TITLE
feat: add kmpTargetsInfo introspection task

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,45 @@ Available presets:
 
 Unknown tokens fail the build at configuration time with a "did you mean ...?" suggestion — silently dropping a misspelled target in CI is the worst failure mode, so the parser is strict. Bare Apple sub-family names (`ios`, `macos`, `watchos`, `tvos`) are rejected with a hint pointing at the relevant leaf or `appleX` preset.
 
+### Debugging the selection
+
+Every project the plugin is applied to gets a `kmpTargetsInfo` task (group `help`) that answers
+"what did the plugin decide for this module, and why?" — the resolved selection, **which
+[source](#selecting-targets) it came from**, the declared supported set, the registered
+intersection, and the vocabulary the parser accepts:
+
+```console
+$ ./gradlew :shared-core:kmpTargetsInfo -q
+
+kmp-targets — :shared-core
+
+Selection (what to build now)
+  targets:  iosArm64, iosSimulatorArm64, jvm
+  source:   kmp-targets.properties
+
+Supported (what this module can build)
+  declared: yes
+  targets:  androidNativeArm32, ..., watchosX64
+
+Registered (selection ∩ supported)
+  targets:  iosArm64, iosSimulatorArm64, jvm
+
+Vocabulary
+  presets:  all, native, appleMobile, appleDesktop, appleWatch, appleTv, apple, linux, mingw, windows, androidNative, web, jvmFamily, mobile
+  leaves:   androidNativeArm32, ..., watchosX64 (25)
+```
+
+The `source` line names the winning layer of the [precedence chain](#selecting-targets) — e.g.
+`command line (-Pkmptargets.targets)`, `kmp-targets.local.properties`, `local.properties`, or the
+`defaultSelection` / built-in fallbacks. One coarseness, stated in the label itself: values from
+`-Dorg.gradle.project.kmptargets.targets` and `~/.gradle/gradle.properties` are indistinguishable
+from root `gradle.properties`, so all three report as the fused `gradle.properties (...)` layer.
+
+The report is read-only (it never registers targets), explicit about every empty case — a module
+that never declared `supports { … }`, a selection narrowed to nothing, or a genuinely disjoint
+`selection ∩ supported` each get their own explanation — and configuration-cache compatible: the
+second run is a cache hit.
+
 ### Supported targets
 
 Every target Kotlin Multiplatform (KGP 2.3.21) supports, except the deprecated `linuxArm32Hfp`:

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -5,11 +5,14 @@ import com.rsicarelli.kmptargets.hierarchy.resolveHierarchyTemplateEnabled
 import com.rsicarelli.kmptargets.hierarchy.toTemplate
 import com.rsicarelli.kmptargets.host.hostImpossibleWarning
 import com.rsicarelli.kmptargets.host.impossibleOnHost
+import com.rsicarelli.kmptargets.info.KmpTargetsInfoTask
+import com.rsicarelli.kmptargets.info.OriginLabels
 import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
 import com.rsicarelli.kmptargets.parser.ParseResult
 import com.rsicarelli.kmptargets.parser.didYouMean
 import com.rsicarelli.kmptargets.parser.parseKmpTargets
+import com.rsicarelli.kmptargets.parser.presetNames
 import com.rsicarelli.kmptargets.source.ConfigFileValueSource
 import com.rsicarelli.kmptargets.source.ConfigKeys
 import com.rsicarelli.kmptargets.source.EnvironmentVariableSource
@@ -42,11 +45,21 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // resolves to an empty set via minus operators (e.g. `jvm,-jvm`) is an explicit "build
         // nothing" and must be honored, not silently treated as the default-all selection (issue
         // #9). Keying off `isNotBlank` (rather than the parsed set's emptiness) is what
-        // distinguishes the two cases.
-        val raw: String? = configSources(target, ConfigKeys.TARGETS, personal, committed).read()
+        // distinguishes the two cases. The first-non-null walk preserves the exact
+        // `composeSelectionSources` semantics (lower layers stay unread once one wins) while also
+        // capturing WHICH layer won, for `kmpTargetsInfo`'s origin report (issue #33).
+        val winner: Pair<String, String>? =
+            labeledSources(target, ConfigKeys.TARGETS, personal, committed).firstNotNullOfOrNull {
+                (label, source) ->
+                source.read()?.let { value -> label to value }
+            }
+        val raw: String? = winner?.second
         if (raw != null && raw.isNotBlank()) {
             ext.globalSelection = parseOrThrow(raw, ConfigKeys.TARGETS)
         }
+        // A blank winner shadows lower layers but does not override the default, so it yields no
+        // origin either — the report then falls through to the defaultSelection/built-in labels.
+        val configOrigin: String? = winner?.takeIf { it.second.isNotBlank() }?.first
 
         // Global default for the hierarchy template, read once at apply time as a primitive.
         val globalHierarchyEnabled: Boolean? =
@@ -64,6 +77,56 @@ public class KmpTargetsPlugin : Plugin<Project> {
                 register(target, ext, globalHierarchyEnabled)
             }
         }
+
+        registerInfoTask(target, ext, configOrigin)
+    }
+
+    /**
+     * Registers the `kmpTargetsInfo` introspection task (issue #33): one task that answers "what
+     * did the plugin decide for this module, and why?".
+     *
+     * Timing under the eager model: registration happens at apply time, but `supports { … }` only
+     * unions the supported set while the build-script body runs. The selection/supported/registered
+     * inputs are therefore wired as providers that map straight to sorted-id `String` lists —
+     * Gradle realizes a scheduled task's property providers at task-graph calculation, after the
+     * whole body ran, so they observe the final state and only primitives are serialized into the
+     * configuration cache. Registration is lazy on purpose: when the task is not requested it is
+     * never configured, so the providers never realize and nothing here can leak into the cache.
+     *
+     * The providers call only `resolvedSelection()`/`resolvedSupported()` — pure reads that never
+     * fire `onSupports` — so the report can never register targets as a side effect. It is also
+     * registered unconditionally (not gated on KGP): without KGP or `supports`, the report states
+     * explicitly that nothing is declared and nothing registers.
+     */
+    private fun registerInfoTask(target: Project, ext: KmpTargetsExtension, configOrigin: String?) {
+        val projectPath = target.path
+        target.tasks.register("kmpTargetsInfo", KmpTargetsInfoTask::class.java) { task ->
+            task.group = "help"
+            task.description =
+                "Prints the resolved kmp-targets selection, its origin, the supported set, and " +
+                    "the registered intersection for this project."
+            task.projectPath.set(projectPath)
+            task.presetNames.set(presetNames)
+            task.leafIds.set(KmpTarget.all.map { it.id }.sorted())
+            task.selectionIds.set(target.provider { ids(ext.resolvedSelection()) })
+            task.supportedIds.set(target.provider { ids(ext.resolvedSupported()) })
+            task.supportsDeclared.set(target.provider { ext.supportsProperty.isPresent })
+            task.registeredIds.set(
+                target.provider { ids(ext.resolvedSelection() intersect ext.resolvedSupported()) }
+            )
+            // The config-layer origin is fixed at apply time, but the fallback labels must read
+            // `defaultSelection` lazily — the body may override it after apply.
+            task.originLabel.set(
+                target.provider {
+                    configOrigin
+                        ?: if (ext.defaultSelection.get() == KmpTargetSet.all) {
+                            OriginLabels.DEFAULT_BUILTIN
+                        } else {
+                            OriginLabels.DEFAULT_BUILD_LOGIC
+                        }
+                }
+            )
+        }
     }
 
     internal companion object {
@@ -73,8 +136,10 @@ public class KmpTargetsPlugin : Plugin<Project> {
     /**
      * The full precedence chain for one global config key (highest first): CLI `-P` →
      * `ORG_GRADLE_PROJECT_<key>` env → personal file → committed file → `gradle.properties` →
-     * `local.properties`. Both global knobs read through this one chain, so they always share the
-     * same precedence.
+     * `local.properties` — each layer paired with the [OriginLabels] name `kmpTargetsInfo` reports
+     * when that layer wins. Both global knobs read through this one chain (via [configSources]), so
+     * they always share the same precedence, and origin reporting can never drift from value
+     * resolution. Adding a future config layer means adding exactly one entry here.
      *
      * The top of the chain is decomposed by hand: `providers.gradleProperty` fuses CLI, env, and
      * `gradle.properties` into one provider with no origin information, but the dedicated files
@@ -84,24 +149,37 @@ public class KmpTargetsPlugin : Plugin<Project> {
      * `ORG_GRADLE_PROJECT_` mapping; `gradleProperty` then serves as the `gradle.properties` layer.
      * It still re-matches CLI/env values, but the first-non-null composition has already caught
      * those above, so the overlap is harmless. Documented nuance: `-Dorg.gradle.project.<key>` and
-     * `~/.gradle/gradle.properties` resolve at that layer too, i.e. below the dedicated files.
+     * `~/.gradle/gradle.properties` resolve at that layer too, i.e. below the dedicated files —
+     * which is why that layer's origin label names the whole fused group.
      */
+    private fun labeledSources(
+        target: Project,
+        key: String,
+        personal: Map<String, String>?,
+        committed: Map<String, String>?,
+    ): List<Pair<String, SelectionSource>> {
+        val cli: String? = target.gradle.startParameter.projectProperties[key]
+        return listOf(
+            OriginLabels.cli(key) to SelectionSource { cli },
+            OriginLabels.environmentVariable(key) to
+                EnvironmentVariableSource(target.providers, ConfigKeys.ENV_PREFIX + key),
+            ConfigKeys.LOCAL_FILE to SelectionSource { personal?.get(key) },
+            ConfigKeys.COMMITTED_FILE to SelectionSource { committed?.get(key) },
+            OriginLabels.gradleProperties(key) to GradlePropertySource(target.providers, key),
+            OriginLabels.LOCAL_PROPERTIES to localPropertiesSource(target, key),
+        )
+    }
+
+    /** The [labeledSources] chain composed into a plain first-non-null value source. */
     private fun configSources(
         target: Project,
         key: String,
         personal: Map<String, String>?,
         committed: Map<String, String>?,
-    ): SelectionSource {
-        val cli: String? = target.gradle.startParameter.projectProperties[key]
-        return composeSelectionSources(
-            SelectionSource { cli },
-            EnvironmentVariableSource(target.providers, ConfigKeys.ENV_PREFIX + key),
-            SelectionSource { personal?.get(key) },
-            SelectionSource { committed?.get(key) },
-            GradlePropertySource(target.providers, key),
-            localPropertiesSource(target, key),
+    ): SelectionSource =
+        composeSelectionSources(
+            *labeledSources(target, key, personal, committed).map { it.second }.toTypedArray()
         )
-    }
 
     /**
      * Reads the global `kmptargets.hierarchyTemplate` flag through the standard [configSources]

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
@@ -1,0 +1,64 @@
+package com.rsicarelli.kmptargets.info
+
+/**
+ * Renders the `kmpTargetsInfo` report from primitives only — no `Project`, extension, or
+ * `KmpTargetSet` ever reaches this function, which is what keeps the task action trivially
+ * configuration-cache safe (and this formatter unit-testable without Gradle).
+ *
+ * Every empty case is spelled out rather than printed as a bare blank: an undeclared `supports`, a
+ * selection narrowed to nothing, and a genuinely disjoint `selection ∩ supported` each get a
+ * distinct explanation, because "what will build and why" is the whole point of the report.
+ */
+internal fun formatKmpTargetsInfo(
+    projectPath: String,
+    selectionIds: List<String>,
+    supportedIds: List<String>,
+    supportsDeclared: Boolean,
+    registeredIds: List<String>,
+    originLabel: String,
+    presetNames: List<String>,
+    leafIds: List<String>,
+): String = buildString {
+    appendLine("kmp-targets — $projectPath")
+    appendLine()
+    appendLine("Selection (what to build now)")
+    appendLine("  targets:  ${idsOrNone(selectionIds, "the selection narrows to nothing")}")
+    appendLine("  source:   $originLabel")
+    appendLine()
+    appendLine("Supported (what this module can build)")
+    if (supportsDeclared) {
+        appendLine("  declared: yes")
+        appendLine("  targets:  ${idsOrNone(supportedIds, "the declared set is empty")}")
+    } else {
+        appendLine(
+            "  declared: no — this module never called supports { }; it registers no targets"
+        )
+    }
+    appendLine()
+    appendLine("Registered (selection ∩ supported)")
+    appendLine("  targets:  ${registeredOrNone(registeredIds, selectionIds, supportedIds)}")
+    appendLine()
+    appendLine("Vocabulary")
+    appendLine("  presets:  ${presetNames.joinToString(", ")}")
+    append("  leaves:   ${leafIds.joinToString(", ")} (${leafIds.size})")
+}
+
+private fun idsOrNone(ids: List<String>, emptyReason: String): String =
+    if (ids.isEmpty()) "(none — $emptyReason)" else ids.joinToString(", ")
+
+/**
+ * The registered line names *why* nothing registers, in precedence order: an empty selection and an
+ * empty supported set each have their own explanation; only when both sides are non-empty is the
+ * emptiness a genuine disjunction.
+ */
+private fun registeredOrNone(
+    registeredIds: List<String>,
+    selectionIds: List<String>,
+    supportedIds: List<String>,
+): String =
+    when {
+        registeredIds.isNotEmpty() -> registeredIds.joinToString(", ")
+        selectionIds.isEmpty() -> "(none — the selection narrows to nothing)"
+        supportedIds.isEmpty() -> "(none — no supported targets declared)"
+        else -> "(none — the selection matches nothing this module supports; nothing registers)"
+    }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
@@ -1,0 +1,65 @@
+package com.rsicarelli.kmptargets.info
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Prints what the plugin decided for this project — the resolved selection (and which config layer
+ * it came from), the declared supported set, the registered intersection, and the vocabulary the
+ * parser accepts. Pure report: it never registers targets or mutates any state.
+ *
+ * Every property is a plain `String`/`Boolean` primitive, wired by the plugin from providers that
+ * realize *after* the build-script body (so all `supports { … }` unions are visible) and serialize
+ * cleanly into the configuration cache. The action reads only these properties — no `Project`,
+ * extension, or model type is ever captured (CLAUDE.md configuration-cache rule).
+ *
+ * The properties are [Internal] rather than `@Input` on purpose: the task declares no outputs, so
+ * it always runs — input fingerprinting would buy nothing for a console report.
+ */
+@DisableCachingByDefault(because = "console report with no outputs; it must always run")
+public abstract class KmpTargetsInfoTask : DefaultTask() {
+
+    /** The path of the project being reported, e.g. `:shared-core`. */
+    @get:Internal public abstract val projectPath: Property<String>
+
+    /** Sorted leaf ids of the resolved selection (`resolvedSelection()`). */
+    @get:Internal public abstract val selectionIds: ListProperty<String>
+
+    /** Sorted leaf ids of the resolved supported set (`resolvedSupported()`). */
+    @get:Internal public abstract val supportedIds: ListProperty<String>
+
+    /** Whether this module ever called `supports { … }` (undeclared registers nothing). */
+    @get:Internal public abstract val supportsDeclared: Property<Boolean>
+
+    /** Sorted leaf ids of `selection ∩ supported` — what actually builds for this module. */
+    @get:Internal public abstract val registeredIds: ListProperty<String>
+
+    /** Human-readable label of the config layer the selection came from (see [OriginLabels]). */
+    @get:Internal public abstract val originLabel: Property<String>
+
+    /** Preset names the parser accepts, in curated declaration order. */
+    @get:Internal public abstract val presetNames: ListProperty<String>
+
+    /** Sorted canonical leaf ids the parser accepts. */
+    @get:Internal public abstract val leafIds: ListProperty<String>
+
+    @TaskAction
+    public fun report() {
+        println(
+            formatKmpTargetsInfo(
+                projectPath = projectPath.get(),
+                selectionIds = selectionIds.get(),
+                supportedIds = supportedIds.get(),
+                supportsDeclared = supportsDeclared.get(),
+                registeredIds = registeredIds.get(),
+                originLabel = originLabel.get(),
+                presetNames = presetNames.get(),
+                leafIds = leafIds.get(),
+            )
+        )
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/OriginLabels.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/OriginLabels.kt
@@ -1,0 +1,45 @@
+package com.rsicarelli.kmptargets.info
+
+import com.rsicarelli.kmptargets.source.ConfigKeys
+
+/**
+ * Canonical human-readable labels for every layer of the global config precedence chain, printed by
+ * `kmpTargetsInfo` as the selection's origin. The labels mirror the chain composed by
+ * `labeledSources` in `KmpTargetsPlugin` (highest first): CLI `-P` → env → personal file →
+ * committed file → `gradle.properties` → `local.properties`, then the two fallbacks when no layer
+ * provides a non-blank value. The dedicated config files are labeled by their file names
+ * ([ConfigKeys.LOCAL_FILE] / [ConfigKeys.COMMITTED_FILE]) directly at the composition site.
+ *
+ * Adding a future config layer means adding its label here and its entry to `labeledSources` —
+ * nothing else.
+ */
+internal object OriginLabels {
+
+    /** The eagerly read CLI start parameter — a genuine `-P<key>=…` on the command line. */
+    fun cli(key: String): String = "command line (-P$key)"
+
+    /** Gradle's native `ORG_GRADLE_PROJECT_<key>` env→project-property mapping. */
+    fun environmentVariable(key: String): String =
+        "environment variable ${ConfigKeys.ENV_PREFIX}$key"
+
+    /**
+     * The fused `providers.gradleProperty` layer. CLI and env are caught by the dedicated layers
+     * above it, but this provider cannot tell the remaining origins apart — root
+     * `gradle.properties`, `-Dorg.gradle.project.<key>`, and `~/.gradle/gradle.properties` all
+     * resolve here — so the label names the whole group.
+     */
+    fun gradleProperties(key: String): String =
+        "gradle.properties (also -Dorg.gradle.project.$key and ~/.gradle/gradle.properties)"
+
+    const val LOCAL_PROPERTIES: String = "local.properties"
+
+    /**
+     * No config layer provided a value and `defaultSelection` holds `all`. The Property API cannot
+     * distinguish an explicit `defaultSelection.set(KmpTargetSet.all)` from the untouched
+     * convention; both report as built-in, which is value-identical and therefore still truthful.
+     */
+    const val DEFAULT_BUILTIN: String = "built-in default (all)"
+
+    /** No config layer provided a value; build logic overrode `defaultSelection`. */
+    const val DEFAULT_BUILD_LOGIC: String = "defaultSelection (build-logic)"
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParser.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/KmpTargetsParser.kt
@@ -45,7 +45,7 @@ public fun parseKmpTargets(raw: String, registry: Set<KmpTarget> = KmpTarget.all
     val presets: Map<String, KmpTargetSet> = PRESETS
 
     val knownNames: Set<String> =
-        registry.flatMap { target -> listOf(target.id) + target.aliases }.toSet() + PRESET_NAMES
+        registry.flatMap { target -> listOf(target.id) + target.aliases }.toSet() + presetNames
 
     var accumulator = KmpTargetSet.empty
     for (rawToken in tokens) {
@@ -95,7 +95,12 @@ private val PRESETS_BY_NAME: Map<String, KmpTargetSet> =
 
 private val PRESETS: Map<String, KmpTargetSet> = PRESETS_BY_NAME.mapKeys { it.key.lowercase() }
 
-private val PRESET_NAMES: Set<String> = PRESETS_BY_NAME.keys
+/**
+ * The preset names the parser accepts, in declaration order (curated to read sensibly: `all`
+ * first). Shared with `kmpTargetsInfo` so the printed vocabulary can never drift from what
+ * [parseKmpTargets] actually resolves.
+ */
+internal val presetNames: List<String> = PRESETS_BY_NAME.keys.toList()
 
 /**
  * Lowercase family names users commonly try to use as selectors. None of them resolve to a leaf,

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
@@ -1,0 +1,112 @@
+package com.rsicarelli.kmptargets.info
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.parser.presetNames
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class KmpTargetsInfoFormatTest {
+
+    @Test
+    fun `given a populated report when formatted then all sections appear with their values`() {
+        val output =
+            format(
+                selectionIds = listOf("androidTarget", "iosArm64"),
+                supportedIds = listOf("androidTarget", "iosArm64", "jvm"),
+                supportsDeclared = true,
+                registeredIds = listOf("androidTarget", "iosArm64"),
+                originLabel = "command line (-Pkmptargets.targets)",
+            )
+        assertContains(output, "kmp-targets — :shared-core")
+        assertContains(output, "Selection (what to build now)")
+        assertContains(output, "source:   command line (-Pkmptargets.targets)")
+        assertContains(output, "Supported (what this module can build)")
+        assertContains(output, "declared: yes")
+        assertContains(output, "androidTarget, iosArm64, jvm")
+        assertContains(output, "Registered (selection ∩ supported)")
+        assertContains(output, "Vocabulary")
+    }
+
+    @Test
+    fun `given supports never declared when formatted then the output states the module registers nothing`() {
+        val output =
+            format(
+                selectionIds = listOf("jvm"),
+                supportedIds = emptyList(),
+                supportsDeclared = false,
+                registeredIds = emptyList(),
+            )
+        assertContains(
+            output,
+            "declared: no — this module never called supports { }; it registers no targets",
+        )
+        assertContains(output, "(none — no supported targets declared)")
+    }
+
+    @Test
+    fun `given disjoint selection and supported when formatted then the empty intersection is explicit`() {
+        val output =
+            format(
+                selectionIds = listOf("wasmJs"),
+                supportedIds = listOf("jvm"),
+                supportsDeclared = true,
+                registeredIds = emptyList(),
+            )
+        assertContains(
+            output,
+            "(none — the selection matches nothing this module supports; nothing registers)",
+        )
+    }
+
+    @Test
+    fun `given a selection narrowed to nothing when formatted then the empty selection is explicit`() {
+        val output =
+            format(
+                selectionIds = emptyList(),
+                supportedIds = listOf("jvm"),
+                supportsDeclared = true,
+                registeredIds = emptyList(),
+            )
+        assertContains(output, "targets:  (none — the selection narrows to nothing)")
+        // The registered section reuses the selection explanation, not the disjoint one.
+        assertFalse("matches nothing this module supports" in output, output)
+    }
+
+    @Test
+    fun `given the vocabulary when formatted then every preset name and leaf id is present`() {
+        val output = format()
+        presetNames.forEach { preset ->
+            assertContains(output, preset, false, "missing preset '$preset' in:\n$output")
+        }
+        KmpTarget.all.forEach { leaf ->
+            assertContains(output, leaf.id, false, "missing leaf '${leaf.id}' in:\n$output")
+        }
+    }
+
+    @Test
+    fun `given the report when formatted then it never references Project state beyond the passed path`() {
+        // Guard for the config-cache contract: the formatter is a pure function of primitives, so
+        // its output for identical inputs is identical.
+        assertTrue(format() == format())
+    }
+
+    private fun format(
+        selectionIds: List<String> = listOf("jvm"),
+        supportedIds: List<String> = listOf("jvm"),
+        supportsDeclared: Boolean = true,
+        registeredIds: List<String> = listOf("jvm"),
+        originLabel: String = "built-in default (all)",
+    ): String =
+        formatKmpTargetsInfo(
+            projectPath = ":shared-core",
+            selectionIds = selectionIds,
+            supportedIds = supportedIds,
+            supportsDeclared = supportsDeclared,
+            registeredIds = registeredIds,
+            originLabel = originLabel,
+            presetNames = presetNames,
+            leafIds = KmpTarget.all.map { it.id }.sorted(),
+        )
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFunctionalTest.kt
@@ -1,0 +1,86 @@
+package com.rsicarelli.kmptargets.info
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Functional (TestKit) proof of what in-process tests cannot exercise: the `kmpTargetsInfo` task
+ * running through Gradle's real launcher with the configuration cache on.
+ *
+ * - The second invocation must be a configuration-cache HIT — the task's inputs are primitives
+ *   resolved at configuration time, so nothing in it can poison the cache entry (issue #33).
+ * - A build that never requests the task must also store cleanly — lazy registration means the
+ *   unrequested task is never configured, so its providers never realize (the isolated-projects
+ *   sample relies on this).
+ *
+ * Kept to the minimum because TestKit forks a real build per case.
+ */
+class KmpTargetsInfoFunctionalTest {
+
+    @Test
+    fun `given configuration cache enabled when kmpTargetsInfo runs twice then the second run reuses the cache entry`(
+        @TempDir dir: Path
+    ) {
+        writeFixture(dir)
+        val first = runner(dir).build()
+        assertTrue("Configuration cache entry stored." in first.output, first.output)
+        val second = runner(dir).build()
+        assertTrue("Reusing configuration cache." in second.output, second.output)
+        assertTrue("kmp-targets — :" in second.output, second.output)
+    }
+
+    @Test
+    fun `given selection via -P mobile when kmpTargetsInfo runs then the output names the mobile leaves and the command line source`(
+        @TempDir dir: Path
+    ) {
+        writeFixture(dir)
+        val result = runner(dir, "kmpTargetsInfo", "-q", "-Pkmptargets.targets=mobile").build()
+        assertTrue(
+            "androidTarget, iosArm64, iosSimulatorArm64, iosX64" in result.output,
+            result.output,
+        )
+        assertTrue("source:   command line (-Pkmptargets.targets)" in result.output, result.output)
+    }
+
+    @Test
+    fun `given selection via ORG_GRADLE_PROJECT env var when kmpTargetsInfo runs then the output names the environment source`(
+        @TempDir dir: Path
+    ) {
+        writeFixture(dir)
+        val result =
+            runner(dir, "kmpTargetsInfo", "-q")
+                .withEnvironment(mapOf("ORG_GRADLE_PROJECT_kmptargets.targets" to "jvm"))
+                .build()
+        assertTrue(
+            "source:   environment variable ORG_GRADLE_PROJECT_kmptargets.targets" in result.output,
+            result.output,
+        )
+    }
+
+    @Test
+    fun `given a build that never requests the info task when run with configuration cache then the entry stores cleanly`(
+        @TempDir dir: Path
+    ) {
+        writeFixture(dir)
+        val result = runner(dir, "help", "--configuration-cache").build()
+        assertTrue("Configuration cache entry stored." in result.output, result.output)
+    }
+
+    private fun writeFixture(dir: Path) {
+        dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
+        dir.resolve("build.gradle.kts").writeText("plugins { id(\"com.rsicarelli.kmptargets\") }\n")
+    }
+
+    private fun runner(dir: Path, vararg arguments: String): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(dir.toFile())
+            .withPluginClasspath()
+            .withArguments(
+                *(arguments.takeIf { it.isNotEmpty() }
+                    ?: arrayOf("kmpTargetsInfo", "--configuration-cache"))
+            )
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTaskTest.kt
@@ -1,0 +1,191 @@
+package com.rsicarelli.kmptargets.info
+
+import com.rsicarelli.kmptargets.KmpTargetsExtension
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import com.rsicarelli.kmptargets.parser.presetNames
+import com.rsicarelli.kmptargets.source.ConfigKeys
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * In-process proof of the `kmpTargetsInfo` wiring: the task's inputs are plain `String` primitives,
+ * realized lazily, that reflect the post-body state of the extension and the config-layer origin
+ * that won. KGP is never applied here — the report must work (and be explicit about "nothing
+ * registers") without it.
+ */
+class KmpTargetsInfoTaskTest {
+
+    private val mobileIds = listOf("androidTarget", "iosArm64", "iosSimulatorArm64", "iosX64")
+    private val allIds = KmpTarget.all.map { it.id }.sorted()
+
+    @Test
+    fun `given no selection source and no defaultSelection override when info task is realized then selection is all and origin is the built-in default`(
+        @TempDir dir: Path
+    ) {
+        val task = infoTask(newAppliedProject(dir))
+        assertEquals(allIds, task.selectionIds.get())
+        assertEquals(OriginLabels.DEFAULT_BUILTIN, task.originLabel.get())
+    }
+
+    @Test
+    fun `given defaultSelection overridden after apply when info task is realized then origin is the build-logic default`(
+        @TempDir dir: Path
+    ) {
+        val project = newAppliedProject(dir)
+        // Build-script-body timing: the override happens AFTER apply, so the origin label must be
+        // resolved lazily to see it.
+        project.extensions
+            .getByType(KmpTargetsExtension::class.java)
+            .defaultSelection
+            .set(KmpTargetSet.web)
+        val task = infoTask(project)
+        assertEquals(listOf("js", "wasmJs", "wasmWasi"), task.selectionIds.get())
+        assertEquals(OriginLabels.DEFAULT_BUILD_LOGIC, task.originLabel.get())
+    }
+
+    @Test
+    fun `given selection via cli property when info task is realized then origin is the command line and selection is the mobile leaves`(
+        @TempDir dir: Path
+    ) {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.gradle.startParameter.projectProperties = mapOf(ConfigKeys.TARGETS to "mobile")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val task = infoTask(project)
+        assertEquals(mobileIds, task.selectionIds.get())
+        assertEquals(OriginLabels.cli(ConfigKeys.TARGETS), task.originLabel.get())
+    }
+
+    @Test
+    fun `given selection only in local properties when info task is realized then origin is local properties`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("local.properties").writeText("kmptargets.targets=jvm\n")
+        val task = infoTask(newAppliedProject(dir))
+        assertEquals(listOf("jvm"), task.selectionIds.get())
+        assertEquals(OriginLabels.LOCAL_PROPERTIES, task.originLabel.get())
+    }
+
+    @Test
+    fun `given selection in gradle properties when info task is realized then origin is the fused gradle properties label`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val task = infoTask(newAppliedProject(dir))
+        assertEquals(OriginLabels.gradleProperties(ConfigKeys.TARGETS), task.originLabel.get())
+    }
+
+    @Test
+    fun `given selection in the committed config file when info task is realized then origin is that file name`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.targets=jvm\n")
+        val task = infoTask(newAppliedProject(dir))
+        assertEquals(ConfigKeys.COMMITTED_FILE, task.originLabel.get())
+    }
+
+    @Test
+    fun `given selection in the personal config file when info task is realized then origin is that file name and it beats the committed file`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.targets=android\n")
+        dir.resolve("kmp-targets.local.properties").writeText("kmptargets.targets=jvm\n")
+        val task = infoTask(newAppliedProject(dir))
+        assertEquals(listOf("jvm"), task.selectionIds.get())
+        assertEquals(ConfigKeys.LOCAL_FILE, task.originLabel.get())
+    }
+
+    @Test
+    fun `given a blank selection value when info task is realized then origin falls back to the built-in default`(
+        @TempDir dir: Path
+    ) {
+        // Blank shadows lower layers but does not override the default — the origin must say where
+        // the selection actually came from, not which layer happened to carry the blank.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=\n")
+        val task = infoTask(newAppliedProject(dir))
+        assertEquals(allIds, task.selectionIds.get())
+        assertEquals(OriginLabels.DEFAULT_BUILTIN, task.originLabel.get())
+    }
+
+    @Test
+    fun `given supports mobile and selection all when info task is realized then registered equals the mobile leaves`(
+        @TempDir dir: Path
+    ) {
+        val project = newAppliedProject(dir)
+        project.extensions.getByType(KmpTargetsExtension::class.java).supports { mobile }
+        val task = infoTask(project)
+        assertEquals(mobileIds, task.registeredIds.get())
+        assertEquals(mobileIds, task.supportedIds.get())
+        assertTrue(task.supportsDeclared.get())
+    }
+
+    @Test
+    fun `given supports called twice when info task is realized then supported reflects the union`(
+        @TempDir dir: Path
+    ) {
+        val project = newAppliedProject(dir)
+        val ext = project.extensions.getByType(KmpTargetsExtension::class.java)
+        // The info task is realized BEFORE the second union — its providers must still observe the
+        // final post-body state, not a snapshot taken at realization time.
+        val task = infoTask(project)
+        ext.supports { jvm }
+        ext.supports { web }
+        assertEquals(listOf("js", "jvm", "wasmJs", "wasmWasi"), task.supportedIds.get())
+    }
+
+    @Test
+    fun `given supports never declared when info task is realized then supported and registered are empty and declared is false`(
+        @TempDir dir: Path
+    ) {
+        val task = infoTask(newAppliedProject(dir))
+        assertEquals(emptyList(), task.supportedIds.get())
+        assertEquals(emptyList(), task.registeredIds.get())
+        assertFalse(task.supportsDeclared.get())
+    }
+
+    @Test
+    fun `given a selection disjoint from supported when info task is realized then registered is empty`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=wasmJs\n")
+        val project = newAppliedProject(dir)
+        project.extensions.getByType(KmpTargetsExtension::class.java).supports { jvm }
+        val task = infoTask(project)
+        assertEquals(emptyList(), task.registeredIds.get())
+        assertEquals(listOf("wasmJs"), task.selectionIds.get())
+        assertEquals(listOf("jvm"), task.supportedIds.get())
+    }
+
+    @Test
+    fun `given the info task when vocabulary inputs are read then they match the parser presets and every leaf id`(
+        @TempDir dir: Path
+    ) {
+        val task = infoTask(newAppliedProject(dir))
+        assertEquals(presetNames, task.presetNames.get())
+        assertEquals(allIds, task.leafIds.get())
+    }
+
+    @Test
+    fun `given the plugin applied without KGP when tasks are listed then kmpTargetsInfo exists in the help group`(
+        @TempDir dir: Path
+    ) {
+        val task = infoTask(newAppliedProject(dir))
+        assertEquals("help", task.group)
+    }
+
+    private fun newAppliedProject(dir: Path): Project {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        return project
+    }
+
+    private fun infoTask(project: Project): KmpTargetsInfoTask =
+        project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+}


### PR DESCRIPTION
Closes #33

## What

A per-project `kmpTargetsInfo` task (group `help`) that makes the plugin's resolution observable: resolved selection, **which config layer it came from**, declared supported set, registered intersection (`selection ∩ supported`), and the vocabulary the parser accepts.

```console
$ ./gradlew -p samples/hello-world :shared-core:kmpTargetsInfo -q

kmp-targets — :shared-core

Selection (what to build now)
  targets:  iosArm64, iosSimulatorArm64, jvm
  source:   kmp-targets.properties

Supported (what this module can build)
  declared: yes
  targets:  androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, androidTarget, iosArm64, iosSimulatorArm64, iosX64, js, jvm, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64

Registered (selection ∩ supported)
  targets:  iosArm64, iosSimulatorArm64, jvm

Vocabulary
  presets:  all, native, appleMobile, appleDesktop, appleWatch, appleTv, apple, linux, mingw, windows, androidNative, web, jvmFamily, mobile
  leaves:   androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, androidTarget, iosArm64, iosSimulatorArm64, iosX64, js, jvm, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64 (25)
```

With `-Pkmptargets.targets=appleMobile,jvm` the source line flips to `command line (-Pkmptargets.targets)`.

## How

- **Origin can't drift from value resolution:** the precedence chain in `KmpTargetsPlugin` is now built from one labeled list (`labeledSources`); `configSources` composes from it and the origin walk reads it. Adding a future config layer is a single added entry. Value semantics are byte-for-byte (first-non-null short-circuit, blank shadows lower layers but yields no origin — the report then names the `defaultSelection`/built-in fallback). The fused `gradleProperty` layer's coarseness (`-Dorg.gradle.project.*`, `~/.gradle/gradle.properties`) is stated in the label itself.
- **Timing under the eager model:** the task registers lazily at apply time, but its inputs are providers mapped straight to sorted-id `String` lists — Gradle realizes them at task-graph calculation, after the build body ran every `supports { }` union. No `afterEvaluate`; only primitives reach the action and the configuration cache. The fallback origin label is resolved lazily too (the body may override `defaultSelection` after apply).
- **Pure report:** only `resolvedSelection()`/`resolvedSupported()` reads — it can never register targets as a side effect. Works without KGP; undeclared `supports`, narrowed-to-nothing selections, and disjoint sets each print their own explicit explanation.
- **Shared vocabulary:** `presetNames` is exposed from the parser so the printed presets always match what `parseKmpTargets` accepts.

## Tests

- Formatter unit tests (pure, Gradle-free): every explicit-empty case + full vocabulary.
- In-process wiring tests: every origin layer (CLI, env-fallback layers, both dedicated files, `gradle.properties`, `local.properties`, blank-shadowing, both defaults), registered intersection, union-after-task-realization timing, declared/undeclared.
- TestKit: **configuration-cache HIT on the second `kmpTargetsInfo` run**, `-P` output through the real launcher, env-var origin, and a clean CC store when the task is never requested (lazy registration ⇒ nothing leaks; covers the isolated-projects sample).

`task ci` green (plugin check + hello-world + isolated-projects samples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)