### PR TITLE
feat: advisory when androidTarget is selected but no Android plugin is applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ changes may land in any release.
   with **≥1** present child instead of ≥2, so intermediates like `iosMain` survive a single-leaf
   selection — for codebases with load-bearing `src/iosMain` dirs. Default unchanged (`true`,
   collapse); never changes what registers; no-op when `kmptargets.hierarchyTemplate=false`.
+- **Android-without-AGP advisory** ([#51]): when a module both selects and supports
+  `androidTarget` but no Android Gradle plugin is applied by the time `supports { }` runs, the
+  plugin skips registering that leaf — the KGP alternative is the fatal
+  `AndroidGradlePluginIsMissing` crash — and logs a one-line advisory naming the module and the
+  fix (apply `com.android.library`/`com.android.application` before `supports { }`), promoted to
+  a build failure under `kmptargets.strict=true` with the identical text. The detection mirrors
+  KGP's full Android plugin id list, the advisory fires at most once per module, and
+  `kmpTargetsInfo` marks the leaf `androidTarget (skipped: no Android plugin applied)` while the
+  condition holds.
 
 ### Fixed
 
@@ -65,3 +74,4 @@ changes may land in any release.
 [#48]: https://github.com/rsicarelli/kmp-targets/issues/48
 [#49]: https://github.com/rsicarelli/kmp-targets/issues/49
 [#50]: https://github.com/rsicarelli/kmp-targets/issues/50
+[#51]: https://github.com/rsicarelli/kmp-targets/issues/51

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Dynamically select which Kotlin Multiplatform targets to build.
 
-**Status:** alpha (pre-1.0). Shipped and exercised by the multi-module sample plus a real 3-OS CI matrix: the global selector with [try-import-style layering](#selecting-targets) (dedicated config files, unified `kmptargets.*` keys), the automatic [minimal hierarchy template](#minimal-hierarchy-template), the [`kmpTargetsInfo`](#debugging-the-selection) introspection task, [host-compatibility](#host-compatibility) and [deprecated-target](#deprecated-targets) advisories, and opt-in [strict mode](#strict-mode). Roadmap: user-defined hierarchy groups, XCFramework helpers, Maven Central / Plugin Portal publishing.
+**Status:** alpha (pre-1.0). Shipped and exercised by the multi-module sample plus a real 3-OS CI matrix: the global selector with [try-import-style layering](#selecting-targets) (dedicated config files, unified `kmptargets.*` keys), the automatic [minimal hierarchy template](#minimal-hierarchy-template), the [`kmpTargetsInfo`](#debugging-the-selection) introspection task, [host-compatibility](#host-compatibility), [deprecated-target](#deprecated-targets), and [android-without-AGP](#android-target-without-the-android-gradle-plugin) advisories, and opt-in [strict mode](#strict-mode). Roadmap: user-defined hierarchy groups, XCFramework helpers, Maven Central / Plugin Portal publishing.
 
 `kmp-targets` is a Gradle plugin for Kotlin Multiplatform projects that lets each developer (and each CI runner) choose which KMP targets to build, via a single Gradle property:
 
@@ -414,10 +414,39 @@ the advisory fires at most once per leaf per module and only for leaves that act
 listing. (`iosX64` is low-tier but *not* deprecated — it carries no marker.) The set is pinned in
 the plugin against the docs page and updated deliberately with Kotlin upgrades.
 
+### Android target without the Android Gradle plugin
+
+`androidTarget` is the one leaf whose registration needs more than KGP: `kotlin.androidTarget()`
+is a **hard KGP failure** (the FATAL `AndroidGradlePluginIsMissing` diagnostic) unless an Android
+Gradle plugin — `com.android.library` or `com.android.application` (or any other id KGP accepts:
+`dynamic-feature`, `test`, …) — is already applied to the module. So when a module both selects
+and supports `androidTarget` but no Android plugin is applied by the time `supports { }` runs, the
+plugin **skips registering that leaf** and logs a one-line advisory naming the module and the fix:
+
+```
+kmp-targets: ':feature' selects and supports [androidTarget] but no Android Gradle plugin is
+applied — the target was not registered. Apply com.android.library or com.android.application
+before supports { }.
+```
+
+This is the one advisory that **does filter**: unlike its siblings, the flagged leaf genuinely does
+not register — the alternative is KGP's raw crash with no module-level guidance, which during
+build-logic migrations reads as "kmp-targets dropped my target". The skip happens in both modes;
+[strict mode](#strict-mode) only changes the severity of the signal. Everything else in the active
+set registers exactly as selected, and the advisory fires at most once per module.
+
+The fix is an **ordering rule**: apply the Android plugin *before* `supports { }`. A convention
+plugin that applies AGP after `supports { }` has already missed registration — though a later
+`supports { }` union re-checks, so AGP applied between two calls lets the later pass register the
+leaf normally. [`kmpTargetsInfo`](#debugging-the-selection) marks the leaf
+`androidTarget (skipped: no Android plugin applied)` in its registered section while the condition
+holds.
+
 ### Strict mode
 
-By default all three advisories — the **empty-overlap** warning (a non-empty selection that matches
+By default all four advisories — the **empty-overlap** warning (a non-empty selection that matches
 nothing a module `supports`, so the module registers zero targets), the
+[**android-without-AGP**](#android-target-without-the-android-gradle-plugin) advisory, the
 [**host-impossible**](#host-compatibility) warning, and the
 [**deprecated-target**](#deprecated-targets) advisory — are just that: warnings. Right for local
 iteration, easy to miss in CI, where a module silently building nothing is usually a real
@@ -425,8 +454,9 @@ configuration bug.
 
 `kmptargets.strict=true` promotes those advisories to configuration-time **build
 failures** (`GradleException`) with the **identical message text** — severity changes, policy does
-not. It never changes *which* configurations are flagged and never changes *what registers*.
-Default **off**, deliberately. The flag resolves through the same
+not. It never changes *which* configurations are flagged and never changes *what registers* (the
+[android-without-AGP](#android-target-without-the-android-gradle-plugin) skip happens with or
+without strict — the flag only escalates its signal). Default **off**, deliberately. The flag resolves through the same
 [precedence chain](#selecting-targets) as every `kmptargets.*` key; anything other than
 `true`/`false` (case-insensitive) is treated as unset, i.e. off.
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsDsl.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsDsl.kt
@@ -80,7 +80,8 @@ public object KmpTargetsDsl {
     // --- Leaves --------------------------------------------------------------------------------
 
     /**
-     * Android (the JVM-backed `androidTarget`); registers only when AGP is applied to the module.
+     * Android (the JVM-backed `androidTarget`); registers only when AGP is applied to the module —
+     * without it the leaf is skipped with an advisory naming the fix (#51).
      */
     public val androidTarget: KmpTargetSet = leaf(KmpTarget.Jvm.Android)
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -168,6 +168,9 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     /** True once the minimal hierarchy template has been applied, so it is applied at most once. */
     internal var hierarchyTemplateApplied: Boolean = false
 
+    /** True once the android-without-AGP advisory fired, so it fires at most once per module. */
+    internal var androidAgpWarned: Boolean = false
+
     /**
      * The resolved supported set: the declared value (unioned across [supports] calls), or
      * [KmpTargetSet.empty] if none was declared. Public so build-logic (and consumers) can read

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -148,6 +148,20 @@ public class KmpTargetsPlugin : Plugin<Project> {
             // The rename annotation (issue #49) reads lazily for the same post-body reason as the
             // selection providers: the body sets `targetName(...)` before `supports { }`.
             task.jvmRegisteredAs.set(target.provider { ext.jvmTargetName.orNull })
+            // Android-skip annotation (#51): same decision source as the advisory
+            // (`shouldWarnAndroidWithoutAgp`), realized lazily post-body and guarded by the same
+            // runtime KGP check as the host data — without KGP nothing registers, so there is no
+            // skip to report. AGP presence is read at provider realization, so AGP applied
+            // anywhere in the body still counts.
+            task.androidWithoutAgp.set(
+                target.provider {
+                    target.pluginManager.hasPlugin(KGP_ID) &&
+                        shouldWarnAndroidWithoutAgp(
+                            ext.resolvedSelection() intersect ext.resolvedSupported(),
+                            isAndroidPluginApplied(target),
+                        )
+                }
+            )
             // The config-layer origin is fixed at apply time, but the fallback labels must read
             // `defaultSelection` lazily — the body may override it after apply.
             task.originLabel.set(
@@ -311,10 +325,12 @@ public class KmpTargetsPlugin : Plugin<Project> {
      * repeated `supports` calls only register the delta (idempotent), each host warning names a
      * leaf at most once, and the template still applies at most once.
      *
-     * When [strict] is on (#34), both advisories fail the build instead of warning — with the
-     * identical message text. Severity changes; policy does not: `shouldWarnEmptyOverlap` and
-     * `impossibleOnHost` stay the single source of truth for *whether* to flag, and what registers
-     * is never affected.
+     * When [strict] is on (#34), the advisories fail the build instead of warning — with the
+     * identical message text. Severity changes; policy does not: `shouldWarnEmptyOverlap`,
+     * `shouldWarnAndroidWithoutAgp`, `impossibleOnHost`, and `freshDeprecated` stay the single
+     * source of truth for *whether* to flag. What registers is never affected — with one deliberate
+     * exception: `androidTarget` without an Android Gradle plugin is skipped in both modes (#51),
+     * because registering it is a hard KGP failure, not a choice.
      */
     private fun register(
         project: Project,
@@ -330,7 +346,15 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // Read once per registration pass, as a plain String — config-cache safe (issue #49). The
         // `targetName` sugar guarantees this was set before the jvm leaf registered.
         val jvmName: String? = ext.jvmTargetName.orNull
+        // Read fresh on every supports{} pass, so AGP applied between two calls counts for the
+        // later pass.
+        val androidPluginApplied = isAndroidPluginApplied(project)
         (active.members - ext.registered).forEach { leaf ->
+            // KGP's androidTarget() reports a FATAL diagnostic (AndroidGradlePluginIsMissing,
+            // thrown immediately) when no Android Gradle plugin is applied. Skip the leaf instead
+            // — the advisory below names the module and the fix — and do NOT record it, so a
+            // later supports{} pass after AGP is applied still registers it.
+            if (leaf == KmpTarget.Jvm.Android && !androidPluginApplied) return@forEach
             registerTarget(kotlin, leaf, jvmName)
             ext.registered.add(leaf)
         }
@@ -343,6 +367,19 @@ public class KmpTargetsPlugin : Plugin<Project> {
             warnOrFail(strict, emptyOverlapWarning(project.path, selection, supported)) {
                 project.logger.warn(it)
             }
+        }
+
+        // Android-without-AGP advisory (#51): the one family member that filters — androidTarget
+        // genuinely did not register (the loop above skipped it; the alternative is KGP's raw
+        // FATAL), so the message says exactly that. Mutually exclusive with empty-overlap (android
+        // active ⇒ the overlap is non-empty). Ordered before host/deprecated: under strict,
+        // "an asked-for target was NOT registered" beats "registered but uncompilable here" beats
+        // "registered but deprecated". Deduped once per module via the boolean flag (a set would
+        // be overkill for a single leaf), recorded AFTER warnOrFail (mirroring the host step) so
+        // a strict failure leaves no bookkeeping behind.
+        if (!ext.androidAgpWarned && shouldWarnAndroidWithoutAgp(active, androidPluginApplied)) {
+            warnOrFail(strict, androidWithoutAgpWarning(project.path)) { project.logger.warn(it) }
+            ext.androidAgpWarned = true
         }
 
         // Host-awareness (#32): names registered native targets this host cannot compile, never
@@ -386,6 +423,9 @@ public class KmpTargetsPlugin : Plugin<Project> {
             ext.deprecatedWarned += freshDeprecated
         }
 
+        // Deliberately receives the unfiltered active set even when android was skipped above:
+        // android is ungrouped in the hierarchy taxonomy (it attaches straight to common and
+        // never affects the native collapse), so filtering would change nothing.
         maybeApplyHierarchyTemplate(
             project,
             ext,
@@ -489,6 +529,49 @@ internal fun emptyOverlapWarning(
 ): String =
     "kmp-targets: '$path' supports ${ids(supported)} but the selection ${ids(selection)} " +
         "matches none of them — registering no targets for this module."
+
+/**
+ * KGP's own Android-plugin id list (`org.jetbrains.kotlin.gradle.utils.androidPluginIds`), mirrored
+ * verbatim so the registration guard skips `androidTarget` on exactly the modules where KGP's
+ * `androidTarget()` would fail — and never on ones (dynamic-feature, test, …) where it succeeds.
+ * Pinned by a test against narrowing to the two common ids.
+ */
+internal val androidPluginIds: List<String> =
+    listOf(
+        "com.android.application",
+        "com.android.library",
+        "com.android.dynamic-feature",
+        "com.android.test",
+        "com.android.instantapp",
+        "com.android.feature",
+    )
+
+/** Whether any Android Gradle plugin is applied to [project] — a cheap plugin-manager lookup. */
+internal fun isAndroidPluginApplied(project: Project): Boolean = androidPluginIds.any {
+    project.pluginManager.hasPlugin(it)
+}
+
+/**
+ * Whether to emit [androidWithoutAgpWarning]: `androidTarget` is in the active (registering) set
+ * but no Android Gradle plugin is applied, so the leaf cannot register — KGP's `androidTarget()` is
+ * a FATAL diagnostic without AGP. Pure over its inputs, so it is unit-testable without Gradle; the
+ * same decision drives the `kmpTargetsInfo` skipped annotation.
+ */
+internal fun shouldWarnAndroidWithoutAgp(
+    active: KmpTargetSet,
+    androidPluginApplied: Boolean,
+): Boolean = KmpTarget.Jvm.Android in active.members && !androidPluginApplied
+
+/**
+ * The android-without-AGP advisory (#51). Mirrors its siblings in shape; serves as both the warning
+ * and the strict-mode failure text through [warnOrFail]. Unlike them it reports a leaf that was
+ * genuinely NOT registered, and names the fix — the ordering rule that the Android plugin must be
+ * applied before `supports { }` runs.
+ */
+internal fun androidWithoutAgpWarning(path: String): String =
+    "kmp-targets: '$path' selects and supports [androidTarget] but no Android Gradle plugin is " +
+        "applied — the target was not registered. Apply com.android.library or " +
+        "com.android.application before supports { }."
 
 /**
  * The deprecated leaves of [active] not yet flagged for this module — the dedup math of the

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
@@ -22,6 +22,7 @@ internal fun formatKmpTargetsInfo(
     hostLabel: String,
     deprecatedIds: List<String>,
     jvmRegisteredAs: String? = null,
+    androidWithoutAgp: Boolean = false,
 ): String = buildString {
     appendLine("kmp-targets — $projectPath")
     appendLine()
@@ -45,6 +46,11 @@ internal fun formatKmpTargetsInfo(
             annotated(registeredOrNone(registeredIds, selectionIds, supportedIds), registeredIds) {
                 id ->
                 val markers = buildList {
+                    // The skip annotation (#51): the literal keeps this file pure-primitive; it
+                    // is KmpTarget.Jvm.Android.id.
+                    if (id == "androidTarget" && androidWithoutAgp) {
+                        add("(skipped: no Android plugin applied)")
+                    }
                     // The rename (issue #49) annotates the jvm leaf so the report explains why the
                     // build has e.g. `compileKotlinDesktop` tasks but no `jvm`-named target.
                     if (id == "jvm" && jvmRegisteredAs != null) {

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
@@ -66,6 +66,15 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
      */
     @get:Internal public abstract val jvmRegisteredAs: Property<String>
 
+    /**
+     * True when `androidTarget` is in the registered intersection but no Android Gradle plugin is
+     * applied, so registration skipped it (#51). The registered line reports `selection ∩
+     * supported` (like the host annotation), so the leaf stays listed and is marked `(skipped: no
+     * Android plugin applied)`. False when AGP is present — or when KGP is absent, in which case
+     * nothing registers and there is no skip to report.
+     */
+    @get:Internal public abstract val androidWithoutAgp: Property<Boolean>
+
     @TaskAction
     public fun report() {
         println(
@@ -82,6 +91,7 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
                 hostLabel = hostLabel.get(),
                 deprecatedIds = deprecatedIds.get(),
                 jvmRegisteredAs = jvmRegisteredAs.orNull?.takeIf { it.isNotBlank() },
+                androidWithoutAgp = androidWithoutAgp.get(),
             )
         )
     }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AndroidAgpAdvisoryInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AndroidAgpAdvisoryInProcessTest.kt
@@ -1,0 +1,201 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.info.KmpTargetsInfoTask
+import com.rsicarelli.kmptargets.model.KmpTarget
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * The android-without-AGP advisory (#51) wired into eager registration: when `androidTarget` is in
+ * `selection ∩ supported` but no Android Gradle plugin is applied, the registration loop SKIPS the
+ * leaf (KGP's `androidTarget()` is a FATAL diagnostic without AGP — pinned below) and the advisory
+ * names the module and the fix — failing with the identical text under `kmptargets.strict=true`
+ * through the same [warnOrFail] escalation point as every other advisory.
+ *
+ * No AGP is on this test classpath, which is exactly the condition under test. The complementary
+ * AGP-applied path ("no advisory, android registers") cannot run in-process: faking the
+ * `com.android.library` id makes KGP's eager `plugins.withId` wiring cast a real AGP
+ * `BaseExtension` and crash, and a real AGP is incompatible with this Gradle/KGP test matrix. That
+ * path is covered at the pure policy seam ([AndroidAgpAdvisoryTest]: `androidPluginApplied = true`
+ * never flags), mirroring how `EnforceHostCompatibilityTest` simulates foreign hosts.
+ */
+class AndroidAgpAdvisoryInProcessTest {
+
+    private val android = KmpTarget.Jvm.Android
+
+    @Test
+    fun `given a KGP project without any android plugin when androidTarget is called directly then KGP fails with its missing-AGP diagnostic`(
+        @TempDir dir: Path
+    ) {
+        // Pins the observed KGP 2.3.21 behavior the guard exists for: androidTarget() without AGP
+        // reports the FATAL AndroidGradlePluginIsMissing diagnostic, thrown immediately. If a
+        // future KGP turns this into a no-op or warning, this red flags the guard for re-review.
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        val ex = assertFails { kotlin.androidTarget() }
+        assertContains(ex.message.orEmpty(), "Android Gradle Plugin")
+    }
+
+    @Test
+    fun `given android selected and supported but no android plugin when supports is declared then android is skipped and the build succeeds`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=android,jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { androidTarget + jvm }
+        // The skip is the advisory's whole point: without it, registration dies mid-loop on KGP's
+        // raw FATAL. Everything else in the active set registers exactly as selected.
+        assertEquals(setOf("jvm"), registeredTargets(project))
+        assertTrue(extension.androidAgpWarned)
+    }
+
+    @Test
+    fun `given strict on and android selected and supported but no android plugin when supports is declared then the build fails with the advisory text`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=android,jvm\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val ex = assertFailsWith<GradleException> { ext(project).supports { androidTarget + jvm } }
+        assertEquals(androidWithoutAgpWarning(project.path), ex.message)
+    }
+
+    @Test
+    fun `given android selected but not supported when supports is declared then no advisory fires`(
+        @TempDir dir: Path
+    ) {
+        // Keyed off the ACTIVE set: android the module cannot build was never going to register,
+        // so there is nothing to flag.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=android,jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { jvm }
+        assertFalse(extension.androidAgpWarned)
+    }
+
+    @Test
+    fun `given android supported but not selected when supports is declared then no advisory fires`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { androidTarget + jvm }
+        assertFalse(extension.androidAgpWarned)
+    }
+
+    @Test
+    fun `given the advisory already fired when a second supports union re-registers then it does not repeat`(
+        @TempDir dir: Path
+    ) {
+        // Strict makes "does not repeat" assertable: pre-seeding the dedup flag must leave the
+        // second pass with nothing to throw (mirrors the deprecation suite's hostWarned pre-seed).
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=android,jvm\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.androidAgpWarned = true
+        extension.supports { androidTarget + jvm }
+        assertEquals(setOf("jvm"), registeredTargets(project))
+    }
+
+    @Test
+    fun `given the advisory fired once when supports is called again without AGP then the flag stays set and nothing fails`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=android,jvm,js\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { androidTarget + jvm }
+        assertTrue(extension.androidAgpWarned)
+        // The union re-runs registration; android is still active and still AGP-less, but the
+        // module was already warned — the pass stays quiet and registers only the fresh leaf.
+        extension.supports { js }
+        assertTrue(extension.androidAgpWarned)
+        assertEquals(setOf("jvm", "js"), registeredTargets(project))
+    }
+
+    @Test
+    fun `given android skipped when registration completes then android stays out of the registered bookkeeping`(
+        @TempDir dir: Path
+    ) {
+        // NOT recording the skipped leaf is what lets a later supports{} pass — after AGP is
+        // applied — register it: the loop only registers `active - registered`.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=android,jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { androidTarget + jvm }
+        assertFalse(android in extension.registered)
+    }
+
+    @Test
+    fun `given android active without an android plugin when the info annotation input is read then it is true`(
+        @TempDir dir: Path
+    ) {
+        // Same decision source as the advisory (shouldWarnAndroidWithoutAgp), realized lazily at
+        // task-graph calculation — so the report annotates the registered section with
+        // `androidTarget (skipped: no Android plugin applied)` exactly when the advisory fired.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=android,jvm\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { androidTarget + jvm }
+        val task = project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+        assertTrue(task.androidWithoutAgp.get())
+    }
+
+    @Test
+    fun `given android not selected when the info annotation input is read then it is false`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { androidTarget + jvm }
+        val task = project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+        assertFalse(task.androidWithoutAgp.get())
+    }
+
+    @Test
+    fun `given strict on when the advisory throws then it leaves no dedup bookkeeping behind`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=android,jvm\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        assertFailsWith<GradleException> { extension.supports { androidTarget + jvm } }
+        // Mirrors the host/deprecated doctrine: the flag is recorded AFTER warnOrFail, so a strict
+        // failure does not mark the module as already-warned.
+        assertFalse(extension.androidAgpWarned)
+    }
+
+    private fun newProjectWithKgp(dir: Path): Project {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        return project
+    }
+
+    private fun ext(project: Project): KmpTargetsExtension =
+        project.extensions.getByType(KmpTargetsExtension::class.java)
+
+    private fun registeredTargets(project: Project): Set<String> =
+        project.extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .names
+            .filter { it != "metadata" }
+            .toSet()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AndroidAgpAdvisoryTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AndroidAgpAdvisoryTest.kt
@@ -1,0 +1,85 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure decision/message facts of the android-without-AGP advisory (#51): `androidTarget` in the
+ * active set can only register when an Android Gradle plugin is applied — KGP's `androidTarget()`
+ * is a FATAL diagnostic without one — so the policy flags exactly the active-android-no-AGP
+ * combination. No Gradle here; the wiring (skip + warnOrFail + dedup) is proven by
+ * [AndroidAgpAdvisoryInProcessTest].
+ */
+class AndroidAgpAdvisoryTest {
+
+    private val android = KmpTarget.Jvm.Android
+    private val jvm = KmpTarget.Jvm.Desktop
+
+    @Test
+    fun `given androidTarget active and no android plugin when the policy is computed then it flags`() {
+        assertTrue(
+            shouldWarnAndroidWithoutAgp(
+                active = KmpTargetSet.of(android, jvm),
+                androidPluginApplied = false,
+            )
+        )
+    }
+
+    @Test
+    fun `given androidTarget active and an android plugin applied when the policy is computed then it does not flag`() {
+        assertFalse(
+            shouldWarnAndroidWithoutAgp(
+                active = KmpTargetSet.of(android, jvm),
+                androidPluginApplied = true,
+            )
+        )
+    }
+
+    @Test
+    fun `given androidTarget not in the active set and no android plugin when the policy is computed then it does not flag`() {
+        assertFalse(
+            shouldWarnAndroidWithoutAgp(active = KmpTargetSet.of(jvm), androidPluginApplied = false)
+        )
+    }
+
+    @Test
+    fun `given an empty active set when the policy is computed then it does not flag`() {
+        assertFalse(
+            shouldWarnAndroidWithoutAgp(active = KmpTargetSet.empty, androidPluginApplied = false)
+        )
+    }
+
+    @Test
+    fun `given a module path when the warning is built then it names the leaf the skip and the fix`() {
+        val message = androidWithoutAgpWarning(":feature")
+        assertContains(message, ":feature")
+        assertContains(message, "[androidTarget]")
+        assertContains(message, "the target was not registered")
+        assertContains(message, "com.android.library")
+        assertContains(message, "com.android.application")
+        assertContains(message, "before supports { }")
+    }
+
+    @Test
+    fun `given the mirrored android plugin id list when compared then it matches KGP's full set`() {
+        // Pins the guard against narrowing to library/application only: the guard SUPPRESSES
+        // registration, so missing an id KGP accepts (dynamic-feature, test, …) would wrongly
+        // skip android on a module where KGP's androidTarget() succeeds.
+        assertEquals(
+            listOf(
+                "com.android.application",
+                "com.android.library",
+                "com.android.dynamic-feature",
+                "com.android.test",
+                "com.android.instantapp",
+                "com.android.feature",
+            ),
+            androidPluginIds,
+        )
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
@@ -147,6 +147,21 @@ class KmpTargetsInfoFormatTest {
     }
 
     @Test
+    fun `given androidTarget registered but skipped for want of an android plugin when formatted then it is marked skipped`() {
+        val output =
+            format(registeredIds = listOf("androidTarget", "jvm"), androidWithoutAgp = true)
+        assertContains(output, "androidTarget (skipped: no Android plugin applied)")
+        assertFalse("jvm (skipped" in output, output)
+    }
+
+    @Test
+    fun `given an android plugin applied when formatted then no skipped annotation appears`() {
+        val output =
+            format(registeredIds = listOf("androidTarget", "jvm"), androidWithoutAgp = false)
+        assertFalse("skipped" in output, output)
+    }
+
+    @Test
     fun `given the vocabulary when formatted then exactly the deprecated leaves carry the marker`() {
         val output = format(deprecatedIds = listOf("macosX64", "tvosX64", "watchosX64"))
         assertContains(output, "macosX64 (deprecated)")
@@ -166,6 +181,7 @@ class KmpTargetsInfoFormatTest {
         hostLabel: String = "",
         deprecatedIds: List<String> = emptyList(),
         jvmRegisteredAs: String? = null,
+        androidWithoutAgp: Boolean = false,
     ): String =
         formatKmpTargetsInfo(
             projectPath = ":shared-core",
@@ -180,5 +196,6 @@ class KmpTargetsInfoFormatTest {
             hostLabel = hostLabel,
             deprecatedIds = deprecatedIds,
             jvmRegisteredAs = jvmRegisteredAs,
+            androidWithoutAgp = androidWithoutAgp,
         )
 }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTaskTest.kt
@@ -213,6 +213,17 @@ class KmpTargetsInfoTaskTest {
     }
 
     @Test
+    fun `given the plugin without KGP when the android annotation input is read then it degrades to false`(
+        @TempDir dir: Path
+    ) {
+        // Without KGP nothing registers at all, so there is no skipped android leaf to annotate —
+        // the provider's KGP guard keeps the report quiet (same wiring path as the host data).
+        val project = newAppliedProject(dir)
+        project.extensions.getByType(KmpTargetsExtension::class.java).supports { mobile }
+        assertFalse(infoTask(project).androidWithoutAgp.get())
+    }
+
+    @Test
     fun `given the info task when deprecated ids are read then they are the pinned registry sorted`(
         @TempDir dir: Path
     ) {

--- a/samples/hello-world/feature-mobile/build.gradle.kts
+++ b/samples/hello-world/feature-mobile/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
     // single `iosMain` — with NO `appleMain`/`nativeMain`. Android isn't selected, so no AGP. The
     // starkest collapse: KGP's default would add 3 redundant intermediates here; the template adds
     // one.
+    //
+    // This module also demos the android-without-AGP advisory (#51): it supports `mobile` (which
+    // includes androidTarget) but applies no Android Gradle plugin, so selecting android skips the
+    // leaf and warns instead of dying on KGP's raw missing-AGP error. See it fire:
+    //   ./gradlew :feature-mobile:kmpTargetsInfo -Pkmptargets.targets=android
+    // (add -Pkmptargets.strict=true to make it fail with the same text)
     kotlin("multiplatform")
     id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
 }


### PR DESCRIPTION
Closes #51

## The failure story

`androidTarget` is the one leaf whose registration needs more than KGP. When a module both selects and supports it but no Android Gradle plugin is applied by the time `supports { }` runs — the easiest ordering to violate from convention plugins during build-logic migrations — the result read as "kmp-targets dropped my target", except worse: it wasn't silent at all.

## Pinned observed behavior (KGP 2.3.21)

The issue assumed a silent skip; the observed behavior is a **hard crash**. `kotlin.androidTarget()` without AGP reports the FATAL `AndroidGradlePluginIsMissing` diagnostic, which the diagnostics collector **throws immediately** from `KotlinAndroidTargetPreset.createTargetInternal` — so registration died mid-`supports{}` on a raw KGP error with no module path and no kmp-targets-level guidance. A test pins this (`given a KGP project without any android plugin when androidTarget is called directly then KGP fails with its missing-AGP diagnostic`); if a future KGP changes the behavior, that red flags the guard for re-review.

## What this PR does

The registration loop now **skips** `androidTarget` when no Android plugin is applied — without recording it in `registered`, so a later `supports{}` pass after AGP is applied still registers it — and a new advisory-family member converts the crash into the family's signal:

```
kmp-targets: ':feature' selects and supports [androidTarget] but no Android Gradle plugin is
applied — the target was not registered. Apply com.android.library or com.android.application
before supports { }.
```

### Advisory-family doctrine

- Pure policy function (`shouldWarnAndroidWithoutAgp`) decides *whether*; unit-tested without Gradle.
- One message function (`androidWithoutAgpWarning`) serves both severities verbatim through `warnOrFail`; `kmptargets.strict=true` promotes it to a `GradleException` with identical text.
- Deduped once per module via a boolean extension flag (one leaf — a set would be overkill), recorded **after** `warnOrFail` so a strict failure leaves no bookkeeping (mirrors host/deprecated).
- **The doctrine exception, stated explicitly:** unlike its siblings this advisory *does* filter — the leaf genuinely does not register, because the alternative is KGP's crash, not a choice. The skip happens in both modes; strict only escalates the signal. README spells this out.

### Ordering decision

Placed after empty-overlap, before host/deprecated. Empty-overlap and this advisory are mutually exclusive (android active ⇒ overlap non-empty); among the leaf advisories under strict, "an asked-for target was NOT registered" beats "registered but uncompilable here" beats "registered but deprecated". Documented in a comment mirroring the existing host-before-deprecated rationale.

### AGP detection

Mirrors **KGP's full Android plugin id list** (`com.android.application`, `library`, `dynamic-feature`, `test`, `instantapp`, `feature`) rather than the two ids from the issue text: since the guard suppresses registration, a narrower check would wrongly skip android on dynamic-feature/test modules where KGP's `androidTarget()` succeeds. A test pins the list; the message still names the two common fixes. Detection is a cheap `pluginManager.hasPlugin` lookup, read fresh on every `supports{}` pass — so AGP applied *between* two calls clears the condition for the later pass, and the leaf (never recorded as registered) registers normally then.

### The ordering rule (the fix)

Apply the Android plugin **before** `supports { }`. AGP after kmp-targets but before `supports{}` (the common convention-plugin order) → no advisory, registers fine. AGP after `supports{}` → that pass already skipped; a later `supports{}` union re-checks and registers it.

### kmpTargetsInfo

The registered section (which reports `selection ∩ supported`, like the host annotation) keeps listing the leaf and marks it `androidTarget (skipped: no Android plugin applied)` while the condition holds — same decision source as the advisory, lazily realized, guarded by the runtime KGP check; the new formatter param defaults to `false` so existing call sites compile unchanged.

## Test limitation, documented

The AGP-applied path ("no advisory, android registers") cannot run in-process: faking the `com.android.library` id makes KGP's eager `plugins.withId` wiring cast a real AGP `BaseExtension` and crash, and a real AGP is incompatible with this Gradle 9.5.1 / KGP 2.3.21 test matrix (AGP 9.x deprecates `androidTarget()`). That path is covered at the pure policy seam (`androidPluginApplied = true` never flags), mirroring how `EnforceHostCompatibilityTest` simulates foreign hosts. Everything else — skip, warn, strict, dedup, no-bookkeeping-on-throw, info annotation — runs in-process against real KGP.

## Sample

The committed selection (`jvm,iosArm64,iosSimulatorArm64`) never activates android, so `task ci` output is unchanged. `feature-mobile` documents the demo:

```
./gradlew -p samples/hello-world :feature-mobile:kmpTargetsInfo -Pkmptargets.targets=android
```

→ warn line for `:feature-mobile`/`:shared-core`/`:legacy-default` + the `(skipped: …)` marker; `-Pkmptargets.strict=true` fails the build. Verified locally; `task ci` green.

Independent of #48–#50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)