### PR TITLE
feat: annotate kmpTargetsInfo with host-compilability and deprecation markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Registered (selection ∩ supported)
 
 Vocabulary
   presets:  all, native, appleMobile, appleDesktop, appleWatch, appleTv, apple, linux, mingw, windows, androidNative, web, jvmFamily, mobile
-  leaves:   androidNativeArm32, ..., watchosX64 (25)
+  leaves:   androidNativeArm32, ..., macosX64 (deprecated), ..., watchosX64 (deprecated) (25)
 ```
 
 The `source` line names the winning layer of the [precedence chain](#selecting-targets) — e.g.
@@ -214,6 +214,12 @@ The report is read-only (it never registers targets), explicit about every empty
 that never declared `supports { … }`, a selection narrowed to nothing, or a genuinely disjoint
 `selection ∩ supported` each get their own explanation — and configuration-cache compatible: the
 second run is a cache hit.
+
+Two per-leaf annotations surface what the lists alone can't say: registered leaves the **current
+host cannot compile** are marked `iosArm64 (not compilable on this host: LINUX_X64)` (same decision
+source as the [host compatibility](#host-compatibility) advisory), and vocabulary leaves Kotlin
+[marks deprecated](https://kotlinlang.org/docs/native-target-support.html) carry `(deprecated)` —
+so the copy-paste surface itself tells you what to avoid adopting.
 
 ### Supported targets
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -3,7 +3,10 @@ package com.rsicarelli.kmptargets
 import com.rsicarelli.kmptargets.hierarchy.computeHierarchySpec
 import com.rsicarelli.kmptargets.hierarchy.resolveHierarchyTemplateEnabled
 import com.rsicarelli.kmptargets.hierarchy.toTemplate
+import com.rsicarelli.kmptargets.host.currentHostEnabled
+import com.rsicarelli.kmptargets.host.currentHostLabel
 import com.rsicarelli.kmptargets.host.enforceHostCompatibility
+import com.rsicarelli.kmptargets.host.hostImpossibleIds
 import com.rsicarelli.kmptargets.info.KmpTargetsInfoTask
 import com.rsicarelli.kmptargets.info.OriginLabels
 import com.rsicarelli.kmptargets.model.KmpTarget
@@ -111,11 +114,32 @@ public class KmpTargetsPlugin : Plugin<Project> {
             task.projectPath.set(projectPath)
             task.presetNames.set(presetNames)
             task.leafIds.set(KmpTarget.all.map { it.id }.sorted())
+            task.deprecatedIds.set(KmpTarget.deprecated.map { it.id }.sorted())
             task.selectionIds.set(target.provider { ids(ext.resolvedSelection()) })
             task.supportedIds.set(target.provider { ids(ext.resolvedSupported()) })
             task.supportsDeclared.set(target.provider { ext.supportsProperty.isPresent })
             task.registeredIds.set(
                 target.provider { ids(ext.resolvedSelection() intersect ext.resolvedSupported()) }
+            )
+            // Host annotations (#44): same decision source as the host advisory, but guarded by a
+            // runtime KGP check INSIDE the provider — one wiring path that degrades to empty
+            // without KGP, and `HostManager` (touched only in host/HostCompatibility.kt bodies)
+            // never classloads on that branch. `hasPlugin` is read at provider realization
+            // (task-graph calc, post-body), so KGP applied after this plugin still counts.
+            task.hostImpossibleIds.set(
+                target.provider {
+                    if (!target.pluginManager.hasPlugin(KGP_ID)) emptyList()
+                    else
+                        hostImpossibleIds(
+                            ext.resolvedSelection() intersect ext.resolvedSupported(),
+                            currentHostEnabled(),
+                        )
+                }
+            )
+            task.hostLabel.set(
+                target.provider {
+                    if (!target.pluginManager.hasPlugin(KGP_ID)) "" else currentHostLabel()
+                }
             )
             // The config-layer origin is fixed at apply time, but the fallback labels must read
             // `defaultSelection` lazily — the body may override it after apply.

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/host/HostCompatibility.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/host/HostCompatibility.kt
@@ -3,6 +3,7 @@ package com.rsicarelli.kmptargets.host
 import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
 import com.rsicarelli.kmptargets.warnOrFail
+import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
 
 /**
@@ -94,3 +95,20 @@ internal fun enforceHostCompatibility(
     )
     return fresh
 }
+
+/**
+ * Sorted ids of the [active] leaves the simulated host (its [enabled] set) cannot compile — the
+ * `kmpTargetsInfo` per-leaf annotation source (#44). Same [impossibleOnHost] decision as the
+ * advisory, behind the same injected-enabled-set seam so tests never depend on the running machine.
+ */
+internal fun hostImpossibleIds(active: KmpTargetSet, enabled: Set<KonanTarget>): List<String> =
+    impossibleOnHost(active, enabled).members.map { it.id }.sorted()
+
+/**
+ * The running host's enabled targets and display label, touched ONLY behind a KGP-presence check:
+ * `HostManager` lives in these function bodies so its classes never load when KGP is absent (the
+ * same lazy-resolution pattern eager registration relies on).
+ */
+internal fun currentHostEnabled(): Set<KonanTarget> = HostManager().enabled.toSet()
+
+internal fun currentHostLabel(): String = HostManager.host.name.uppercase()

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
@@ -18,6 +18,9 @@ internal fun formatKmpTargetsInfo(
     originLabel: String,
     presetNames: List<String>,
     leafIds: List<String>,
+    hostImpossibleIds: List<String>,
+    hostLabel: String,
+    deprecatedIds: List<String>,
 ): String = buildString {
     appendLine("kmp-targets — $projectPath")
     appendLine()
@@ -36,12 +39,32 @@ internal fun formatKmpTargetsInfo(
     }
     appendLine()
     appendLine("Registered (selection ∩ supported)")
-    appendLine("  targets:  ${registeredOrNone(registeredIds, selectionIds, supportedIds)}")
+    appendLine(
+        "  targets:  " +
+            annotated(registeredOrNone(registeredIds, selectionIds, supportedIds), registeredIds) {
+                id ->
+                if (id in hostImpossibleIds) "(not compilable on this host: $hostLabel)" else null
+            }
+    )
     appendLine()
     appendLine("Vocabulary")
     appendLine("  presets:  ${presetNames.joinToString(", ")}")
-    append("  leaves:   ${leafIds.joinToString(", ")} (${leafIds.size})")
+    append(
+        "  leaves:   " +
+            leafIds.joinToString(", ") { id ->
+                if (id in deprecatedIds) "$id (deprecated)" else id
+            } +
+            " (${leafIds.size})"
+    )
 }
+
+/**
+ * Re-renders [ids] with a per-leaf [marker] suffix when any leaf earns one; falls back to the
+ * pre-rendered [plain] line (which carries the explicit empty-case wording) when none does.
+ */
+private fun annotated(plain: String, ids: List<String>, marker: (String) -> String?): String =
+    if (ids.none { marker(it) != null }) plain
+    else ids.joinToString(", ") { id -> marker(id)?.let { "$id $it" } ?: id }
 
 private fun idsOrNone(ids: List<String>, emptyReason: String): String =
     if (ids.isEmpty()) "(none — $emptyReason)" else ids.joinToString(", ")

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
@@ -47,6 +47,19 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
     /** Sorted canonical leaf ids the parser accepts. */
     @get:Internal public abstract val leafIds: ListProperty<String>
 
+    /**
+     * Sorted ids of registered leaves the current host cannot compile, annotated per leaf in the
+     * registered section. Empty when everything compiles here — or when KGP is absent, in which
+     * case there is no host data to report and the annotation simply vanishes.
+     */
+    @get:Internal public abstract val hostImpossibleIds: ListProperty<String>
+
+    /** The current host's display name (e.g. `MACOS_ARM64`); empty when KGP is absent. */
+    @get:Internal public abstract val hostLabel: Property<String>
+
+    /** Sorted ids of leaves Kotlin marks deprecated, annotated in the vocabulary listing. */
+    @get:Internal public abstract val deprecatedIds: ListProperty<String>
+
     @TaskAction
     public fun report() {
         println(
@@ -59,6 +72,9 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
                 originLabel = originLabel.get(),
                 presetNames = presetNames.get(),
                 leafIds = leafIds.get(),
+                hostImpossibleIds = hostImpossibleIds.get(),
+                hostLabel = hostLabel.get(),
+                deprecatedIds = deprecatedIds.get(),
             )
         )
     }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/host/EnforceHostCompatibilityTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/host/EnforceHostCompatibilityTest.kt
@@ -105,6 +105,32 @@ class EnforceHostCompatibilityTest {
         assertTrue(warnings.isEmpty(), "expected no warnings, got: $warnings")
     }
 
+    // -- info-task annotation seam (#44) ---------------------------------------------------------
+
+    @Test
+    fun `given iosArm64 active on a simulated linux host when impossible ids are computed then it is the only annotation`() {
+        assertEquals(
+            listOf("iosArm64"),
+            hostImpossibleIds(KmpTargetSet.of(iosArm64, KmpTarget.Jvm.Desktop), linuxEnabled),
+        )
+    }
+
+    @Test
+    fun `given the same active set on a simulated mac host when impossible ids are computed then none are annotated`() {
+        assertEquals(
+            emptyList(),
+            hostImpossibleIds(KmpTargetSet.of(iosArm64, tvosArm64), macEnabled),
+        )
+    }
+
+    @Test
+    fun `given several impossible leaves when impossible ids are computed then they are sorted`() {
+        assertEquals(
+            listOf("iosArm64", "tvosArm64"),
+            hostImpossibleIds(KmpTargetSet.of(tvosArm64, iosArm64), linuxEnabled),
+        )
+    }
+
     private fun enforce(
         active: KmpTargetSet,
         enabled: Set<KonanTarget> = linuxEnabled,

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
@@ -92,12 +92,49 @@ class KmpTargetsInfoFormatTest {
         assertTrue(format() == format())
     }
 
+    @Test
+    fun `given registered leaves the host cannot compile when formatted then each is marked with the host name`() {
+        val output =
+            format(
+                registeredIds = listOf("iosArm64", "jvm", "linuxX64"),
+                hostImpossibleIds = listOf("iosArm64"),
+                hostLabel = "LINUX_X64",
+            )
+        assertContains(output, "iosArm64 (not compilable on this host: LINUX_X64)")
+        assertFalse("jvm (not compilable" in output, output)
+        assertFalse("linuxX64 (not compilable" in output, output)
+    }
+
+    @Test
+    fun `given all registered leaves compilable when formatted then no host annotation appears`() {
+        val output =
+            format(
+                registeredIds = listOf("iosArm64", "jvm"),
+                hostImpossibleIds = emptyList(),
+                hostLabel = "MACOS_ARM64",
+            )
+        assertFalse("not compilable" in output, output)
+    }
+
+    @Test
+    fun `given the vocabulary when formatted then exactly the deprecated leaves carry the marker`() {
+        val output = format(deprecatedIds = listOf("macosX64", "tvosX64", "watchosX64"))
+        assertContains(output, "macosX64 (deprecated)")
+        assertContains(output, "tvosX64 (deprecated)")
+        assertContains(output, "watchosX64 (deprecated)")
+        // iosX64 is tier-3 but NOT deprecated — it must stay unmarked.
+        assertFalse("iosX64 (deprecated)" in output, output)
+    }
+
     private fun format(
         selectionIds: List<String> = listOf("jvm"),
         supportedIds: List<String> = listOf("jvm"),
         supportsDeclared: Boolean = true,
         registeredIds: List<String> = listOf("jvm"),
         originLabel: String = "built-in default (all)",
+        hostImpossibleIds: List<String> = emptyList(),
+        hostLabel: String = "",
+        deprecatedIds: List<String> = emptyList(),
     ): String =
         formatKmpTargetsInfo(
             projectPath = ":shared-core",
@@ -108,5 +145,8 @@ class KmpTargetsInfoFormatTest {
             originLabel = originLabel,
             presetNames = presetNames,
             leafIds = KmpTarget.all.map { it.id }.sorted(),
+            hostImpossibleIds = hostImpossibleIds,
+            hostLabel = hostLabel,
+            deprecatedIds = deprecatedIds,
         )
 }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTaskTest.kt
@@ -180,6 +180,25 @@ class KmpTargetsInfoTaskTest {
         assertEquals("help", task.group)
     }
 
+    @Test
+    fun `given the plugin without KGP when annotation inputs are read then host data degrades to empty`(
+        @TempDir dir: Path
+    ) {
+        // Graceful degradation AND a classloading guard: without KGP the providers must never
+        // touch HostManager, so the host annotations simply vanish from the report.
+        val task = infoTask(newAppliedProject(dir))
+        assertEquals(emptyList(), task.hostImpossibleIds.get())
+        assertEquals("", task.hostLabel.get())
+    }
+
+    @Test
+    fun `given the info task when deprecated ids are read then they are the pinned registry sorted`(
+        @TempDir dir: Path
+    ) {
+        val task = infoTask(newAppliedProject(dir))
+        assertEquals(listOf("macosX64", "tvosX64", "watchosX64"), task.deprecatedIds.get())
+    }
+
     private fun newAppliedProject(dir: Path): Project {
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("com.rsicarelli.kmptargets")


### PR DESCRIPTION
Closes #44

> **Stacked on #45** (base = `feat/deprecation-advisory-43`; consumes its `KmpTarget.deprecated` registry). When #45 squash-merges with branch deletion, GitHub auto-retargets this PR to `main` — it then gets rebased onto main and CI re-runs before merging.

## What

`kmpTargetsInfo` gains the per-leaf annotations #33 deferred, so one task now shows what resolved, what builds **here**, and what the ecosystem is sunsetting:

```
Registered (selection ∩ supported)
  targets:  iosArm64 (not compilable on this host: LINUX_X64), jvm

Vocabulary
  leaves:   ..., macosX64 (deprecated), ..., tvosX64 (deprecated), ..., watchosX64 (deprecated) (25)
```

- **Host-compilability** — same decision source as the #32 advisory (`impossibleOnHost` + `HostManager`), via a new `hostImpossibleIds(active, enabled)` seam with the enabled-set **injected**, so tests simulate Linux/mac hosts deterministically (the issue's seam AC).
- **Deprecation** — straight from #45's pinned `KmpTarget.deprecated` registry; `iosX64` (tier-3, not deprecated) stays unmarked. The vocabulary is exactly the copy-paste surface users pick targets from, so the marker lands where adoption decisions happen.

## Design notes

- **Graceful degradation without KGP**: host inputs are wired through one guarded provider — `hasPlugin(KGP_ID)` checked at provider realization (task-graph calc, post-body) — returning empty without KGP, and `HostManager` (confined to `host/HostCompatibility.kt` function bodies) never classloads on that branch. Verified by an in-process test on a KGP-less project.
- **CC contract intact**: the three new task inputs are `@Internal` primitives resolved at configuration time; the existing TestKit configuration-cache-HIT test passes unchanged.
- **Formatter stays pure**: annotation rendering is unit-tested, and the explicit empty-case wordings (disjoint/undeclared/narrowed-to-nothing) are preserved — annotations only apply when there are ids to annotate.
- Display only: no warning/failure behavior changes (those live in #32/#34/#45).

## Tests (8 new; full suite green)

Pure seam: `hostImpossibleIds` on simulated linux → `["iosArm64"]`, mac → `[]`, sorted-output. Formatter: host marker on exactly the impossible ids · no marker when all compilable · exactly the deprecated trio carries `(deprecated)`, iosX64 unmarked. In-process: KGP-less project → empty host inputs (degradation + classloading guard) · `deprecatedIds` == pinned registry. `task ci` green.

README "Debugging the selection" updated with both annotations and a pointer to the host-compatibility section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)