### PR TITLE
fix: lower emitted metadata/bytecode to consumer floors (Gradle 8.x kotlin-dsl, JDK 17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,5 +37,16 @@ changes may land in any release.
 - Both dedicated files are tracked configuration-cache inputs: edits invalidate the cache,
   untouched files keep cache hits.
 
+### Fixed
+
+- **Plugin jar is now consumable from Gradle 8.x `kotlin-dsl` build-logic and JDK 17 daemons**
+  ([#48]). The jar previously carried Kotlin 2.3 metadata (rejected by the Gradle-embedded Kotlin
+  2.0.x compiler on Gradle 8.11–8.14) and Java 23 bytecode (unloadable on JDK 17). The build now
+  drops `jvmToolchain(23)` and pins the emitted output instead — `languageVersion`/`apiVersion`
+  2.0, `jvmTarget` 17 + `-Xjdk-release=17` / `--release 17`, and `coreLibrariesVersion` 2.0.21 so
+  the POM stops declaring a toolchain-version stdlib. A new `verifyCompatFloors` task guards the
+  floors on every `check`.
+
 [#30]: https://github.com/rsicarelli/kmp-targets/issues/30
 [#31]: https://github.com/rsicarelli/kmp-targets/issues/31
+[#48]: https://github.com/rsicarelli/kmp-targets/issues/48

--- a/README.md
+++ b/README.md
@@ -461,6 +461,25 @@ This repo runs the pattern for real:
 hello-world sample per host — the macOS job is the only place Apple targets get genuinely
 compiled — so the example above can't rot.
 
+## Compatibility
+
+The published jar targets the oldest supported consumer, not the toolchain this repo builds with:
+
+| Consumer surface | Floor |
+|---|---|
+| `kotlin-dsl` build-logic (Gradle-embedded Kotlin) | Gradle 8.11+ / embedded Kotlin **2.0** |
+| Daemon JVM | **JDK 17** |
+| Kotlin Gradle Plugin at runtime | **KGP 2.2+** |
+
+The repo itself builds with the latest mise-pinned JDK and Kotlin — there are **no Gradle
+toolchains** (see [why toolchains are rarely a good
+idea](https://jakewharton.com/gradle-toolchains-are-rarely-a-good-idea/)). Instead the build pins
+the emitted output: Kotlin `languageVersion`/`apiVersion` 2.0 (metadata the embedded 8.x compiler
+can read), `jvmTarget` 17 + `-Xjdk-release=17` / `--release 17` (bytecode JDK 17 daemons can load,
+with accidental-new-API protection), and a `kotlin-stdlib` 2.0.21 POM dependency. A
+`verifyCompatFloors` task inspects the built jar on every `check`, so the floors cannot silently
+regress.
+
 ## Installation
 
 The plugin is not yet published to the Gradle Plugin Portal or Maven Central. Track progress in the issues / releases. Locally:

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins { `kotlin-dsl` }
+
+dependencies {
+    // API artifact only — deliberately NOT the full kotlin-gradle-plugin. buildSrc classes sit in
+    // a parent classloader of every build script; shipping the full KGP here would put the
+    // org.jetbrains.kotlin.jvm plugin on that parent classpath and break the root build's
+    // version-carrying `alias(libs.plugins.kotlin.jvm)` ("plugin already on the classpath").
+    // The API jar has the task/option types JvmCompatibility.kt needs and nothing more.
+    implementation(libs.kotlin.gradlePluginApi)
+
+    // Class-file reader for VerifyCompatFloorsTask: walks the built jar asserting the bytecode and
+    // Kotlin-metadata floors actually hold. Gradle bundles ASM only as an internal impldep.
+    implementation(libs.asm)
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,9 @@
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
+}
+
+rootProject.name = "buildSrc"

--- a/buildSrc/src/main/kotlin/JvmCompatibility.kt
+++ b/buildSrc/src/main/kotlin/JvmCompatibility.kt
@@ -1,0 +1,69 @@
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
+/**
+ * The oldest consumer this plugin promises to work with, expressed as compilation floors.
+ *
+ * A Gradle plugin's compiled output is consumed in two hostile-to-newness places:
+ * 1. **`kotlin-dsl` build-logic compilation.** Convention plugins that wrap kmp-targets compile
+ *    with the *Gradle-embedded* Kotlin compiler — Kotlin 2.0.x on the Gradle 8.11–8.14 line. That
+ *    compiler must be able to read this jar's Kotlin metadata, so language/API levels are pinned
+ *    to [KotlinVersion.KOTLIN_2_0].
+ * 2. **The consumer's daemon JVM.** Builds routinely run on JDK 17 even when this repo develops on
+ *    a newer JDK, so bytecode is pinned to 17 ([JvmTarget.JVM_17] / [JavaVersion.VERSION_17]).
+ *
+ * Strategy: build with the locally installed JDK (mise-pinned), explicitly target the floors — no
+ * Gradle toolchains. See:
+ * - https://jakewharton.com/gradle-toolchains-are-rarely-a-good-idea/
+ * - https://jakewharton.com/kotlins-jdk-release-compatibility-flag/
+ */
+internal val javaFloor = JavaVersion.VERSION_17
+internal val jvmTargetFloor = JvmTarget.JVM_17
+internal val kotlinFloor = KotlinVersion.KOTLIN_2_0
+
+/**
+ * The stdlib version published as this plugin's dependency. Without this pin, KGP adds the
+ * *toolchain's* stdlib (2.3.x) to the POM and consumers on the floor pull 2.3-metadata jars onto
+ * their `kotlin-dsl` compile classpath — failing exactly the way the language/api pin prevents.
+ * Must stay on the same minor as [kotlinFloor]. Applied via `kotlin { coreLibrariesVersion }` in
+ * the consuming build script — `KotlinProjectExtension` lives in the full KGP jar, which buildSrc
+ * deliberately keeps off its classpath (see buildSrc/build.gradle.kts).
+ */
+const val KOTLIN_FLOOR_STDLIB: String = "2.0.21"
+
+/**
+ * Pins this project's compiled output to the consumer floors documented above.
+ *
+ * - Java: `sourceCompatibility`/`targetCompatibility` plus `--release`, so javac refuses JDK-18+
+ *   APIs instead of producing bytecode that fails at runtime on a 17 daemon.
+ * - Kotlin: `jvmTarget` for bytecode, `languageVersion`/`apiVersion` for metadata the embedded
+ *   2.0.x compiler can read, and `-Xjdk-release` so kotlinc gets the same accidental-new-API
+ *   protection javac gets from `--release`.
+ *
+ * That these floors hold in the built jar is enforced by [registerCompatFloorsVerification].
+ */
+fun Project.configureJvmCompatibility() {
+    extensions.configure(JavaPluginExtension::class.java) {
+        sourceCompatibility = javaFloor
+        targetCompatibility = javaFloor
+    }
+
+    tasks.withType(JavaCompile::class.java).configureEach {
+        options.release.set(javaFloor.majorVersion.toInt())
+    }
+
+    tasks.withType(KotlinCompilationTask::class.java).configureEach {
+        compilerOptions.languageVersion.set(kotlinFloor)
+        compilerOptions.apiVersion.set(kotlinFloor)
+        (compilerOptions as? KotlinJvmCompilerOptions)?.let { options ->
+            options.jvmTarget.set(jvmTargetFloor)
+            options.freeCompilerArgs.add("-Xjdk-release=${jvmTargetFloor.target}")
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/VerifyCompatFloorsTask.kt
+++ b/buildSrc/src/main/kotlin/VerifyCompatFloorsTask.kt
@@ -1,0 +1,167 @@
+import java.util.jar.JarFile
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.bundling.Jar
+import org.objectweb.asm.AnnotationVisitor
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.Opcodes
+
+/**
+ * Guards the consumer floors declared in JvmCompatibility.kt by inspecting the *built jar* — the
+ * artifact consumers actually load — instead of trusting compiler flags to have applied:
+ * - every class file's major version must be ≤ [maxClassMajorVersion] (61 = Java 17), or JDK 17
+ *   daemons throw `UnsupportedClassVersionError`;
+ * - every `@kotlin.Metadata` `mv` must match [expectedMetadataMajorMinor] ([2, 0]), or the
+ *   Gradle-embedded Kotlin 2.0.x compiler rejects the jar from `kotlin-dsl` build-logic;
+ * - the resolved `kotlin-stdlib` must be [expectedStdlibVersion], or the POM ships a
+ *   toolchain-version stdlib that drags 2.3 metadata back onto the consumer's compile classpath.
+ *
+ * Wired into `check` by [registerCompatFloorsVerification], so `task ci` fails on any regression.
+ */
+abstract class VerifyCompatFloorsTask : DefaultTask() {
+
+    @get:InputFile abstract val pluginJar: RegularFileProperty
+
+    @get:Input abstract val maxClassMajorVersion: Property<Int>
+
+    @get:Input abstract val expectedMetadataMajorMinor: ListProperty<Int>
+
+    @get:Input abstract val expectedStdlibVersion: Property<String>
+
+    @get:Input abstract val resolvedStdlibVersion: Property<String>
+
+    @TaskAction
+    fun verify() {
+        val maxMajor = maxClassMajorVersion.get()
+        val expectedMv = expectedMetadataMajorMinor.get()
+        val violations = mutableListOf<String>()
+
+        JarFile(pluginJar.get().asFile).use { jar ->
+            jar.entries()
+                .asSequence()
+                .filter { it.name.endsWith(".class") && !it.name.startsWith("META-INF/") }
+                .forEach { entry ->
+                    val bytes = jar.getInputStream(entry).use { it.readBytes() }
+
+                    // Class-file major version: u2 at offset 6 (magic u4, minor u2, major u2).
+                    val major = ((bytes[6].toInt() and 0xff) shl 8) or (bytes[7].toInt() and 0xff)
+                    if (major > maxMajor) {
+                        violations +=
+                            "${entry.name}: class file major version $major > $maxMajor " +
+                                "(Java ${maxMajor - 44})"
+                    }
+
+                    val mv = readKotlinMetadataVersion(bytes)
+                    if (mv != null && (mv[0] != expectedMv[0] || mv[1] != expectedMv[1])) {
+                        violations +=
+                            "${entry.name}: @kotlin.Metadata mv=${mv.toList()}, expected " +
+                                "[${expectedMv[0]}, ${expectedMv[1]}, *] — unreadable by the " +
+                                "Gradle-embedded Kotlin ${expectedMv[0]}.${expectedMv[1]} compiler"
+                    }
+                }
+        }
+
+        if (resolvedStdlibVersion.get() != expectedStdlibVersion.get()) {
+            violations +=
+                "kotlin-stdlib resolves to ${resolvedStdlibVersion.get()}, expected " +
+                    "${expectedStdlibVersion.get()} — the POM would carry a stdlib above the " +
+                    "consumer floor (check `kotlin { coreLibrariesVersion }`)"
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "Plugin jar violates the consumer compatibility floors " +
+                    "(see buildSrc/src/main/kotlin/JvmCompatibility.kt):\n" +
+                    violations.joinToString("\n") { "  - $it" }
+            )
+        }
+    }
+
+    /** Extracts the `mv` array from `@kotlin.Metadata`, or null for non-Kotlin classes. */
+    private fun readKotlinMetadataVersion(classBytes: ByteArray): IntArray? {
+        var mv: IntArray? = null
+        val collector =
+            object : ClassVisitor(Opcodes.ASM9) {
+                override fun visitAnnotation(
+                    descriptor: String,
+                    visible: Boolean,
+                ): AnnotationVisitor? {
+                    if (descriptor != "Lkotlin/Metadata;") return null
+                    return object : AnnotationVisitor(Opcodes.ASM9) {
+                        override fun visitArray(name: String?): AnnotationVisitor? {
+                            if (name != "mv") return null
+                            val values = mutableListOf<Int>()
+                            return object : AnnotationVisitor(Opcodes.ASM9) {
+                                override fun visit(name: String?, value: Any?) {
+                                    values += value as Int
+                                }
+
+                                override fun visitEnd() {
+                                    mv = values.toIntArray()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        val flags = ClassReader.SKIP_CODE or ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES
+        ClassReader(classBytes).accept(collector, flags)
+        return mv
+    }
+}
+
+/**
+ * Registers `verifyCompatFloors` against this project's `jar` output and hooks it into `check`.
+ * All inputs are primitives/Providers resolved at configuration time — no `Project` capture, so
+ * the task is configuration-cache safe.
+ */
+fun Project.registerCompatFloorsVerification() {
+    // The stdlib version the consumer will actually resolve (and the POM will declare). Lazy:
+    // resolution happens only when the task's inputs are fingerprinted, never at configuration.
+    val resolvedStdlib =
+        configurations
+            .getByName("runtimeClasspath")
+            .incoming
+            .resolutionResult
+            .rootComponent
+            .map { root -> findKotlinStdlibVersion(root) ?: "absent" }
+
+    val verifyCompatFloors =
+        tasks.register("verifyCompatFloors", VerifyCompatFloorsTask::class.java) {
+            pluginJar.set(tasks.named("jar", Jar::class.java).flatMap { it.archiveFile })
+            // Class-file major = Java feature version + 44 → Java 17 = 61.
+            maxClassMajorVersion.set(javaFloor.majorVersion.toInt() + 44)
+            expectedMetadataMajorMinor.set(kotlinFloor.version.split(".").map(String::toInt))
+            expectedStdlibVersion.set(KOTLIN_FLOOR_STDLIB)
+            resolvedStdlibVersion.set(resolvedStdlib)
+        }
+
+    tasks.named("check") { dependsOn(verifyCompatFloors) }
+}
+
+private fun findKotlinStdlibVersion(root: ResolvedComponentResult): String? {
+    val seen = mutableSetOf<ResolvedComponentResult>()
+    val queue = ArrayDeque(listOf(root))
+    while (queue.isNotEmpty()) {
+        val component = queue.removeFirst()
+        if (!seen.add(component)) continue
+        for (dependency in component.dependencies.filterIsInstance<ResolvedDependencyResult>()) {
+            val module = dependency.selected.moduleVersion
+            if (module?.group == "org.jetbrains.kotlin" && module.name == "kotlin-stdlib") {
+                return module.version
+            }
+            queue += dependency.selected
+        }
+    }
+    return null
+}

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -5,7 +5,21 @@ plugins {
     `maven-publish`
 }
 
-kotlin { jvmToolchain(23) }
+// No toolchain on purpose: build with the locally installed (mise-pinned) JDK, target the oldest
+// supported consumer. Floors (Java 17 bytecode, Kotlin 2.0 metadata) live in buildSrc's
+// JvmCompatibility.kt — consumers compile their build-logic with Gradle's embedded Kotlin and run
+// daemons on JDK 17, so emitting current-toolchain levels would make the jar unconsumable there.
+configureJvmCompatibility()
+
+// Inspects the built jar (bytecode + metadata floors, resolved stdlib) and fails `check` on any
+// regression — the floors above are only promises until the artifact proves them.
+registerCompatFloorsVerification()
+
+// The published stdlib dependency must sit on the same floor: without this, KGP writes the
+// toolchain's stdlib (2.3.x) into the POM and floor consumers pull 2.3-metadata jars onto their
+// kotlin-dsl compile classpath. Lives here (not JvmCompatibility.kt) because the `kotlin {}` DSL
+// type is only on this script's classpath via the applied plugin.
+kotlin { coreLibrariesVersion = KOTLIN_FLOOR_STDLIB }
 
 // Publish a -sources.jar alongside the plugin so IntelliJ can render the DSL's KDoc on hover.
 // `java-gradle-plugin` builds the `pluginMaven` publication from `components["java"]`; attaching

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,12 @@
 kotlin = "2.3.21"
 junit = "6.1.0"
 ktfmt = "0.26.0"
+asm = "9.8"
 
 [libraries]
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
+asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 
 [plugins]


### PR DESCRIPTION
## Problem

Real consumers wire kmp-targets into convention plugins inside a `kotlin-dsl` build-logic included build. There, the **Gradle-embedded Kotlin compiler** (2.0.21 on Gradle 8.11–8.14) must read the plugin jar's Kotlin metadata, and daemons routinely run **JDK 17**. The jar built with `jvmToolchain(23)` and no lowering carried:

- **Kotlin 2.3 metadata** → embedded 2.0.x compiler rejects it (`class … was compiled with a newer Kotlin`)
- **Java 23 bytecode** → `UnsupportedClassVersionError` on JDK 17 daemons

This blocked the primary build-logic integration story for anyone not on Gradle 9.x + JDK 23.

## Strategy: target the floors, no toolchains

Build with the locally installed (mise-pinned) JDK, explicitly pin the *emitted output* — per [Gradle toolchains are rarely a good idea](https://jakewharton.com/gradle-toolchains-are-rarely-a-good-idea/) and [Kotlin's JDK release compatibility flag](https://jakewharton.com/kotlins-jdk-release-compatibility-flag/). Three pins, each with its own failure mode:

| Pin | Failure mode it prevents |
|---|---|
| `languageVersion`/`apiVersion` = **2.0** | jar metadata unreadable by the Gradle-embedded Kotlin 2.0.x compiler in 8.x `kotlin-dsl` build-logic |
| `jvmTarget 17` + `-Xjdk-release=17` (Kotlin), `--release 17` (Java) | bytecode unloadable on JDK 17 daemons; accidental use of JDK 18+ APIs that would fail only at consumer runtime |
| `kotlin { coreLibrariesVersion = "2.0.21" }` | KGP writes the *toolchain's* stdlib (2.3.x) into the POM, dragging 2.3-metadata jars back onto the consumer's `kotlin-dsl` compile classpath — found only by compiling a real consumer |

The floors live in `buildSrc/src/main/kotlin/JvmCompatibility.kt`. buildSrc depends on `kotlin-gradle-plugin-api` only — the full KGP would sit in a parent classloader of every build script and break the root build's version-carrying `alias(libs.plugins.kotlin.jvm)`.

All KGP APIs the plugin uses (`applyHierarchyTemplate`, `HostManager().enabled`, target factories) exist in 2.2.x — only emitted metadata/bytecode needed lowering; KGP stays `compileOnly`.

## Guarded check, not a one-off

`verifyCompatFloors` (new, `buildSrc/src/main/kotlin/VerifyCompatFloorsTask.kt`, wired into `check`) inspects the built jar and fails on: any class file major version > 61, any `@kotlin.Metadata` `mv` ≠ `[2, 0, *]`, or a resolved `kotlin-stdlib` off the 2.0.21 floor. Configuration-cache safe (all inputs are primitives/Providers; no `Project` capture). Negative-tested: lowering the floor to 52 makes it fail with per-class violations.

## Verification

```
$ ./gradlew :gradle-plugin:jar
$ javap -verbose -p KmpTargetsExtension.class | grep "major version"
  major version: 61

$ javap -verbose -p KmpTargetsExtension.class | grep -A2 "mv="
      mv=[2,0,0]
      k=1
      xi=48

$ grep -B2 -A3 kotlin-stdlib gradle-plugin/build/publications/pluginMaven/pom-default.xml
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-stdlib</artifactId>
      <version>2.0.21</version>
      <scope>compile</scope>
    </dependency>

$ ./gradlew :gradle-plugin:verifyCompatFloors
BUILD SUCCESSFUL

$ task ci   # check (tests + ktfmt + verifyCompatFloors) + publish-local + both samples
BUILD SUCCESSFUL ×7
```

The hello-world / isolated-projects samples need no changes (they run Gradle 9.5.1) and stay green.

Validated against a **real Gradle 8.14.3 / KGP 2.2.21 consumer**: a `kotlin-dsl` build-logic convention plugin compiles against the published jar with these floors in place.

Docs: new README **Compatibility** section (consumer floor table + no-toolchain rationale); CHANGELOG entry under Unreleased.

Independent of #49 and #50.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)