### PR TITLE
feat: opt-in no-collapse hierarchy mode (kmptargets.hierarchyCollapse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ changes may land in any release.
   configuration time with a "did you mean …?" suggestion.
 - Both dedicated files are tracked configuration-cache inputs: edits invalidate the cache,
   untouched files keep cache hits.
+- **Opt-in no-collapse hierarchy mode** ([#50]): `kmptargets.hierarchyCollapse=false` (global key)
+  or `kmpTargets { collapseHierarchy.set(false) }` (per-module, wins) makes a group materialize
+  with **≥1** present child instead of ≥2, so intermediates like `iosMain` survive a single-leaf
+  selection — for codebases with load-bearing `src/iosMain` dirs. Default unchanged (`true`,
+  collapse); never changes what registers; no-op when `kmptargets.hierarchyTemplate=false`.
 
 ### Fixed
 
@@ -50,3 +55,4 @@ changes may land in any release.
 [#30]: https://github.com/rsicarelli/kmp-targets/issues/30
 [#31]: https://github.com/rsicarelli/kmp-targets/issues/31
 [#48]: https://github.com/rsicarelli/kmp-targets/issues/48
+[#50]: https://github.com/rsicarelli/kmp-targets/issues/50

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ to do, instead of loose keys buried among unrelated daemon/cache settings in `gr
 # kmp-targets.properties — committed, team-shared
 kmptargets.targets=jvm,iosArm64
 kmptargets.hierarchyTemplate=true
+# kmptargets.hierarchyCollapse=false    # opt-out of single-child collapse — see "Minimal hierarchy template"
 # kmptargets.strict=true    # opt-in: advisories become failures — see "Strict mode"
 ```
 
@@ -307,6 +308,40 @@ kmpTargets { hierarchyTemplate.set(false) }
 
 Precedence is **project DSL > global key > built-in default (`true`)**. Opt out when a module
 supplies its own `applyHierarchyTemplate { … }`, so the plugin stays out of the way.
+
+#### Keeping intermediates: no-collapse mode
+
+The collapse rule above is what keeps the tree minimal: a group materializes a source set only when
+it merges **≥2** present children; a single-child group collapses away. That is the right default
+for new code, but established codebases have **load-bearing intermediate source dirs** — dozens of
+modules with `src/iosMain` holding `actual` implementations. For them, narrowing the selection to a
+single iOS leaf (`-Pkmptargets.targets=iosArm64`, the everyday "build for device only" move)
+silently drops `iosMain` from the model and the build breaks with unresolved `expect` declarations.
+
+The opt-out is the **no-collapse** mode: a group materializes whenever it has **≥1** present child,
+so `iosMain` survives a single-iOS-leaf selection. Single-child chains materialize fully
+(`nativeMain → appleMain → iosMain` for one iOS leaf) — the inert empty intermediates are harmless
+(no code, no `expect`/`actual` to resolve). Empty groups are still dropped, and ungrouped leaves
+(jvm/android/web) still never form groups.
+
+```properties
+# kmp-targets.properties — global default (same precedence chain as the other keys)
+kmptargets.hierarchyCollapse=false
+```
+
+```kotlin
+// any module's build.gradle.kts — per-project override; set BEFORE supports { }
+kmpTargets {
+    collapseHierarchy.set(false)
+    supports { appleMobile }
+}
+```
+
+Precedence mirrors `hierarchyTemplate`: **project DSL > global key > built-in default (`true`,
+collapse — the minimal tree)**. The knob never changes **what registers** — only which intermediate
+source sets materialize — and it is a documented no-op when `hierarchyTemplate` resolves to `false`
+(KGP's default template owns the tree then). A possible future extension — force-materializing
+*named* groups only (e.g. just `ios`) to avoid the inert parents — is out of scope for now.
 
 ### Host compatibility
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -48,6 +48,18 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     public abstract val hierarchyTemplate: Property<Boolean>
 
     /**
+     * Per-project opt-out of the single-child collapse rule (issue #50). Unset defers to the global
+     * `kmptargets.hierarchyCollapse` property, which itself defaults to `true` (collapse — the
+     * minimal tree). When `false`, a group materializes whenever it has ≥1 present child, so
+     * intermediates like `iosMain` survive a single-leaf selection — for codebases with
+     * load-bearing `src/iosMain` dirs whose everyday workflow narrows to one iOS leaf. No effect
+     * when [hierarchyTemplate] resolves to `false` (KGP's default template owns the tree then).
+     *
+     * Set it **before** [supports], for the same eager-registration reason as [hierarchyTemplate].
+     */
+    public abstract val collapseHierarchy: Property<Boolean>
+
+    /**
      * What this module can build. Unset means "not declared" → no targets register, and
      * [resolvedSupported] returns [KmpTargetSet.empty]. Written by the [supports] block (or its raw
      * overload), which unions on each call.

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -1,6 +1,7 @@
 package com.rsicarelli.kmptargets
 
 import com.rsicarelli.kmptargets.hierarchy.computeHierarchySpec
+import com.rsicarelli.kmptargets.hierarchy.resolveHierarchyCollapseEnabled
 import com.rsicarelli.kmptargets.hierarchy.resolveHierarchyTemplateEnabled
 import com.rsicarelli.kmptargets.hierarchy.toTemplate
 import com.rsicarelli.kmptargets.host.currentHostEnabled
@@ -63,9 +64,12 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // origin either — the report then falls through to the defaultSelection/built-in labels.
         val configOrigin: String? = winner?.takeIf { it.second.isNotBlank() }?.first
 
-        // Global default for the hierarchy template, read once at apply time as a primitive.
+        // Global defaults for the hierarchy template and its collapse rule (issue #50), each read
+        // once at apply time as a primitive.
         val globalHierarchyEnabled: Boolean? =
             hierarchyTemplateEnabledGlobally(target, personal, committed)
+        val globalCollapseEnabled: Boolean? =
+            hierarchyCollapseEnabledGlobally(target, personal, committed)
 
         // Strict mode (#34): opt-in promotion of the selection/host advisories to failures, read
         // once at apply time as a primitive Boolean (default off) so no `Project` is captured.
@@ -80,7 +84,7 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // cache.
         ext.onSupports = {
             target.pluginManager.withPlugin(KGP_ID) {
-                register(target, ext, globalHierarchyEnabled, strict)
+                register(target, ext, globalHierarchyEnabled, globalCollapseEnabled, strict)
             }
         }
 
@@ -225,6 +229,21 @@ public class KmpTargetsPlugin : Plugin<Project> {
             ?.toBooleanStrictOrNull()
 
     /**
+     * Reads the global `kmptargets.hierarchyCollapse` flag (issue #50) through the standard
+     * [configSources] chain, with the same `null` = "not set" semantics as the template flag.
+     */
+    private fun hierarchyCollapseEnabledGlobally(
+        target: Project,
+        personal: Map<String, String>?,
+        committed: Map<String, String>?,
+    ): Boolean? =
+        configSources(target, ConfigKeys.HIERARCHY_COLLAPSE, personal, committed)
+            .read()
+            ?.trim()
+            ?.lowercase()
+            ?.toBooleanStrictOrNull()
+
+    /**
      * Reads the global `kmptargets.strict` flag through the standard [configSources] chain.
      * Deliberately opt-in: unset — or anything other than `true`/`false` (case-insensitive, per
      * `toBooleanStrictOrNull`) — means OFF, the advisory-only behavior.
@@ -298,6 +317,7 @@ public class KmpTargetsPlugin : Plugin<Project> {
         project: Project,
         ext: KmpTargetsExtension,
         globalHierarchyEnabled: Boolean?,
+        globalCollapseEnabled: Boolean?,
         strict: Boolean,
     ) {
         val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
@@ -360,7 +380,13 @@ public class KmpTargetsPlugin : Plugin<Project> {
             ext.deprecatedWarned += freshDeprecated
         }
 
-        maybeApplyHierarchyTemplate(project, ext, active, globalHierarchyEnabled)
+        maybeApplyHierarchyTemplate(
+            project,
+            ext,
+            active,
+            globalHierarchyEnabled,
+            globalCollapseEnabled,
+        )
     }
 
     /**
@@ -374,11 +400,16 @@ public class KmpTargetsPlugin : Plugin<Project> {
         ext: KmpTargetsExtension,
         active: KmpTargetSet,
         globalEnabled: Boolean?,
+        globalCollapseEnabled: Boolean?,
     ) {
         if (ext.hierarchyTemplateApplied || active.isEmpty()) return
         if (!resolveHierarchyTemplateEnabled(ext.hierarchyTemplate.orNull, globalEnabled)) return
+        // The collapse knob (issue #50) only matters when the minimal template itself applies —
+        // with the template disabled, KGP's default hierarchy owns the tree.
+        val collapse =
+            resolveHierarchyCollapseEnabled(ext.collapseHierarchy.orNull, globalCollapseEnabled)
         val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
-        kotlin.applyHierarchyTemplate(computeHierarchySpec(active).toTemplate())
+        kotlin.applyHierarchyTemplate(computeHierarchySpec(active, collapse).toTemplate())
         ext.hierarchyTemplateApplied = true
     }
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyComposer.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyComposer.kt
@@ -14,11 +14,16 @@ import com.rsicarelli.kmptargets.model.KmpTargetSet
  *
  * Consequence (the article's point): an iOS-only module yields `iosMain` only — no redundant
  * `appleMain`/`nativeMain` — while iOS + linux yields `nativeMain` over `iosMain` + `linuxMain`.
+ *
+ * [collapse] (default `true`) is the no-collapse knob (issue #50): when `false`, a group
+ * materializes with **≥1** present child instead of ≥2, so intermediates like `iosMain` survive a
+ * single-leaf selection — load-bearing for codebases with established `src/iosMain` dirs. Empty
+ * groups are still dropped, and ungrouped leaves (jvm/android/web) still never form groups.
  */
-internal fun computeHierarchySpec(active: KmpTargetSet): HierarchySpec {
+internal fun computeHierarchySpec(active: KmpTargetSet, collapse: Boolean = true): HierarchySpec {
     // The native subtree, collapsed; plus any leaf that belongs to no group (jvm/android/web),
     // which always attaches directly to `common`.
-    val nativeRoots = contributionOf(HierarchyGroup.NATIVE, active)
+    val nativeRoots = contributionOf(HierarchyGroup.NATIVE, active, collapse)
     val ungrouped =
         active.members
             .filter { mostSpecificGroup(it) == null }
@@ -30,13 +35,18 @@ internal fun computeHierarchySpec(active: KmpTargetSet): HierarchySpec {
 /**
  * The set of nodes [group] contributes to its parent's children, with the collapse rule applied: ≥2
  * present children ⇒ a single [HierarchyNode.Group]; exactly one ⇒ that child bubbles up unchanged
- * (collapse); none ⇒ nothing.
+ * (collapse) — unless [collapse] is off, in which case the group materializes anyway; none ⇒
+ * nothing (in both modes).
  */
-private fun contributionOf(group: HierarchyGroup, active: KmpTargetSet): Set<HierarchyNode> {
+private fun contributionOf(
+    group: HierarchyGroup,
+    active: KmpTargetSet,
+    collapse: Boolean,
+): Set<HierarchyNode> {
     val fromChildGroups: Set<HierarchyNode> =
         HierarchyGroup.entries
             .filter { it.parent == group }
-            .flatMap { contributionOf(it, active) }
+            .flatMap { contributionOf(it, active, collapse) }
             .toSet()
     val directLeaves: Set<HierarchyNode> =
         active.members
@@ -44,9 +54,9 @@ private fun contributionOf(group: HierarchyGroup, active: KmpTargetSet): Set<Hie
             .map { HierarchyNode.Leaf(it) }
             .toSet()
     val presentChildren = fromChildGroups + directLeaves
-    return when (presentChildren.size) {
-        0 -> emptySet()
-        1 -> presentChildren
+    return when {
+        presentChildren.isEmpty() -> emptySet()
+        collapse && presentChildren.size == 1 -> presentChildren
         else -> setOf(HierarchyNode.Group(group, presentChildren))
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateGate.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateGate.kt
@@ -11,3 +11,15 @@ internal fun resolveHierarchyTemplateEnabled(
     projectOverride: Boolean?,
     globalProperty: Boolean?,
 ): Boolean = projectOverride ?: globalProperty ?: true
+
+/**
+ * Resolves whether the single-child collapse rule is enabled (issue #50), with the exact same
+ * precedence shape as the template gate: per-project override (the `kmpTargets { collapseHierarchy
+ * }` DSL) wins over the global `kmptargets.hierarchyCollapse` property, which wins over the
+ * built-in default of `true` (collapse — the minimal-tree behavior). Meaningless when the template
+ * itself is disabled: KGP's default hierarchy owns the tree then.
+ */
+internal fun resolveHierarchyCollapseEnabled(
+    projectOverride: Boolean?,
+    globalProperty: Boolean?,
+): Boolean = projectOverride ?: globalProperty ?: true

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
@@ -14,13 +14,20 @@ internal object ConfigKeys {
     const val HIERARCHY_TEMPLATE: String = "kmptargets.hierarchyTemplate"
 
     /**
+     * Global opt-out for the single-child collapse rule (`true`/`false`, default `true` —
+     * issue #50). When `false`, a group materializes with ≥1 present child, so intermediates like
+     * `iosMain` survive a single-leaf selection. No effect when the template itself is disabled.
+     */
+    const val HIERARCHY_COLLAPSE: String = "kmptargets.hierarchyCollapse"
+
+    /**
      * Global opt-in promoting the selection/host advisories to build failures (`true`/`false`,
      * default off — issue #34).
      */
     const val STRICT: String = "kmptargets.strict"
 
     /** Every key the dedicated config files may legally contain (unknown keys fail the build). */
-    val ALL: Set<String> = setOf(TARGETS, HIERARCHY_TEMPLATE, STRICT)
+    val ALL: Set<String> = setOf(TARGETS, HIERARCHY_TEMPLATE, HIERARCHY_COLLAPSE, STRICT)
 
     /** Committed, team-shared config file at the root of the build. */
     const val COMMITTED_FILE: String = "kmp-targets.properties"

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsPluginTest.kt
@@ -251,6 +251,25 @@ class KmpTargetsPluginTest {
     }
 
     @Test
+    fun `given committed config file with a hierarchyCollapse typo when plugin applied then the build fails with a suggestion`(
+        @TempDir dir: Path
+    ) {
+        // The collapse knob (issue #50) lives in the same validated key registry as the others.
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.hierachyCollapse=false\n")
+        val project = newProject(dir)
+        val ex =
+            assertFailsWith<Exception> { project.pluginManager.apply("com.rsicarelli.kmptargets") }
+        val rootCause =
+            generateSequence(ex as Throwable?) { it.cause }
+                .firstOrNull { it.message?.contains("kmp-targets.properties") == true }
+        assertNotNull(rootCause, "expected file-tagged cause in chain, root: ${ex.message}")
+        assertTrue(
+            rootCause.message!!.contains("did you mean 'kmptargets.hierarchyCollapse'?"),
+            "expected suggestion, got: ${rootCause.message}",
+        )
+    }
+
+    @Test
     fun `given the legacy placeholder task name when listed then it does not exist`(
         @TempDir dir: Path
     ) {

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyCollapseGateTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyCollapseGateTest.kt
@@ -1,0 +1,42 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Precedence of the collapse knob (issue #50), mirroring the hierarchy-template gate exactly:
+ * per-project DSL > global `kmptargets.hierarchyCollapse` > built-in default (`true`).
+ */
+class HierarchyCollapseGateTest {
+
+    @Test
+    fun `given nothing set when resolved then collapse defaults to true`() {
+        assertTrue(resolveHierarchyCollapseEnabled(projectOverride = null, globalProperty = null))
+    }
+
+    @Test
+    fun `given global false when resolved then collapse is false`() {
+        assertFalse(resolveHierarchyCollapseEnabled(projectOverride = null, globalProperty = false))
+    }
+
+    @Test
+    fun `given global true when resolved then collapse is true`() {
+        assertTrue(resolveHierarchyCollapseEnabled(projectOverride = null, globalProperty = true))
+    }
+
+    @Test
+    fun `given project false and no global when resolved then collapse is false`() {
+        assertFalse(resolveHierarchyCollapseEnabled(projectOverride = false, globalProperty = null))
+    }
+
+    @Test
+    fun `given project true over global false when resolved then the project override wins`() {
+        assertTrue(resolveHierarchyCollapseEnabled(projectOverride = true, globalProperty = false))
+    }
+
+    @Test
+    fun `given project false over global true when resolved then the project override wins`() {
+        assertFalse(resolveHierarchyCollapseEnabled(projectOverride = false, globalProperty = true))
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyComposerNoCollapseTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyComposerNoCollapseTest.kt
@@ -1,0 +1,136 @@
+package com.rsicarelli.kmptargets.hierarchy
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The no-collapse mode (issue #50): when collapse is disabled, a group materializes with **≥1**
+ * present child instead of ≥2, so intermediate source sets like `iosMain` survive a single-leaf
+ * selection — load-bearing for codebases with established `src/iosMain` dirs whose everyday
+ * workflow narrows the selection to one iOS leaf. Empty groups are still dropped, and ungrouped
+ * leaves (jvm/android/web) still never form groups.
+ */
+class HierarchyComposerNoCollapseTest {
+
+    @Test
+    fun `given a single iOS leaf and collapse disabled when computed then the full native apple ios chain materializes`() {
+        val spec =
+            computeHierarchySpec(
+                KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64),
+                collapse = false,
+            )
+        val expected =
+            spec(
+                group(
+                    HierarchyGroup.NATIVE,
+                    group(
+                        HierarchyGroup.APPLE,
+                        group(HierarchyGroup.IOS, leaf(KmpTarget.Native.Apple.Ios.Arm64)),
+                    ),
+                )
+            )
+        assertEquals(expected, spec)
+    }
+
+    @Test
+    fun `given two iOS leaves and collapse disabled when computed then ios still groups and parents materialize`() {
+        val spec =
+            computeHierarchySpec(
+                KmpTargetSet.of(
+                    KmpTarget.Native.Apple.Ios.Arm64,
+                    KmpTarget.Native.Apple.Ios.SimulatorArm64,
+                ),
+                collapse = false,
+            )
+        val expected =
+            spec(
+                group(
+                    HierarchyGroup.NATIVE,
+                    group(
+                        HierarchyGroup.APPLE,
+                        group(
+                            HierarchyGroup.IOS,
+                            leaf(KmpTarget.Native.Apple.Ios.Arm64),
+                            leaf(KmpTarget.Native.Apple.Ios.SimulatorArm64),
+                        ),
+                    ),
+                )
+            )
+        assertEquals(expected, spec)
+    }
+
+    @Test
+    fun `given jvm only and collapse disabled when computed then no groups appear`() {
+        // Ungrouped leaves attach directly to common in both modes — no-collapse must not invent
+        // groups that never owned the leaf.
+        val spec = computeHierarchySpec(KmpTargetSet.of(KmpTarget.Jvm.Desktop), collapse = false)
+        assertEquals(spec(leaf(KmpTarget.Jvm.Desktop)), spec)
+    }
+
+    @Test
+    fun `given an empty set and collapse disabled when computed then the spec is empty`() {
+        // Groups with zero present children are dropped in both modes.
+        assertEquals(
+            HierarchySpec(emptySet()),
+            computeHierarchySpec(KmpTargetSet.empty, collapse = false),
+        )
+    }
+
+    @Test
+    fun `given collapse enabled when computed then behavior is identical to the single-argument call`() {
+        // Regression pin: the default mode must stay byte-identical to the pre-knob composer.
+        for (set in
+            listOf(
+                KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64),
+                KmpTargetSet.appleMobile,
+                KmpTargetSet.apple,
+                KmpTargetSet.native,
+                KmpTargetSet.all,
+                KmpTargetSet.web,
+            )) {
+            assertEquals(computeHierarchySpec(set), computeHierarchySpec(set, collapse = true))
+        }
+    }
+
+    @Test
+    fun `given ios and linux and collapse disabled when computed then apple materializes between native and ios`() {
+        // With collapse on, this exact set produces nativeMain directly over iosMain + the linux
+        // leaf (appleMain collapses away). No-collapse keeps every owning group on the path.
+        val spec =
+            computeHierarchySpec(
+                KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64, KmpTarget.Native.Linux.X64),
+                collapse = false,
+            )
+        val expected =
+            spec(
+                group(
+                    HierarchyGroup.NATIVE,
+                    group(
+                        HierarchyGroup.APPLE,
+                        group(HierarchyGroup.IOS, leaf(KmpTarget.Native.Apple.Ios.Arm64)),
+                    ),
+                    group(HierarchyGroup.LINUX, leaf(KmpTarget.Native.Linux.X64)),
+                )
+            )
+        assertEquals(expected, spec)
+        assertTrue(HierarchyGroup.APPLE in spec.roots.flatMap { it.groupsRecursiveLocal() })
+    }
+
+    // -- helpers ----------------------------------------------------------------------------
+
+    private fun leaf(t: KmpTarget) = HierarchyNode.Leaf(t)
+
+    private fun group(g: HierarchyGroup, vararg children: HierarchyNode) =
+        HierarchyNode.Group(g, children.toSet())
+
+    private fun spec(vararg roots: HierarchyNode) = HierarchySpec(roots.toSet())
+
+    private fun HierarchyNode.groupsRecursiveLocal(): List<HierarchyGroup> =
+        when (this) {
+            is HierarchyNode.Leaf -> emptyList()
+            is HierarchyNode.Group -> listOf(group) + children.flatMap { it.groupsRecursiveLocal() }
+        }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/hierarchy/HierarchyTemplateInProcessTest.kt
@@ -125,6 +125,101 @@ class HierarchyTemplateInProcessTest {
     }
 
     @Test
+    fun `given single iosArm64 and global collapse false when applied then iosMain materializes`(
+        @TempDir dir: Path
+    ) {
+        // The no-collapse mode (issue #50): codebases with load-bearing src/iosMain must keep the
+        // intermediate when the selection narrows to one iOS leaf.
+        val sourceSets =
+            sourceSetsOf(dir, "iosArm64", extraProps = "kmptargets.hierarchyCollapse=false\n")
+        assertTrue("iosMain" in sourceSets, sourceSets.toString())
+    }
+
+    @Test
+    fun `given single iosArm64 and collapse false in committed config file when applied then iosMain materializes`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.hierarchyCollapse=false\n")
+        val sourceSets = sourceSetsOf(dir, "iosArm64")
+        assertTrue("iosMain" in sourceSets, sourceSets.toString())
+    }
+
+    @Test
+    fun `given collapse false in committed but true in personal file when applied then the single-leaf chain collapses`(
+        @TempDir dir: Path
+    ) {
+        // The collapse key reads through the same precedence chain as every other global (#30).
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.hierarchyCollapse=false\n")
+        dir.resolve("kmp-targets.local.properties").writeText("kmptargets.hierarchyCollapse=true\n")
+        val sourceSets = sourceSetsOf(dir, "iosArm64")
+        assertFalse("iosMain" in sourceSets, "personal file should win: $sourceSets")
+    }
+
+    @Test
+    fun `given a non-boolean collapse value when applied then it is treated as unset and the chain collapses`(
+        @TempDir dir: Path
+    ) {
+        // `no` is not a strict boolean → unset → built-in default (collapse on), same parsing
+        // contract as the template and strict flags.
+        val sourceSets =
+            sourceSetsOf(dir, "iosArm64", extraProps = "kmptargets.hierarchyCollapse=no\n")
+        assertFalse("iosMain" in sourceSets, "non-boolean must mean unset: $sourceSets")
+    }
+
+    @Test
+    fun `given global collapse false but project override true when applied then the single-leaf chain collapses`(
+        @TempDir dir: Path
+    ) {
+        val sourceSets =
+            sourceSetsOf(dir, "iosArm64", extraProps = "kmptargets.hierarchyCollapse=false\n") {
+                it.extensions.getByType(KmpTargetsExtension::class.java).collapseHierarchy.set(true)
+            }
+        assertFalse("iosMain" in sourceSets, "project override should win: $sourceSets")
+    }
+
+    @Test
+    fun `given hierarchy template false and collapse false when applied then collapse is a no-op and KGP default applies`(
+        @TempDir dir: Path
+    ) {
+        // The documented interaction (issue #50): with the template disabled, KGP's default
+        // hierarchy owns the tree, so the collapse knob changes nothing.
+        val sourceSets =
+            sourceSetsOf(
+                dir,
+                "iosArm64,iosX64,iosSimulatorArm64",
+                extraProps =
+                    "kmptargets.hierarchyTemplate=false\nkmptargets.hierarchyCollapse=false\n",
+            )
+        assertTrue("appleMain" in sourceSets, "KGP default should own the tree: $sourceSets")
+        assertTrue("nativeMain" in sourceSets, sourceSets.toString())
+    }
+
+    @Test
+    fun `given two ios leaves and collapse false when applied then commonMain edges survive through the full chain`(
+        @TempDir dir: Path
+    ) {
+        // The full materialized chain must stay connected: leaf → ios → apple → native → common.
+        dir.resolve("gradle.properties")
+            .writeText(
+                "kmptargets.targets=iosArm64,iosSimulatorArm64\nkmptargets.hierarchyCollapse=false\n"
+            )
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.extensions.getByType(KmpTargetsExtension::class.java).supports(KmpTargetSet.all)
+        (project as ProjectInternal).evaluate()
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        val sourceSets = kotlin.sourceSets.names.toSet()
+        assertTrue("iosMain" in sourceSets, sourceSets.toString())
+        assertTrue("appleMain" in sourceSets, sourceSets.toString())
+        assertTrue("nativeMain" in sourceSets, sourceSets.toString())
+        val iosDependsOn = kotlin.sourceSets.getByName("iosMain").dependsOn.map { it.name }
+        assertTrue("appleMain" in iosDependsOn, iosDependsOn.toString())
+        val nativeDependsOn = kotlin.sourceSets.getByName("nativeMain").dependsOn.map { it.name }
+        assertTrue("commonMain" in nativeDependsOn, nativeDependsOn.toString())
+    }
+
+    @Test
     fun `given a plain Kotlin Multiplatform module without kmp-targets when applied then KGP default is untouched`(
         @TempDir dir: Path
     ) {

--- a/samples/hello-world/pinned-intermediates/build.gradle.kts
+++ b/samples/hello-world/pinned-intermediates/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    // The no-collapse mode (issue #50). With collapse ON (the default), this module's two selected
+    // iOS leaves would share a single `iosMain` and — worse — narrowing the selection to ONE leaf
+    // (`-Pkmptargets.targets=iosArm64`, the everyday "build for device only" move) would drop
+    // `iosMain` entirely, breaking any module with load-bearing `src/iosMain` code. With collapse
+    // OFF, every owning group materializes (≥1 present child): `iosMain`, `appleMain`, and
+    // `nativeMain` all exist, and they survive a single-leaf selection. The empty parents are
+    // inert. What REGISTERS never changes — only which intermediate source sets materialize.
+    kotlin("multiplatform")
+    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+}
+
+kmpTargets {
+    // Same ordering rule as hierarchyTemplate: set BEFORE `supports`, which eagerly registers and
+    // applies the template. Project DSL wins over the global `kmptargets.hierarchyCollapse` key.
+    collapseHierarchy.set(false)
+    supports { appleMobile }
+}
+
+// Regression gate, wired into `check` and run by `task ci`. The read is a provider on purpose —
+// unlike eager TARGET registration, the template's intermediate SOURCE SETS materialize during
+// KGP's finalization, after this body runs. The provider realizes post-body and the config cache
+// stores only the resulting Set<String> (no Project captured). Host-blind: asserts source-set
+// existence only, no native compilation.
+val observedSourceSets = provider { kotlin.sourceSets.names.toSet() }
+
+tasks.register("verifyPinnedIntermediates") {
+    val observed = observedSourceSets
+    val expected = setOf("iosMain", "appleMain", "nativeMain")
+    doLast {
+        val sets = observed.get()
+        check(sets.containsAll(expected)) {
+            "no-collapse regressed: expected $expected to materialize, saw $sets"
+        }
+    }
+}
+
+tasks.named("check") { dependsOn("verifyPinnedIntermediates") }

--- a/samples/hello-world/settings.gradle.kts
+++ b/samples/hello-world/settings.gradle.kts
@@ -48,6 +48,11 @@ include(":core-and-apple")
 // supports{all}, opts OUT → KGP default: iosMain + appleMain + nativeMain
 include(":legacy-default")
 
+// supports{appleMobile}, collapse OFF → iosMain + appleMain + nativeMain all materialize, so
+// `iosMain` survives even a single-leaf selection. `verifyPinnedIntermediates` fails the build if
+// the pinned chain ever collapses again.
+include(":pinned-intermediates")
+
 // no kmp-targets at all → KGP default, untouched (non-interference)
 include(":plain-kmp")
 


### PR DESCRIPTION
Closes #50

## The failure story

The minimal hierarchy template collapses single-child groups — the right default for new code. But established codebases have **load-bearing intermediate source dirs**: the real consumer this was validated against has ~40 modules with `src/iosMain` holding `actual` implementations, and its everyday selection is a **single iOS leaf** (`-Pkmptargets.targets=iosArm64`, the "build for device only" move). Under the collapse rule that selection silently drops `iosMain` from the model, and the build breaks with unresolved `expect` declarations — making the most common selection-change workflow unsafe exactly for the consumers the plugin targets.

## What this adds

An opt-in **no-collapse** mode: a group materializes whenever it has **≥1 present child** (instead of ≥2), so `iosMain` survives a single-iOS-leaf selection. Single-child chains materialize fully (`nativeMain → appleMain → iosMain` for one iOS leaf); the inert empty intermediates are harmless. Empty groups still drop, and ungrouped leaves (jvm/android/web) still never form groups — in either mode.

- **Global key**: `kmptargets.hierarchyCollapse=false` — registered in the validated key registry, so a typo fails with a did-you-mean suggestion; reads through the standard precedence chain (CLI `-P` → env → personal file → committed file → `gradle.properties` → `local.properties`).
- **Per-module DSL**: `kmpTargets { collapseHierarchy.set(false) }`, set before `supports { }` (same eager-registration ordering rule as `hierarchyTemplate`).
- **Precedence** mirrors `hierarchyTemplate`: project DSL > global key > built-in default (`true`, collapse — current behavior, pinned byte-identical by regression tests).
- **Never changes what registers** — only which intermediate source sets materialize. Config-cache safe: the global is read once at apply time as a primitive.
- **Documented no-op** when `hierarchyTemplate` resolves to `false` (KGP's default template owns the tree then) — pinned by an in-process test.

## Key-name decision

The issue text suggested `kmptargets.hierarchy.collapse`; this PR uses **`kmptargets.hierarchyCollapse`** for consistency with the existing flat-camelCase namespace (`kmptargets.hierarchyTemplate`, `kmptargets.strict`). Noted on the issue.

## Validation

Re-derived from a bundled implementation validated against a real consumer (~40 modules with load-bearing `src/iosMain`, everyday selection = one iOS leaf). Coverage:

- `HierarchyComposerNoCollapseTest` — pure composer in no-collapse mode, incl. the default-mode byte-identity regression pin
- `HierarchyCollapseGateTest` — full precedence table
- `HierarchyTemplateInProcessTest` — real KGP in-process: global key, committed file, personal-over-committed, project override, non-boolean = unset, template-off no-op, and full-chain `dependsOn` edges
- `KmpTargetsPluginTest` — did-you-mean on a `hierachyCollapse` typo
- Sample `:pinned-intermediates` with a `verifyPinnedIntermediates` gate wired into `check`; passes under both the default selection and `-Pkmptargets.targets=iosArm64`

`task ci` green (check + publish-local + both samples, configuration cache stored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)