### PR TITLE
ci: add per-host KMP target matrix for the sample + consumer CI guidance

### DIFF
--- a/.github/workflows/sample-matrix.yml
+++ b/.github/workflows/sample-matrix.yml
@@ -1,0 +1,76 @@
+# Per-host KMP target matrix over the hello-world sample (issue #35): each runner builds only the
+# subset of targets it can host, selected via the SAME `kmptargets.targets` vocabulary developers
+# use locally — see the README "CI" section, which this workflow is the living, exercised example
+# for. Additive to ci.yml (the fast lane stays a single ubuntu `check` + samples job).
+#
+# Every job's selection must include BOTH `jvm` and `iosArm64`: the sample's
+# :eager-conventions:verifyEagerTargets regression gate asserts exactly [iosArm64, jvm] registers
+# for that module, and :feature-mobile supports only `mobile` (sample has no AGP, so an iOS leaf is
+# its only selectable shape). Registration is host-blind by design — selecting iosArm64 on
+# Linux/Windows registers it with an advisory and KGP disables its compile tasks there.
+#
+# Gradle comes from the committed wrapper (9.5.1) — no `gradle-version` override — and the JDK
+# matches .mise.toml (Temurin 23), so CI and local toolchains stay aligned.
+
+name: Sample matrix
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: sample-matrix-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sample:
+    name: sample (${{ matrix.os }})
+    strategy:
+      # A Windows konan hiccup must not cancel the macOS job — the one paying for real Apple
+      # compilation coverage that ci.yml's ubuntu fast lane can never have.
+      fail-fast: false
+      matrix:
+        include:
+          # Real Linux-native compilation. Web targets are deliberately left to the ubuntu job in
+          # ci.yml's `check` (kotlinNpmInstall's Node download is a flake vector with no
+          # host-specific signal). iosArm64 is gate-only here: registered, advisory-warned,
+          # compile tasks disabled on this host.
+          - os: ubuntu-latest
+            targets: jvm,iosArm64,linuxX64,linuxArm64
+          # The only host that can compile/link Apple targets — the job this workflow exists for.
+          - os: macos-latest
+            targets: appleMobile,jvm
+          # The only host for MinGW. iosArm64 is gate-only, as on ubuntu.
+          - os: windows-latest
+            targets: windows,jvm,iosArm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '23'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      # The samples are standalone builds that consume the plugin from mavenLocal.
+      - name: Publish plugin to Maven Local
+        run: ./gradlew publishToMavenLocal
+
+      # Diagnostic showcase: print what the plugin resolved for this host's selection.
+      # The -P flag is quoted because PowerShell (windows-latest) splits unquoted commas into
+      # an array — the quotes are harmless on bash.
+      - name: Show resolved targets (kmpTargetsInfo)
+        run: ./gradlew -p samples/hello-world :shared-core:kmpTargetsInfo -q "-Pkmptargets.targets=${{ matrix.targets }}"
+
+      - name: Build sample with host-appropriate selection
+        run: ./gradlew -p samples/hello-world build "-Pkmptargets.targets=${{ matrix.targets }}"

--- a/README.md
+++ b/README.md
@@ -313,7 +313,88 @@ env:
 
 > **Heads-up for cross-host CI:** with strict on, a selection that includes targets the agent
 > cannot compile (e.g. iOS leaves on a Linux runner) fails the build by design. Strict CI pairs
-> with per-host selections (e.g. `-Pkmptargets.targets=linux,jvm,web` on Linux agents).
+> with per-host selections — see [CI](#ci) for the matrix pattern.
+
+## CI
+
+Kotlin Multiplatform CI has a sharp cost asymmetry: on **private repositories**, GitHub Actions
+macOS runners bill at roughly **10x** the Ubuntu per-minute rate (public repos get standard runners
+free), and Apple/native compilation — the part that *requires* macOS — is the dominant slice of
+total CI time. The cost-aware, idiomatic pattern is an **OS × selection matrix**: each runner
+compiles only the subset of targets it can host, instead of every runner attempting (or wastefully
+cross-compiling) the full set.
+
+`kmp-targets` is purpose-built for this. The matrix passes a host-appropriate selection per job —
+and the values are **literally the same strings** a developer puts in `kmp-targets.local.properties`
+or `-Pkmptargets.targets` locally (see [Selecting targets](#selecting-targets) and the
+[Selection grammar](#selection-grammar)). CI never grows its own divergent selection language.
+
+```yaml
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            targets: jvm,android,web,linuxX64,linuxArm64,androidNative
+          - os: macos-latest
+            targets: apple
+          - os: windows-latest
+            targets: windows
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '23'
+      - uses: gradle/actions/setup-gradle@v6
+      # Quoted on purpose: PowerShell (windows-latest) splits unquoted commas into an array.
+      - run: ./gradlew build "-Pkmptargets.targets=${{ matrix.targets }}"
+```
+
+Host → target mapping:
+
+| Runner | `kmptargets.targets` | Rationale |
+|---|---|---|
+| `ubuntu-latest` | `jvm,android,js,wasmJs,wasmWasi,linuxX64,linuxArm64,androidNative` | the cheap runner — every non-Apple, non-MinGW target cross-compiles here (`android` requires AGP in your build; `web` is the `js,wasmJs,wasmWasi` preset) |
+| `macos-latest` | `apple` (or `appleMobile` on PRs) | the only host that can compile/link Apple targets; keep the expensive runner's set minimal |
+| `windows-latest` | `mingwX64` (alias `windows`) | the only host for MinGW |
+
+Notes:
+
+- **Same vocabulary, no drift.** Matrix values are plain [selection grammar](#selection-grammar)
+  strings — presets, leaves, and `-` exclusions all work. What CI builds is what
+  `kmpTargetsInfo` ([Debugging the selection](#debugging-the-selection)) prints locally for the
+  same value.
+- **Env form.** `ORG_GRADLE_PROJECT_kmptargets.targets` as a job `env:` is equivalent (dotted env
+  keys work on GitHub Actions); `-P` is the canonical recommendation. Both sit above the committed
+  `kmp-targets.properties` in [precedence](#selecting-targets), so a per-job value always wins
+  over the repo default.
+- **Cost tier (optional).** Restrict the macOS job to `appleMobile` on `pull_request` and run the
+  full `apple` preset only on `push` to `main` — the matrix `targets` value is the only thing that
+  changes. Label-gated jobs are a further refinement, not covered here.
+- **Strict mode pairs well.** Set [`kmptargets.strict=true`](#strict-mode) on jobs whose selection
+  the host can fully compile — a misconfigured module then fails the job instead of silently
+  building nothing.
+- **Configuration cache.** Each distinct selection is a distinct configuration-cache key; matrix
+  jobs with different selections won't share an entry. Expected, not a regression.
+- **Toolchain parity.** JDK via `setup-java` (Temurin 23) matches the repo's mise pin
+  (`.mise.toml`); Gradle comes from the committed wrapper (9.5.1) in both places — don't pin a
+  different version in CI.
+
+This repo runs the pattern for real:
+[`.github/workflows/sample-matrix.yml`](./.github/workflows/sample-matrix.yml) builds the
+hello-world sample per host — the macOS job is the only place Apple targets get genuinely
+compiled — so the example above can't rot.
 
 ## Installation
 


### PR DESCRIPTION
Closes #35

## What

Two deliverables (the issue's recommended **both**):

1. **README `## CI` section** — copy-pasteable consumer guidance: a complete GitHub Actions OS × selection matrix, the host → target mapping table, and the **no-drift principle**: matrix values are literally the same `kmptargets.targets` strings developers use locally (`kmp-targets.local.properties` / `-P`), linked to the Selection grammar. Plus: the quoted-`-P` PowerShell gotcha, the `ORG_GRADLE_PROJECT_kmptargets.targets` env equivalent, the optional `appleMobile`-on-PR / `apple`-on-main cost tier, [strict mode](#) pairing, the per-selection configuration-cache-key note, and toolchain parity (Temurin 23 ↔ `.mise.toml`, committed Gradle 9.5.1 wrapper, no override). Cost framing distinguishes public repos (standard runners free) from private (macOS ≈10x) — the latter is who the guidance targets.

2. **`.github/workflows/sample-matrix.yml`** — the living, exercised example so the docs can't rot. Additive: `ci.yml`'s ubuntu fast lane is untouched.

| job | `kmptargets.targets` | coverage |
|---|---|---|
| `ubuntu-latest` | `jvm,iosArm64,linuxX64,linuxArm64` | real Linux-native compilation |
| `macos-latest` | `appleMobile,jvm` | **first real Apple compilation in this repo's CI** |
| `windows-latest` | `windows,jvm,iosArm64` | first real MinGW compilation |

Each job publishes to mavenLocal, prints **`kmpTargetsInfo`** (the per-host resolution lands in the CI logs — dogfooding #33), then builds the sample with the override. `fail-fast: false` so a Windows hiccup can't cancel the macOS coverage.

## Why every job selects `jvm` + `iosArm64`

`:eager-conventions:verifyEagerTargets` asserts exactly `[iosArm64, jvm]` registers, and `:feature-mobile` supports only `mobile` (the sample has no AGP, so an iOS leaf is its only selectable shape — an empty intersection is a hard KGP error). Registration is host-blind by design, so the gate-only `iosArm64` is safe on Linux/Windows: advisory-warned, compile tasks disabled. The workflow header documents this; the consumer example in the README has no such constraint.

## Verification

- All three selections built green locally (every module intersection traced non-empty; gate satisfied in each, including the tight macOS exact-match `appleMobile,jvm ∩ jvm+iosArm64 = [iosArm64, jvm]`).
- YAML parses; `task ci` green.
- **The real proof runs on this PR**: the `pull_request` trigger executes the three-OS matrix in the checks below — Linux/Windows genuinely disabling the iOS tasks, macOS genuinely compiling them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)