### PR TITLE
feat: warn (and fail under strict) when deprecated Kotlin/Native targets register

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -102,6 +102,9 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     /** Leaves already named in a host-impossible warning, so each is warned at most once. */
     internal val hostWarned: MutableSet<KmpTarget> = mutableSetOf()
 
+    /** Leaves already named in a deprecation advisory, so each is flagged at most once. */
+    internal val deprecatedWarned: MutableSet<KmpTarget> = mutableSetOf()
+
     /** True once the minimal hierarchy template has been applied, so it is applied at most once. */
     internal var hierarchyTemplateApplied: Boolean = false
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -314,6 +314,28 @@ public class KmpTargetsPlugin : Plugin<Project> {
                 project.logger.warn(it)
             }
 
+        // Deprecation advisory (#43): Kotlin's docs mark leaves deprecated but KGP (2.3.21) emits
+        // no configuration-time signal when they register, so this plugin does. Keyed off the
+        // ACTIVE set — a deprecated leaf the module doesn't support never registers, so it is
+        // never flagged. Signal only, never filtering; deduped per leaf via `deprecatedWarned`,
+        // recorded AFTER warnOrFail (mirroring the host step) so a strict failure leaves no
+        // bookkeeping behind. Ordered after the host advisory: under strict, "this machine can't
+        // build it" beats "the ecosystem is sunsetting it". If a future KGP version emits its own
+        // deprecation warning, delete this advisory.
+        val freshDeprecated = freshDeprecated(active, ext.deprecatedWarned)
+        if (freshDeprecated.isNotEmpty()) {
+            warnOrFail(
+                strict,
+                deprecatedTargetsWarning(
+                    project.path,
+                    KmpTargetSet.of(*freshDeprecated.toTypedArray()),
+                ),
+            ) {
+                project.logger.warn(it)
+            }
+            ext.deprecatedWarned += freshDeprecated
+        }
+
         maybeApplyHierarchyTemplate(project, ext, active, globalHierarchyEnabled)
     }
 
@@ -400,5 +422,24 @@ internal fun emptyOverlapWarning(
 ): String =
     "kmp-targets: '$path' supports ${ids(supported)} but the selection ${ids(selection)} " +
         "matches none of them — registering no targets for this module."
+
+/**
+ * The deprecated leaves of [active] not yet flagged for this module — the dedup math of the
+ * deprecation advisory (#43), pure so it is unit-testable without Gradle. Keyed off the active
+ * (registered) set on purpose: a deprecated leaf the module never registers is nobody's problem.
+ */
+internal fun freshDeprecated(active: KmpTargetSet, alreadyWarned: Set<KmpTarget>): Set<KmpTarget> =
+    active.members.filterTo(mutableSetOf()) { it in KmpTarget.deprecated } - alreadyWarned
+
+/**
+ * Single aggregated deprecation advisory naming the [deprecated] ids (sorted). Mirrors
+ * [emptyOverlapWarning]/`hostImpossibleWarning` in shape; serves as both the warning and the
+ * strict-mode failure text through `warnOrFail`, so the two can never drift apart. The version
+ * stamp must track the `KmpTarget.deprecated` overrides (see the model KDoc).
+ */
+internal fun deprecatedTargetsWarning(path: String, deprecated: KmpTargetSet): String =
+    "kmp-targets: '$path' registers ${ids(deprecated)} which Kotlin marks deprecated " +
+        "(since Kotlin 2.3.20, see https://kotlinlang.org/docs/native-target-support.html) — " +
+        "still registered (selection is unchanged), but consider migrating off them."
 
 private fun ids(set: KmpTargetSet): List<String> = set.members.map { it.id }.sorted()

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTarget.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/KmpTarget.kt
@@ -227,5 +227,20 @@ public sealed interface KmpTarget {
                 Web.WasmJs,
                 Web.WasmWasi,
             )
+
+        /**
+         * Leaves Kotlin itself marks deprecated on the official target-support page
+         * (https://kotlinlang.org/docs/native-target-support.html). Hand-stamped against **Kotlin
+         * 2.3.20** — a Kotlin upgrade that changes the page must update this set (and its pinning
+         * test) deliberately. Deprecation is *signal only*: deprecated leaves stay selectable, stay
+         * in every preset, and register exactly like any other leaf.
+         *
+         * Deliberately a companion registry, NOT a `deprecated` property with a default getter on
+         * the interface: a default member would be a JVM default method, making every leaf's
+         * class-init trigger this interface's `<clinit>` (JLS 12.4.1) — which builds [all] while
+         * the entry-point leaf is still mid-initialization, poisoning the set with nulls.
+         */
+        public val deprecated: Set<KmpTarget> =
+            setOf(Native.Apple.Macos.X64, Native.Apple.Watchos.X64, Native.Apple.Tvos.X64)
     }
 }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDeprecationAdvisoryTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDeprecationAdvisoryTest.kt
@@ -1,0 +1,128 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * The deprecation advisory (#43): registering a leaf Kotlin marks deprecated warns once per leaf
+ * per module — and fails with the identical text under `kmptargets.strict=true`, through the same
+ * [warnOrFail] escalation point as every other advisory. Pure decision/message facts are covered by
+ * the unit tests next to those functions; this suite proves the wiring inside eager registration,
+ * KGP applied before `supports` so failures propagate unwrapped.
+ */
+class KmpTargetsDeprecationAdvisoryTest {
+
+    private val macosX64 = KmpTarget.Native.Apple.Macos.X64
+    private val watchosX64 = KmpTarget.Native.Apple.Watchos.X64
+
+    @Test
+    fun `given a deprecated leaf in the active set when supports is declared then it still registers and the build succeeds`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=macosX64,jvm\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { appleDesktop + jvm }
+        // Signal, never filtering: the deprecated leaf registers exactly as selected.
+        assertEquals(setOf("macosX64", "jvm"), registeredTargets(project))
+    }
+
+    @Test
+    fun `given strict on and a deprecated leaf in the active set when supports is declared then the build fails with the advisory text`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=macosX64,jvm\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val ex = assertFailsWith<GradleException> { ext(project).supports { appleDesktop + jvm } }
+        assertEquals(deprecatedTargetsWarning(project.path, KmpTargetSet.of(macosX64)), ex.message)
+    }
+
+    @Test
+    fun `given a second supports union introducing another deprecated leaf when registered then only the fresh leaf is flagged`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=macosX64,watchosX64,jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { appleDesktop }
+        assertEquals(setOf<KmpTarget>(macosX64), extension.deprecatedWarned)
+        extension.supports { appleWatch }
+        // The union re-runs registration; only the newly active deprecated leaf joins the dedup
+        // set — macosX64 is not re-flagged.
+        assertEquals(setOf<KmpTarget>(macosX64, watchosX64), extension.deprecatedWarned)
+    }
+
+    @Test
+    fun `given only non-deprecated targets including iosX64 when supports is declared then no deprecation advisory fires`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosX64,jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { appleMobile + jvm }
+        assertEquals(emptySet(), extension.deprecatedWarned)
+    }
+
+    @Test
+    fun `given a deprecated leaf selected but unsupported when supports is declared then no advisory fires`(
+        @TempDir dir: Path
+    ) {
+        // The advisory keys off the ACTIVE set (selection ∩ supported): a deprecated leaf the
+        // module cannot build never registers, so there is nothing to flag.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=macosX64,jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { jvm }
+        assertEquals(emptySet(), extension.deprecatedWarned)
+    }
+
+    // -- pure message facts ----------------------------------------------------------------------
+
+    @Test
+    fun `given deprecated leaves when the warning is built then it names the sorted ids the version and the docs page`() {
+        val message = deprecatedTargetsWarning(":lib", KmpTargetSet.of(watchosX64, macosX64))
+        assertContains(message, "[macosX64, watchosX64]")
+        assertContains(message, ":lib")
+        assertContains(message, "since Kotlin 2.3.20")
+        assertContains(message, "https://kotlinlang.org/docs/native-target-support.html")
+        assertContains(message, "still registered")
+    }
+
+    @Test
+    fun `given an active set and already warned leaves when fresh deprecated is computed then only new deprecated leaves remain`() {
+        val active = KmpTargetSet.of(macosX64, watchosX64, KmpTarget.Jvm.Desktop)
+        assertEquals(
+            setOf<KmpTarget>(watchosX64),
+            freshDeprecated(active, alreadyWarned = setOf(macosX64)),
+        )
+    }
+
+    private fun newProjectWithKgp(dir: Path): Project {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        return project
+    }
+
+    private fun ext(project: Project): KmpTargetsExtension =
+        project.extensions.getByType(KmpTargetsExtension::class.java)
+
+    private fun registeredTargets(project: Project): Set<String> =
+        project.extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .names
+            .filter { it != "metadata" }
+            .toSet()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDeprecationAdvisoryTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDeprecationAdvisoryTest.kt
@@ -44,7 +44,13 @@ class KmpTargetsDeprecationAdvisoryTest {
         dir.resolve("gradle.properties")
             .writeText("kmptargets.targets=macosX64,jvm\nkmptargets.strict=true\n")
         val project = newProjectWithKgp(dir)
-        val ex = assertFailsWith<GradleException> { ext(project).supports { appleDesktop + jvm } }
+        val extension = ext(project)
+        // Machine-independence: every deprecated leaf is an Apple target, so on a non-mac host the
+        // HOST advisory would throw first under strict (deliberate ordering — "this machine can't
+        // build it" beats "the ecosystem is sunsetting it"). Pre-seeding the host dedup set leaves
+        // the deprecation advisory as the only thrower on every host.
+        extension.hostWarned += macosX64
+        val ex = assertFailsWith<GradleException> { extension.supports { appleDesktop + jvm } }
         assertEquals(deprecatedTargetsWarning(project.path, KmpTargetSet.of(macosX64)), ex.message)
     }
 

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/model/KmpTargetDeprecationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/model/KmpTargetDeprecationTest.kt
@@ -1,0 +1,44 @@
+package com.rsicarelli.kmptargets.model
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the deprecated-target set to the official docs page
+ * (https://kotlinlang.org/docs/native-target-support.html, as of Kotlin 2.3.20): exactly the three
+ * x86-64 Apple leaves. A Kotlin upgrade that changes the page must come through this test — the set
+ * is hand-stamped, so drift is a deliberate review, never an accident.
+ */
+class KmpTargetDeprecationTest {
+
+    @Test
+    fun `given the model when deprecated leaves are collected then they are exactly the three x64 apple leaves`() {
+        assertEquals(
+            setOf("macosX64", "tvosX64", "watchosX64"),
+            KmpTarget.deprecated.map { it.id }.toSet(),
+        )
+    }
+
+    @Test
+    fun `given the deprecated registry when compared to the catalog then it is a strict subset of all`() {
+        // The registry may only ever name leaves the plugin actually ships.
+        assertEquals(KmpTarget.deprecated, KmpTarget.deprecated intersect KmpTarget.all)
+    }
+
+    @Test
+    fun `given iosX64 when checked then it is tier-3 but not deprecated`() {
+        // The docs page keeps iosX64 (the Intel-mac simulator) in tier 3 — supported, not
+        // deprecated. It must never be swept up with the deprecated x64 trio.
+        assertFalse(KmpTarget.Native.Apple.Ios.X64 in KmpTarget.deprecated)
+    }
+
+    @Test
+    fun `given the deprecated leaves when presets are read then they still contain them`() {
+        // Presets stay faithful to KGP's target set: deprecation adds signal, never filtering.
+        assertEquals(true, KmpTarget.Native.Apple.Macos.X64 in KmpTargetSet.appleDesktop)
+        assertEquals(true, KmpTarget.Native.Apple.Watchos.X64 in KmpTargetSet.appleWatch)
+        assertEquals(true, KmpTarget.Native.Apple.Tvos.X64 in KmpTargetSet.appleTv)
+        assertEquals(true, KmpTarget.Native.Apple.Macos.X64 in KmpTargetSet.all)
+    }
+}


### PR DESCRIPTION
Closes #43

## What

Kotlin's [target-support page](https://kotlinlang.org/docs/native-target-support.html) marks **`macosX64`, `watchosX64`, `tvosX64` deprecated since Kotlin 2.3.20** — and KGP 2.3.21 emits **zero configuration-time signal** when they register (verified empirically), while this plugin actively advertises them (DSL, presets, `kmpTargetsInfo` vocabulary). This PR adds the missing signal at the eager registration point:

```
kmp-targets: ':shared-core' registers [macosX64] which Kotlin marks deprecated (since Kotlin 2.3.20,
see https://kotlinlang.org/docs/native-target-support.html) — still registered (selection is
unchanged), but consider migrating off them.
```

Under `kmptargets.strict=true` the same text becomes a `GradleException` — through the existing `warnOrFail` escalation point, so warning and failure can never drift apart.

## Design

- **Signal only, never filtering.** The leaf registers exactly as selected; presets keep their deprecated members. Keys off the **active** set (`selection ∩ supported`) — a deprecated leaf a module doesn't support never registers, so it's never flagged.
- **`KmpTarget.deprecated`** companion registry pins exactly the three x64 Apple leaves (`iosX64` is tier-3, *not* deprecated — stays unmarked), guarded by a pinning test so a Kotlin upgrade changes the set deliberately, never by accident.
- **Deduped per leaf per module** via `ext.deprecatedWarned` (mirrors `hostWarned`; recorded after `warnOrFail` so a strict failure leaves no bookkeeping). Ordered after the host advisory: under strict, "this machine can't build it" beats "the ecosystem is sunsetting it".
- If a future KGP emits its own deprecation warning, this advisory is one keyed message to delete (noted in the code).

## The interesting bug the suite caught

The first implementation used `val deprecated: Boolean get() = false` **on the sealed interface** with three overrides. That default getter is a JVM default method — and per **JLS 12.4.1**, an interface with default methods is initialized when any implementing class initializes. So every leaf's class-init started triggering `KmpTarget.<clinit>`, which builds `all` by reading leaf `INSTANCE`s — while the entry-point leaf was still mid-initialization → **nulls poisoned `all` and the presets**, failing half the suite. The companion-registry shape (the issue's sanctioned alternative) has no default member, hence no init edge; the KDoc documents the landmine for posterity.

## Tests (10 new; full suite green)

- Pinning: registry == exactly `{macosX64, tvosX64, watchosX64}` · subset-of-`all` guard · `iosX64` not deprecated · presets still contain deprecated leaves.
- Pure: `freshDeprecated` dedup math · message names sorted ids + "still registered" + version + URL.
- In-process (KGP + ProjectBuilder): registers-and-succeeds (signal not filtering) · strict-ON fails with **message equality** · second `supports` union re-flags only the fresh leaf · selected-but-unsupported never flags.

`task ci` green (samples + isolated projects). `grep afterEvaluate src/main` stays empty. Sample demo verified: default warns per module, `-Pkmptargets.strict=true` fails with the identical text.

Stacked follow-up: #44 (kmpTargetsInfo annotations) branches off this PR and consumes the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)