### PR TITLE
feat: add opt-in strict mode promoting selection/host warnings to failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,32 @@ be skipped here.
 The warning is purely advisory and fires at most once per target per module. JVM and Web targets
 (`androidTarget`, `jvm`, `js`, `wasmJs`, `wasmWasi`) are host-agnostic and never warned.
 
+### Strict mode
+
+By default both advisories — the **empty-overlap** warning (a non-empty selection that matches
+nothing a module `supports`, so the module registers zero targets) and the **host-impossible**
+warning above — are just that: warnings. Right for local iteration, easy to miss in CI, where a
+module silently building nothing is usually a real configuration bug.
+
+`kmptargets.strict=true` promotes exactly those two advisories to configuration-time **build
+failures** (`GradleException`) with the **identical message text** — severity changes, policy does
+not. It never changes *which* configurations are flagged and never changes *what registers*.
+Default **off**, deliberately. The flag resolves through the same
+[precedence chain](#selecting-targets) as every `kmptargets.*` key; anything other than
+`true`/`false` (case-insensitive) is treated as unset, i.e. off.
+
+The recommended setup keeps local builds advisory and turns CI strict:
+
+```yaml
+# CI only — e.g. a GitHub Actions env block
+env:
+  ORG_GRADLE_PROJECT_kmptargets.strict: "true"   # or: ./gradlew build -Pkmptargets.strict=true
+```
+
+> **Heads-up for cross-host CI:** with strict on, a selection that includes targets the agent
+> cannot compile (e.g. iOS leaves on a Linux runner) fails the build by design. Strict CI pairs
+> with per-host selections (e.g. `-Pkmptargets.targets=linux,jvm,web` on Linux agents).
+
 ## Installation
 
 The plugin is not yet published to the Gradle Plugin Portal or Maven Central. Track progress in the issues / releases. Locally:

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -3,8 +3,7 @@ package com.rsicarelli.kmptargets
 import com.rsicarelli.kmptargets.hierarchy.computeHierarchySpec
 import com.rsicarelli.kmptargets.hierarchy.resolveHierarchyTemplateEnabled
 import com.rsicarelli.kmptargets.hierarchy.toTemplate
-import com.rsicarelli.kmptargets.host.hostImpossibleWarning
-import com.rsicarelli.kmptargets.host.impossibleOnHost
+import com.rsicarelli.kmptargets.host.enforceHostCompatibility
 import com.rsicarelli.kmptargets.info.KmpTargetsInfoTask
 import com.rsicarelli.kmptargets.info.OriginLabels
 import com.rsicarelli.kmptargets.model.KmpTarget
@@ -65,6 +64,10 @@ public class KmpTargetsPlugin : Plugin<Project> {
         val globalHierarchyEnabled: Boolean? =
             hierarchyTemplateEnabledGlobally(target, personal, committed)
 
+        // Strict mode (#34): opt-in promotion of the selection/host advisories to failures, read
+        // once at apply time as a primitive Boolean (default off) so no `Project` is captured.
+        val strict: Boolean = strictModeEnabled(target, personal, committed)
+
         // Eager registration: `supports { … }` in the build-script body registers `selection ∩
         // supported` immediately — no deferred (after-evaluate) pass, no timing wall. We hook it
         // via
@@ -74,7 +77,7 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // cache.
         ext.onSupports = {
             target.pluginManager.withPlugin(KGP_ID) {
-                register(target, ext, globalHierarchyEnabled)
+                register(target, ext, globalHierarchyEnabled, strict)
             }
         }
 
@@ -197,6 +200,22 @@ public class KmpTargetsPlugin : Plugin<Project> {
             ?.lowercase()
             ?.toBooleanStrictOrNull()
 
+    /**
+     * Reads the global `kmptargets.strict` flag through the standard [configSources] chain.
+     * Deliberately opt-in: unset — or anything other than `true`/`false` (case-insensitive, per
+     * `toBooleanStrictOrNull`) — means OFF, the advisory-only behavior.
+     */
+    private fun strictModeEnabled(
+        target: Project,
+        personal: Map<String, String>?,
+        committed: Map<String, String>?,
+    ): Boolean =
+        configSources(target, ConfigKeys.STRICT, personal, committed)
+            .read()
+            ?.trim()
+            ?.lowercase()
+            ?.toBooleanStrictOrNull() ?: false
+
     /** The parsed entries of a dedicated config file in the root directory, or `null` if absent. */
     private fun configFile(target: Project, fileName: String): Map<String, String>? =
         target.providers
@@ -245,11 +264,17 @@ public class KmpTargetsPlugin : Plugin<Project> {
      * and applies the minimal hierarchy template — all off the cumulative supported set, so
      * repeated `supports` calls only register the delta (idempotent), each host warning names a
      * leaf at most once, and the template still applies at most once.
+     *
+     * When [strict] is on (#34), both advisories fail the build instead of warning — with the
+     * identical message text. Severity changes; policy does not: `shouldWarnEmptyOverlap` and
+     * `impossibleOnHost` stay the single source of truth for *whether* to flag, and what registers
+     * is never affected.
      */
     private fun register(
         project: Project,
         ext: KmpTargetsExtension,
         globalHierarchyEnabled: Boolean?,
+        strict: Boolean,
     ) {
         val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
         val selection = ext.resolvedSelection()
@@ -260,30 +285,34 @@ public class KmpTargetsPlugin : Plugin<Project> {
             ext.registered.add(leaf)
         }
 
-        // Advisory only: the selection is non-empty yet genuinely disjoint from the supported set,
-        // so nothing registers. Keyed off the actual overlap (not "nothing registered"), so the
-        // message can never name a token present in both lists (issue #10).
+        // The selection is non-empty yet genuinely disjoint from the supported set, so nothing
+        // registers. Keyed off the actual overlap (not "nothing registered"), so the message can
+        // never name a token present in both lists (issue #10). Safe to fail here under strict:
+        // the intersection is empty, so no target half-registered before the throw.
         if (shouldWarnEmptyOverlap(selection, supported)) {
-            project.logger.warn(emptyOverlapWarning(project.path, selection, supported))
+            warnOrFail(strict, emptyOverlapWarning(project.path, selection, supported)) {
+                project.logger.warn(it)
+            }
         }
 
-        // Host-awareness (#32): advisory only — names registered native targets this host cannot
-        // compile, never changing what registers (the set stays identical across hosts).
-        // HostManager is touched only here, inside `withPlugin(KGP_ID)` at configuration time, so
-        // its classes never load when KGP is absent and nothing host-derived is held by a task
-        // action. Deduped per leaf via `hostWarned`, so a later `supports` union that introduces a
-        // new impossible leaf still warns — for that leaf only.
-        val fresh = impossibleOnHost(active, HostManager().enabled.toSet()).members - ext.hostWarned
-        if (fresh.isNotEmpty()) {
-            project.logger.warn(
-                hostImpossibleWarning(
-                    project.path,
-                    HostManager.host,
-                    KmpTargetSet.of(*fresh.toTypedArray()),
-                )
-            )
-            ext.hostWarned += fresh
-        }
+        // Host-awareness (#32): names registered native targets this host cannot compile, never
+        // changing what registers (the set stays identical across hosts). HostManager is touched
+        // only here, inside `withPlugin(KGP_ID)` at configuration time, so its classes never load
+        // when KGP is absent and nothing host-derived is held by a task action. Deduped per leaf
+        // via `hostWarned`, so a later `supports` union that introduces a new impossible leaf
+        // still flags — for that leaf only. The decision lives behind an enabled-set parameter
+        // (`enforceHostCompatibility`) so strict-mode tests can simulate any host.
+        ext.hostWarned +=
+            enforceHostCompatibility(
+                path = project.path,
+                active = active,
+                enabled = HostManager().enabled.toSet(),
+                host = HostManager.host,
+                alreadyWarned = ext.hostWarned,
+                strict = strict,
+            ) {
+                project.logger.warn(it)
+            }
 
         maybeApplyHierarchyTemplate(project, ext, active, globalHierarchyEnabled)
     }
@@ -344,6 +373,16 @@ public class KmpTargetsPlugin : Plugin<Project> {
             KmpTarget.Web.WasmWasi -> kotlin.wasmWasi { nodejs() }
         }
     }
+}
+
+/**
+ * Strict mode's single escalation point (#34): warn when [strict] is off — byte-for-byte the
+ * advisory behavior — and fail with the **same** [message] when on. Severity changes; the decision
+ * of *whether* to flag stays with the callers' policy functions.
+ */
+internal fun warnOrFail(strict: Boolean, message: String, warn: (String) -> Unit) {
+    if (strict) throw GradleException(message)
+    warn(message)
 }
 
 /**

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/host/HostCompatibility.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/host/HostCompatibility.kt
@@ -2,6 +2,7 @@ package com.rsicarelli.kmptargets.host
 
 import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
+import com.rsicarelli.kmptargets.warnOrFail
 import org.jetbrains.kotlin.konan.target.KonanTarget
 
 /**
@@ -63,3 +64,33 @@ internal fun hostImpossibleWarning(
     "kmp-targets: '$path' selects ${impossible.members.map { it.id }.sorted()} which cannot be " +
         "compiled on this host (${host.name.uppercase()}) — still registered (selection is " +
         "host-independent), but compile/link tasks for them will fail or be skipped here."
+
+/**
+ * The host-advisory step of registration, behind an injected [enabled] set so strict-mode tests can
+ * simulate any host (on a macOS machine nothing is host-impossible, so the real path can never be
+ * triggered deterministically in-process).
+ *
+ * Computes the freshly-flagged leaves — [impossibleOnHost] minus [alreadyWarned] — and escalates
+ * them through [warnOrFail]: advisory when [strict] is off, `GradleException` with the identical
+ * [hostImpossibleWarning] text when on. Returns the fresh set for the caller's dedup bookkeeping
+ * (an empty fresh set is a silent no-op, so a leaf is flagged at most once per build). Policy stays
+ * owned by [impossibleOnHost]/[hostImpossibleWarning]; this only sequences decision → severity.
+ */
+internal fun enforceHostCompatibility(
+    path: String,
+    active: KmpTargetSet,
+    enabled: Set<KonanTarget>,
+    host: KonanTarget,
+    alreadyWarned: Set<KmpTarget>,
+    strict: Boolean,
+    warn: (String) -> Unit,
+): Set<KmpTarget> {
+    val fresh = impossibleOnHost(active, enabled).members - alreadyWarned
+    if (fresh.isEmpty()) return emptySet()
+    warnOrFail(
+        strict,
+        hostImpossibleWarning(path, host, KmpTargetSet.of(*fresh.toTypedArray())),
+        warn,
+    )
+    return fresh
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
@@ -13,8 +13,14 @@ internal object ConfigKeys {
     /** Global opt-out for the minimal hierarchy template (`true`/`false`). */
     const val HIERARCHY_TEMPLATE: String = "kmptargets.hierarchyTemplate"
 
+    /**
+     * Global opt-in promoting the selection/host advisories to build failures (`true`/`false`,
+     * default off — issue #34).
+     */
+    const val STRICT: String = "kmptargets.strict"
+
     /** Every key the dedicated config files may legally contain (unknown keys fail the build). */
-    val ALL: Set<String> = setOf(TARGETS, HIERARCHY_TEMPLATE)
+    val ALL: Set<String> = setOf(TARGETS, HIERARCHY_TEMPLATE, STRICT)
 
     /** Committed, team-shared config file at the root of the build. */
     const val COMMITTED_FILE: String = "kmp-targets.properties"

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsStrictModeFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsStrictModeFunctionalTest.kt
@@ -1,0 +1,51 @@
+package com.rsicarelli.kmptargets
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Functional (TestKit) proof of strict mode's configuration-cache contract, which in-process tests
+ * cannot exercise: the flag is read once at apply time as a primitive `Boolean` (never capturing
+ * `Project`), so a healthy configuration with strict ON must store a configuration-cache entry and
+ * reuse it on the second run. KGP is applied for real here — the strict branch lives inside the
+ * eager registration that only runs under `withPlugin(KGP)`.
+ *
+ * Kept to the minimum (one fixture, two builds) because a KGP-resolving TestKit build is the most
+ * expensive kind.
+ */
+class KmpTargetsStrictModeFunctionalTest {
+
+    @Test
+    fun `given strict on and a healthy configuration when the build runs twice with configuration cache then the second run reuses the entry`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm\nkmptargets.strict=true\n")
+        dir.resolve("build.gradle.kts")
+            .writeText(
+                """
+                plugins {
+                    id("org.jetbrains.kotlin.multiplatform")
+                    id("com.rsicarelli.kmptargets")
+                }
+
+                kmpTargets { supports { jvm } }
+                """
+                    .trimIndent()
+            )
+        val runner =
+            GradleRunner.create()
+                .withProjectDir(dir.toFile())
+                .withPluginClasspath()
+                .withArguments("help", "--configuration-cache")
+        val first = runner.build()
+        assertTrue("Configuration cache entry stored." in first.output, first.output)
+        val second = runner.build()
+        assertTrue("Reusing configuration cache." in second.output, second.output)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsStrictModeTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsStrictModeTest.kt
@@ -1,0 +1,133 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Strict mode (`kmptargets.strict`): the opt-in that promotes the empty-overlap advisory to a
+ * `GradleException` at the eager registration point. KGP is applied BEFORE `supports { … }` is
+ * called directly on the extension, so the failure propagates unwrapped from the `supports` call
+ * and the message can be asserted for verbatim equality with [emptyOverlapWarning]. Default OFF —
+ * behavior without the flag must be byte-for-byte the advisory-only path.
+ *
+ * The host-impossible strict path is covered deterministically through the pure seam in
+ * `host/EnforceHostCompatibilityTest` (a real host that can compile everything would never trigger
+ * it here).
+ */
+class KmpTargetsStrictModeTest {
+
+    @Test
+    fun `given strict off by default and a disjoint selection when supports is declared then configuration succeeds and registers nothing`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=wasmJs\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { jvm }
+        assertEquals(emptySet(), registeredTargets(project))
+    }
+
+    @Test
+    fun `given strict on and a disjoint selection when supports is declared then the build fails with the empty-overlap text`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=wasmJs\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val ex = assertFailsWith<GradleException> { ext(project).supports { jvm } }
+        assertEquals(
+            emptyOverlapWarning(
+                path = project.path,
+                selection = KmpTargetSet.of(KmpTarget.Web.WasmJs),
+                supported = KmpTargetSet.of(KmpTarget.Jvm.Desktop),
+            ),
+            ex.message,
+        )
+    }
+
+    @Test
+    fun `given strict on and an overlapping selection when supports is declared then configuration succeeds and registers the intersection`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm,wasmJs\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { jvm }
+        assertEquals(setOf("jvm"), registeredTargets(project))
+    }
+
+    @Test
+    fun `given a non-boolean strict value and a disjoint selection when supports is declared then strict is treated as off`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=wasmJs\nkmptargets.strict=yes\n")
+        val project = newProjectWithKgp(dir)
+        // `yes` is not a strict boolean → unset → OFF: advisory only, no failure.
+        ext(project).supports { jvm }
+        assertEquals(emptySet(), registeredTargets(project))
+    }
+
+    @Test
+    fun `given strict false in gradle properties and true in local properties when disjoint then the gradle property wins and it does not fail`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=wasmJs\nkmptargets.strict=false\n")
+        dir.resolve("local.properties").writeText("kmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { jvm }
+        assertEquals(emptySet(), registeredTargets(project))
+    }
+
+    @Test
+    fun `given strict enabled via the committed config file when disjoint then the build fails`(
+        @TempDir dir: Path
+    ) {
+        // Also proves kmptargets.strict is a known key for the dedicated files' fail-loud
+        // validation — an unknown key would already fail at apply with a did-you-mean error.
+        dir.resolve("kmp-targets.properties")
+            .writeText("kmptargets.targets=wasmJs\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        assertFailsWith<GradleException> { ext(project).supports { jvm } }
+    }
+
+    @Test
+    fun `given strict enabled via the cli property when disjoint then the build fails`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=wasmJs\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.gradle.startParameter.projectProperties = mapOf("kmptargets.strict" to "true")
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        assertFailsWith<GradleException> { ext(project).supports { jvm } }
+    }
+
+    private fun newProjectWithKgp(dir: Path): Project {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        return project
+    }
+
+    private fun ext(project: Project): KmpTargetsExtension =
+        project.extensions.getByType(KmpTargetsExtension::class.java)
+
+    private fun registeredTargets(project: Project): Set<String> =
+        project.extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .names
+            .filter { it != "metadata" }
+            .toSet()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/host/EnforceHostCompatibilityTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/host/EnforceHostCompatibilityTest.kt
@@ -1,0 +1,124 @@
+package com.rsicarelli.kmptargets.host
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import org.gradle.api.GradleException
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.junit.jupiter.api.Test
+
+/**
+ * Strict-mode escalation of the host advisory, tested through the pure seam: the enabled-target set
+ * is injected, so every case simulates a host deterministically — no test here may depend on what
+ * the machine running the suite can compile (on macOS nothing is host-impossible, which is exactly
+ * why the seam exists). Policy stays owned by [impossibleOnHost] / [hostImpossibleWarning]; this
+ * suite only proves the warn↔fail severity switch and that both carry the identical message.
+ */
+class EnforceHostCompatibilityTest {
+
+    /** A Linux x64 host: Linux, MinGW and Android NDK cross-compile; Apple does not. */
+    private val linuxEnabled: Set<KonanTarget> =
+        setOf(
+            KonanTarget.LINUX_X64,
+            KonanTarget.LINUX_ARM64,
+            KonanTarget.MINGW_X64,
+            KonanTarget.ANDROID_ARM32,
+            KonanTarget.ANDROID_ARM64,
+            KonanTarget.ANDROID_X86,
+            KonanTarget.ANDROID_X64,
+        )
+
+    /** A macOS host: every Kotlin/Native target compiles. */
+    private val macEnabled: Set<KonanTarget> =
+        KmpTargetSet.native.members.mapNotNull(::konanTargetOf).toSet()
+
+    private val iosArm64 = KmpTarget.Native.Apple.Ios.Arm64
+    private val tvosArm64 = KmpTarget.Native.Apple.Tvos.Arm64
+
+    @Test
+    fun `given strict on and an impossible target on a simulated linux host when enforced then it fails with the exact warning text`() {
+        val ex =
+            assertFailsWith<GradleException> {
+                enforce(active = KmpTargetSet.of(iosArm64), strict = true)
+            }
+        assertEquals(
+            hostImpossibleWarning(":lib", KonanTarget.LINUX_X64, KmpTargetSet.of(iosArm64)),
+            ex.message,
+        )
+    }
+
+    @Test
+    fun `given strict off and an impossible target on a simulated linux host when enforced then it warns with the same text and returns the fresh set`() {
+        val warnings = mutableListOf<String>()
+        val fresh =
+            enforce(active = KmpTargetSet.of(iosArm64), strict = false, warn = warnings::add)
+        assertEquals(setOf<KmpTarget>(iosArm64), fresh)
+        assertEquals(
+            listOf(hostImpossibleWarning(":lib", KonanTarget.LINUX_X64, KmpTargetSet.of(iosArm64))),
+            warnings,
+        )
+    }
+
+    @Test
+    fun `given an already warned leaf and a newly impossible leaf when enforced strict then the failure names only the fresh leaf`() {
+        val ex =
+            assertFailsWith<GradleException> {
+                enforce(
+                    active = KmpTargetSet.of(iosArm64, tvosArm64),
+                    alreadyWarned = setOf(iosArm64),
+                    strict = true,
+                )
+            }
+        assertEquals(
+            hostImpossibleWarning(":lib", KonanTarget.LINUX_X64, KmpTargetSet.of(tvosArm64)),
+            ex.message,
+        )
+    }
+
+    @Test
+    fun `given only already warned leaves when enforced strict then it neither fails nor warns and returns empty`() {
+        val warnings = mutableListOf<String>()
+        val fresh =
+            enforce(
+                active = KmpTargetSet.of(iosArm64),
+                alreadyWarned = setOf(iosArm64),
+                strict = true,
+                warn = warnings::add,
+            )
+        assertEquals(emptySet(), fresh)
+        assertTrue(warnings.isEmpty(), "expected no warnings, got: $warnings")
+    }
+
+    @Test
+    fun `given nothing impossible on a simulated mac host when enforced strict then it returns empty and never warns or fails`() {
+        val warnings = mutableListOf<String>()
+        val fresh =
+            enforce(
+                active = KmpTargetSet.of(iosArm64, tvosArm64),
+                enabled = macEnabled,
+                strict = true,
+                warn = warnings::add,
+            )
+        assertEquals(emptySet(), fresh)
+        assertTrue(warnings.isEmpty(), "expected no warnings, got: $warnings")
+    }
+
+    private fun enforce(
+        active: KmpTargetSet,
+        enabled: Set<KonanTarget> = linuxEnabled,
+        alreadyWarned: Set<KmpTarget> = emptySet(),
+        strict: Boolean,
+        warn: (String) -> Unit = { error("unexpected warning: $it") },
+    ): Set<KmpTarget> =
+        enforceHostCompatibility(
+            path = ":lib",
+            active = active,
+            enabled = enabled,
+            host = KonanTarget.LINUX_X64,
+            alreadyWarned = alreadyWarned,
+            strict = strict,
+            warn = warn,
+        )
+}

--- a/samples/hello-world/kmp-targets.properties
+++ b/samples/hello-world/kmp-targets.properties
@@ -7,3 +7,9 @@
 # template has something to collapse: iOS-supporting modules get a single `iosMain` (no redundant
 # `appleMain`/`nativeMain`), which is the whole point of the feature.
 kmptargets.targets=jvm,iosArm64,iosSimulatorArm64
+
+# Opt-in strict mode: promotes the empty-overlap and host-impossible advisories to build failures
+# (same message text). Left off here on purpose — this sample selects iOS leaves, so a non-mac
+# host running it under strict would fail by design. Enable per run to see it:
+#   ./gradlew help -Pkmptargets.strict=true -Pkmptargets.targets=web
+# kmptargets.strict=true


### PR DESCRIPTION
Closes #34

## What

An **opt-in** strict mode — one global toggle, `kmptargets.strict`, default **OFF** — that promotes the two configuration-time advisories to `GradleException` failures with the **identical message text**:

- **empty-overlap**: a non-empty selection disjoint from a module's `supports { … }` (the module would silently register zero targets)
- **host-impossible** (#32): selected native targets the current host cannot compile

Severity changes; policy does not. `shouldWarnEmptyOverlap` / `impossibleOnHost` remain the sole deciders of *whether* to flag, and **what registers never changes** — the #32 cross-host determinism invariant holds.

```console
$ ./gradlew help -Pkmptargets.strict=true -Pkmptargets.targets=web   # in samples/hello-world

* What went wrong:
kmp-targets: ':core-and-apple' supports [iosArm64, ..., watchosX64] but the selection [js, wasmJs, wasmWasi] matches none of them — registering no targets for this module.
```

Same run without the flag: 5 warnings, build succeeds — the default is byte-for-byte the previous behavior.

## How

- **`ConfigKeys.STRICT`** (`kmptargets.strict`), registered in `ALL` so the dedicated `kmp-targets(.local).properties` files accept it through the existing fails-loud unknown-key validation. Resolves through the standard 6-layer precedence chain, mirroring `kmptargets.hierarchyTemplate` (`toBooleanStrictOrNull()`; non-boolean values like `yes` mean unset → OFF). Read once at apply time as a primitive `Boolean`, riding the existing `onSupports` closure — config-cache safe, no `afterEvaluate`, no `Project` capture.
- **`warnOrFail(strict, message, warn)`** — the single escalation point both advisory sites route through, so warning and failure text can never drift apart (the ACs demand message equality, asserted verbatim in tests).
- **`enforceHostCompatibility(...)`** — the host-advisory step of `register(...)` extracted behind an injected enabled-target set: the deterministic test seam. On a macOS machine nothing is host-impossible, so the real strict-host path can never be triggered in-process; the seam lets tests simulate any host while `HostManager` stays touched only inside `withPlugin(KGP)`.
- Empty-overlap failing at the registration point is safe by construction: it only fires when `selection ∩ supported` is empty, so nothing half-registers before the throw.

## Tests (13 new; full suite green)

- **`EnforceHostCompatibilityTest`** (pure, simulated Linux/mac hosts): strict-ON throws with message equal to `hostImpossibleWarning(...)`; strict-OFF warns the same text and returns the fresh set; dedup names only freshly-impossible leaves; already-warned/healthy cases neither warn nor fail.
- **`KmpTargetsStrictModeTest`** (in-process, KGP applied): default-OFF disjoint only warns and registers nothing; strict-ON disjoint fails with message equal to `emptyOverlapWarning(...)`; healthy-under-strict succeeds and registers the intersection; non-boolean → OFF; `gradle.properties` beats `local.properties`; ON via committed config file (proving key validation accepts it); ON via `-P`.
- **`KmpTargetsStrictModeFunctionalTest`** (TestKit, real KGP): healthy strict-ON build stores a configuration-cache entry and **reuses** it on the second run.

`task ci` green (plugin check + hello-world + isolated-projects samples). `grep -rn afterEvaluate gradle-plugin/src/main` stays empty.

## Docs

README gains a `### Strict mode` section (default OFF, CI recommendation via `ORG_GRADLE_PROJECT_kmptargets.strict=true`, and a heads-up that strict + cross-host CI pairs with per-host selections). The sample's `kmp-targets.properties` documents the flag commented-out — enabling it for real would make a future non-mac CI sample run fail by design, since the sample selects iOS leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)