### PR TITLE
feat: registered-targets query surface for build-logic (registered(), onRegistered)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ changes may land in any release.
   with **≥1** present child instead of ≥2, so intermediates like `iosMain` survive a single-leaf
   selection — for codebases with load-bearing `src/iosMain` dirs. Default unchanged (`true`,
   collapse); never changes what registers; no-op when `kmptargets.hierarchyTemplate=false`.
+- **Registered-targets query surface for build-logic** ([#52]): `registered()` /
+  `registered(slice)` snapshot what the plugin **actually registered** as a `KmpTargetSet`
+  (family-sliceable with the existing presets: `registered(KmpTargetSet.appleMobile)`), and
+  `onRegistered { … }` delivers a `RegisteredTarget` per leaf with `configureEach` semantics
+  (replays for already-registered leaves, fires per delta of later `supports { }` unions) — so
+  per-target wiring like KSP's `ksp<Target>` configurations needs no KGP konan imports:
+  `onRegistered { add("ksp${it.gradleNameCapitalized}", dep) }`. The carrier's `gradleName` is the
+  name registration actually used (a renamed jvm reports `desktop`); `registered()` mirrors real
+  registrations, not the abstract plan — empty without KGP, and the #51-skipped `androidTarget`
+  stays absent.
 - **Android-without-AGP advisory** ([#51]): when a module both selects and supports
   `androidTarget` but no Android Gradle plugin is applied by the time `supports { }` runs, the
   plugin skips registering that leaf — the KGP alternative is the fatal
@@ -75,3 +85,4 @@ changes may land in any release.
 [#49]: https://github.com/rsicarelli/kmp-targets/issues/49
 [#50]: https://github.com/rsicarelli/kmp-targets/issues/50
 [#51]: https://github.com/rsicarelli/kmp-targets/issues/51
+[#52]: https://github.com/rsicarelli/kmp-targets/issues/52

--- a/README.md
+++ b/README.md
@@ -103,6 +103,52 @@ This is how a team centralizes per-module shape vocabulary in their own naming, 
 vocabulary baked into this plugin's artifact. The DSL stays the primitive; convention plugins are an
 optional layer you own.
 
+#### Querying what registered
+
+Conventions routinely need to wire *per-target* things after registration — the canonical case is
+KSP, where each target gets its own configuration (`kspIosArm64`, `kspIosSimulatorArm64`, …).
+Without help, every convention re-derives family matching and name mangling by importing KGP
+internals:
+
+```kotlin
+// Before — KGP konan types plus hand-rolled name mangling:
+kotlin.targets.withType<KotlinNativeTarget>()
+    .matching { it.konanTarget.family == Family.IOS }
+    .forEach { add("ksp${it.targetName.replaceFirstChar(Char::titlecase)}", dep) }
+```
+
+The extension exposes the **registered** set directly (issue #52), so build-logic never touches
+`konanTarget`:
+
+```kotlin
+// After — per-leaf hook with the actual Gradle name, pre-mangled:
+kmpTargets.onRegistered { add("ksp${it.gradleNameCapitalized}", dep) }
+
+// Snapshots, family-sliced with plain set algebra:
+kmpTargets.registered()                          // everything registered so far, as KmpTargetSet
+kmpTargets.registered(KmpTargetSet.appleMobile)  // just the registered iOS leaves
+```
+
+**Callback vs snapshot.** `onRegistered` has `configureEach` semantics: hooked *before* the
+module's `supports { }` it fires as each leaf registers; hooked *after*, it replays for the leaves
+already registered — and a later `supports { }` union fires only its delta. That makes it the
+ordering-immune choice for convention plugins. The `registered()` snapshot is the simple read for
+build-script code that runs after `supports { }`; remember it is a point-in-time value — a later
+`supports { }` call can union in more leaves.
+
+Each `onRegistered` callback receives a `RegisteredTarget`: the model leaf plus the Gradle target
+name registration **actually used** — a jvm leaf renamed via `targetName(jvm, "desktop")` reports
+`gradleName == "desktop"`, so configuration wiring keeps working without the consumer knowing
+about the rename. `registered()` deliberately mirrors real registrations, not the abstract
+`resolvedSelection() ∩ resolvedSupported()` plan: without KGP applied it is empty (and
+`onRegistered` never fires), and an `androidTarget` skipped because no Android Gradle plugin is
+applied stays absent — so KSP wiring can never target a configuration that doesn't exist. Like
+`supports`, the callback is a configuration-time tool: never hold it (or the extension) from a
+task action.
+
+The sample's [`kmpModule` convention](samples/hello-world/build-logic/src/main/kotlin/KmpModule.kt)
+uses `onRegistered` as the canonical pattern.
+
 ### Configuration files
 
 Global `kmp-targets` configuration lives in a **dedicated, committed root config file** —

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -2,6 +2,7 @@ package com.rsicarelli.kmptargets
 
 import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
+import com.rsicarelli.kmptargets.model.RegisteredTarget
 import javax.inject.Inject
 import org.gradle.api.GradleException
 import org.gradle.api.model.ObjectFactory
@@ -98,7 +99,7 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
         if (name.isBlank()) {
             throw GradleException("kmp-targets: the jvm target name must not be blank.")
         }
-        if (KmpTarget.Jvm.Desktop in registered) {
+        if (KmpTarget.Jvm.Desktop in registeredLeaves) {
             throw GradleException(
                 "kmp-targets: targetName must be called before supports { } — the jvm leaf " +
                     "already registered under its default name and KGP registration is one-way."
@@ -157,7 +158,7 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     public fun resolvedSelection(): KmpTargetSet = globalSelection ?: defaultSelection.get()
 
     /** Leaves already registered with KGP, so repeated registration stays idempotent. */
-    internal val registered: MutableSet<KmpTarget> = mutableSetOf()
+    internal val registeredLeaves: MutableSet<KmpTarget> = mutableSetOf()
 
     /** Leaves already named in a host-impossible warning, so each is warned at most once. */
     internal val hostWarned: MutableSet<KmpTarget> = mutableSetOf()
@@ -177,4 +178,77 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
      * what this module ended up declaring.
      */
     public fun resolvedSupported(): KmpTargetSet = supportsProperty.orNull ?: KmpTargetSet.empty
+
+    /**
+     * Every registration this plugin performed, in order, as [RegisteredTarget] carriers — the
+     * single source for [registered] snapshots and [onRegistered] replay. Appended by
+     * [recordRegistration] from the plugin's registration loop.
+     */
+    internal val registeredLog: MutableList<RegisteredTarget> = mutableListOf()
+
+    /** Actions hooked via [onRegistered], fired for each future [recordRegistration]. */
+    internal val onRegisteredActions: MutableList<(RegisteredTarget) -> Unit> = mutableListOf()
+
+    /**
+     * Records that [leaf] registered with KGP under [gradleName] and fires the [onRegistered]
+     * actions. The log is appended *before* firing and the actions iterate a snapshot, so an action
+     * that re-enters (e.g. by calling [supports]) sees a consistent log and never trips a
+     * concurrent modification — though nested fire ordering is unspecified and re-entering is not a
+     * supported pattern.
+     */
+    internal fun recordRegistration(leaf: KmpTarget, gradleName: String) {
+        val carrier = RegisteredTarget(leaf, gradleName)
+        registeredLog += carrier
+        onRegisteredActions.toList().forEach { it(carrier) }
+    }
+
+    /**
+     * Snapshot of the targets this plugin **actually registered** with KGP so far (issue #52) —
+     * `selection ∩ supported` as of the last [supports] call, minus anything registration skipped.
+     * One call instead of intersecting [resolvedSelection] and [resolvedSupported] by hand, but
+     * deliberately *not* the same thing: this mirrors real registrations, so it is empty when KGP
+     * is not applied, and omits `androidTarget` when no Android Gradle plugin is present (the #51
+     * skip). For the abstract plan regardless of what registered, intersect the two resolved sets
+     * yourself.
+     *
+     * It is a snapshot: a later [supports] call can union in more leaves. Read it *after* the
+     * module's `supports { }` for simple cases, or use [onRegistered] for ordering-immune wiring.
+     */
+    public fun registered(): KmpTargetSet =
+        KmpTargetSet.of(*registeredLog.map { it.leaf }.toTypedArray())
+
+    /**
+     * [registered] narrowed to [slice] via plain set algebra — family slicing without KGP konan
+     * types: `registered(KmpTargetSet.appleMobile)` is exactly the registered iOS leaves.
+     */
+    public fun registered(slice: KmpTargetSet): KmpTargetSet = registered() intersect slice
+
+    /**
+     * Runs [action] for every target this plugin registered: immediately for the ones already
+     * registered (replay), and again for each later registration (a second `supports { }` call
+     * fires only its delta) — `configureEach` semantics, so convention plugins don't care whether
+     * they run before or after the module's `supports { }`. The canonical per-target wiring,
+     * KSP-style, without importing KGP konan types or re-deriving name mangling:
+     * ```kotlin
+     * // Before:
+     * kotlin.targets.withType<KotlinNativeTarget>()
+     *     .matching { it.konanTarget.family == Family.IOS }
+     *     .forEach { add("ksp${it.targetName.replaceFirstChar(Char::titlecase)}", dep) }
+     *
+     * // After:
+     * kmpTargets.onRegistered { add("ksp${it.gradleNameCapitalized}", dep) }
+     * ```
+     *
+     * [RegisteredTarget.gradleName] is what registration actually called — `"desktop"` for a jvm
+     * leaf renamed via [targetName], not a name re-derived from the leaf. Never fires when KGP is
+     * absent (nothing registers), and never for the #51-skipped `androidTarget`.
+     *
+     * [action] runs at configuration time only — mirror the [supports] discipline and never hold it
+     * (or the extension) from a task action; the [RegisteredTarget] it receives is itself
+     * configuration-cache safe (a `data object` leaf plus strings).
+     */
+    public fun onRegistered(action: (RegisteredTarget) -> Unit) {
+        registeredLog.toList().forEach(action)
+        onRegisteredActions += action
+    }
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -349,14 +349,17 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // Read fresh on every supports{} pass, so AGP applied between two calls counts for the
         // later pass.
         val androidPluginApplied = isAndroidPluginApplied(project)
-        (active.members - ext.registered).forEach { leaf ->
+        (active.members - ext.registeredLeaves).forEach { leaf ->
             // KGP's androidTarget() reports a FATAL diagnostic (AndroidGradlePluginIsMissing,
             // thrown immediately) when no Android Gradle plugin is applied. Skip the leaf instead
             // — the advisory below names the module and the fix — and do NOT record it, so a
             // later supports{} pass after AGP is applied still registers it.
             if (leaf == KmpTarget.Jvm.Android && !androidPluginApplied) return@forEach
-            registerTarget(kotlin, leaf, jvmName)
-            ext.registered.add(leaf)
+            val gradleName = registerTarget(kotlin, leaf, jvmName)
+            // Leaf first, then the carrier+callbacks (issue #52): an onRegistered action that
+            // re-enters register() must already see this leaf as registered.
+            ext.registeredLeaves.add(leaf)
+            ext.recordRegistration(leaf, gradleName)
         }
 
         // The selection is non-empty yet genuinely disjoint from the supported set, so nothing
@@ -459,15 +462,22 @@ public class KmpTargetsPlugin : Plugin<Project> {
         ext.hierarchyTemplateApplied = true
     }
 
+    /**
+     * Registers [target] with KGP and returns the Gradle target name registration actually used —
+     * read off the `KotlinTarget` each KGP factory returns, never re-derived from the leaf, so the
+     * [RegisteredTarget][com.rsicarelli.kmptargets.model.RegisteredTarget] carriers stay truthful
+     * for the renamed jvm leaf (issue #49) and for whatever name KGP picks.
+     */
     private fun registerTarget(
         kotlin: KotlinMultiplatformExtension,
         target: KmpTarget,
         jvmName: String?,
-    ) {
+    ): String =
         when (target) {
             KmpTarget.Jvm.Android -> kotlin.androidTarget()
-            // The only renamable leaf (issue #49): KGP's hierarchy matchers (`withJvm()`) key off
-            // the platform type, so a custom-named jvm target attaches exactly like the default.
+            // The only renamable leaf (issue #49): KGP's hierarchy matchers (`withJvm()`) key
+            // off the platform type, so a custom-named jvm target attaches exactly like the
+            // default.
             KmpTarget.Jvm.Desktop -> if (jvmName != null) kotlin.jvm(jvmName) else kotlin.jvm()
             KmpTarget.Native.Apple.Ios.Arm64 -> kotlin.iosArm64()
             KmpTarget.Native.Apple.Ios.SimulatorArm64 -> kotlin.iosSimulatorArm64()
@@ -500,8 +510,7 @@ public class KmpTargetsPlugin : Plugin<Project> {
                     nodejs()
                 }
             KmpTarget.Web.WasmWasi -> kotlin.wasmWasi { nodejs() }
-        }
-    }
+        }.targetName
 }
 
 /**

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/RegisteredTarget.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/RegisteredTarget.kt
@@ -1,0 +1,33 @@
+package com.rsicarelli.kmptargets.model
+
+/**
+ * One target this plugin actually registered with KGP (issue #52): the model [leaf] plus the Gradle
+ * target [name][gradleName] registration really used — sourced from the `KotlinTarget` KGP
+ * returned, never re-derived from the leaf. That keeps it truthful for a renamed jvm leaf
+ * (`targetName(jvm, "desktop")` → `gradleName == "desktop"`), so per-target wiring works without
+ * the consumer touching KGP types:
+ * ```kotlin
+ * // Before — KGP internals plus hand-rolled name mangling:
+ * kotlin.targets.withType<KotlinNativeTarget>()
+ *     .matching { it.konanTarget.family == Family.IOS }
+ *     .forEach { add("ksp${it.targetName.replaceFirstChar(Char::titlecase)}", dep) }
+ *
+ * // After — the carrier delivered by KmpTargetsExtension.onRegistered:
+ * kmpTargets.onRegistered { add("ksp${it.gradleNameCapitalized}", dep) }
+ * ```
+ *
+ * Holds only a `data object` leaf and a `String` — immutable and configuration-cache safe by
+ * construction. Like everything around eager registration, it is a configuration-time value: don't
+ * store it in task state you don't own.
+ */
+public data class RegisteredTarget(val leaf: KmpTarget, val gradleName: String) {
+
+    /**
+     * [gradleName] with its first char title-cased, the shape Gradle configuration names mangle
+     * target names into — `"iosArm64"` → `"IosArm64"`, ready for
+     * `"ksp${it.gradleNameCapitalized}"`. Computed from [gradleName], so the two can never
+     * disagree.
+     */
+    public val gradleNameCapitalized: String
+        get() = gradleName.replaceFirstChar(Char::titlecase)
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AndroidAgpAdvisoryInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AndroidAgpAdvisoryInProcessTest.kt
@@ -139,7 +139,7 @@ class AndroidAgpAdvisoryInProcessTest {
         val project = newProjectWithKgp(dir)
         val extension = ext(project)
         extension.supports { androidTarget + jvm }
-        assertFalse(android in extension.registered)
+        assertFalse(android in extension.registeredLeaves)
     }
 
     @Test

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtensionTest.kt
@@ -1,6 +1,8 @@
 package com.rsicarelli.kmptargets
 
+import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
+import com.rsicarelli.kmptargets.model.RegisteredTarget
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -33,6 +35,58 @@ class KmpTargetsExtensionTest {
         ext.defaultSelection.set(KmpTargetSet.web)
         assertTrue(ext.defaultSelection.isPresent)
         assertEquals(KmpTargetSet.web, ext.defaultSelection.get())
+    }
+
+    @Test
+    fun `given nothing recorded when registered is read then it is empty`() {
+        val ext = newExtension()
+        assertEquals(KmpTargetSet.empty, ext.registered())
+        assertEquals(KmpTargetSet.empty, ext.registered(KmpTargetSet.appleMobile))
+    }
+
+    @Test
+    fun `given a recorded registration when registered is read then the snapshot holds the leaf`() {
+        val ext = newExtension()
+        ext.recordRegistration(KmpTarget.Native.Apple.Ios.Arm64, "iosArm64")
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64), ext.registered())
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64),
+            ext.registered(KmpTargetSet.appleMobile),
+        )
+        assertEquals(KmpTargetSet.empty, ext.registered(KmpTargetSet.web))
+    }
+
+    @Test
+    fun `given an action that records another registration when fired then no concurrent modification occurs`() {
+        // Re-entrancy guard: recordRegistration fires a snapshot of the actions, and onRegistered
+        // replays a snapshot of the log — an action that re-enters (e.g. by calling supports())
+        // must not blow up mid-iteration. Nested fire ordering stays unspecified.
+        val ext = newExtension()
+        val seen = mutableListOf<RegisteredTarget>()
+        ext.onRegistered {
+            if (it.leaf == KmpTarget.Jvm.Desktop) {
+                ext.recordRegistration(KmpTarget.Native.Apple.Ios.Arm64, "iosArm64")
+            }
+            seen += it
+        }
+        ext.recordRegistration(KmpTarget.Jvm.Desktop, "jvm")
+        assertEquals(
+            setOf(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64),
+            seen.map { it.leaf }.toSet(),
+        )
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64),
+            ext.registered(),
+        )
+    }
+
+    @Test
+    fun `given an action that hooks another action when replayed then no concurrent modification occurs`() {
+        val ext = newExtension()
+        ext.recordRegistration(KmpTarget.Jvm.Desktop, "jvm")
+        val inner = mutableListOf<RegisteredTarget>()
+        ext.onRegistered { ext.onRegistered { nested -> inner += nested } }
+        assertEquals(listOf(KmpTarget.Jvm.Desktop), inner.map { it.leaf })
     }
 
     private fun newExtension(): KmpTargetsExtension {

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsRegisteredTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsRegisteredTest.kt
@@ -1,0 +1,171 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import com.rsicarelli.kmptargets.model.RegisteredTarget
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * The registered-targets query surface (issue #52): [KmpTargetsExtension.registered] snapshots and
+ * the [KmpTargetsExtension.onRegistered] per-leaf hook let build-logic wire per-target things
+ * (canonically KSP's `ksp<Target>` configurations) off what this plugin actually registered —
+ * without importing KGP konan types or re-deriving name mangling.
+ */
+class KmpTargetsRegisteredTest {
+
+    @Test
+    fun `given supports mobile under a narrowed selection when registered is read then it equals selection intersect supported`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,jvm")
+        project.kmpTargets().supports(KmpTargetSet.mobile)
+        // mobile = androidTarget + ios*; the selection narrows it to iosArm64 (jvm is selected but
+        // not supported here).
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64),
+            project.kmpTargets().registered(),
+        )
+    }
+
+    @Test
+    fun `given a slice argument when registered appleMobile is read then only the apple-mobile leaves return`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,iosSimulatorArm64,jvm")
+        project
+            .kmpTargets()
+            .supports(KmpTargetSet.appleMobile + KmpTargetSet.of(KmpTarget.Jvm.Desktop))
+        assertEquals(
+            KmpTargetSet.of(
+                KmpTarget.Native.Apple.Ios.Arm64,
+                KmpTarget.Native.Apple.Ios.SimulatorArm64,
+            ),
+            project.kmpTargets().registered(KmpTargetSet.appleMobile),
+        )
+    }
+
+    @Test
+    fun `given onRegistered hooked before supports when supports runs then the action fires for every registered leaf`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "jvm,iosArm64")
+        val seen = mutableListOf<RegisteredTarget>()
+        project.kmpTargets().onRegistered { seen += it }
+        project
+            .kmpTargets()
+            .supports(KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64))
+        assertEquals(
+            setOf(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64),
+            seen.map { it.leaf }.toSet(),
+        )
+        assertEquals(setOf("jvm", "iosArm64"), seen.map { it.gradleName }.toSet())
+    }
+
+    @Test
+    fun `given onRegistered hooked after supports when hooked then it fires immediately for already-registered leaves`(
+        @TempDir dir: Path
+    ) {
+        // configureEach semantics: a convention plugin must not care whether it ran before or
+        // after the module's supports { } — late hooks replay the log.
+        val project = projectWithSelection(dir, "jvm,iosArm64")
+        project
+            .kmpTargets()
+            .supports(KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64))
+        val seen = mutableListOf<RegisteredTarget>()
+        project.kmpTargets().onRegistered { seen += it }
+        assertEquals(
+            setOf(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64),
+            seen.map { it.leaf }.toSet(),
+        )
+    }
+
+    @Test
+    fun `given two supports calls when the union registers a new leaf then onRegistered fires for the delta only`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "jvm,iosArm64,linuxX64")
+        val seen = mutableListOf<RegisteredTarget>()
+        project.kmpTargets().onRegistered { seen += it }
+        project
+            .kmpTargets()
+            .supports(KmpTargetSet.of(KmpTarget.Jvm.Desktop, KmpTarget.Native.Apple.Ios.Arm64))
+        assertEquals(2, seen.size, seen.toString())
+        project.kmpTargets().supports(KmpTargetSet.of(KmpTarget.Native.Linux.X64))
+        assertEquals(3, seen.size, "second supports must fire only the delta: $seen")
+        assertEquals(KmpTarget.Native.Linux.X64, seen.last().leaf)
+    }
+
+    @Test
+    fun `given KGP absent when registered and onRegistered are used then nothing registered and nothing fires`(
+        @TempDir dir: Path
+    ) {
+        // Documented semantics: registered() mirrors what actually registered with KGP — not the
+        // abstract selection ∩ supported plan. Without KGP nothing registers, so the snapshot is
+        // empty and the hook never fires (and nothing crashes).
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64,jvm\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val seen = mutableListOf<RegisteredTarget>()
+        project.kmpTargets().onRegistered { seen += it }
+        project.kmpTargets().supports(KmpTargetSet.mobile)
+        assertEquals(KmpTargetSet.empty, project.kmpTargets().registered())
+        assertEquals(emptyList(), seen)
+    }
+
+    @Test
+    fun `given the ksp use case when wiring config names via gradleNameCapitalized then the names match KGP's`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,iosSimulatorArm64")
+        val kspConfigurations = mutableSetOf<String>()
+        project.kmpTargets().onRegistered { kspConfigurations += "ksp${it.gradleNameCapitalized}" }
+        project.kmpTargets().supports(KmpTargetSet.appleMobile)
+        val expected =
+            project.kotlinTargetNames().map { "ksp${it.replaceFirstChar(Char::titlecase)}" }.toSet()
+        assertEquals(expected, kspConfigurations)
+        assertTrue("kspIosArm64" in kspConfigurations, kspConfigurations.toString())
+    }
+
+    @Test
+    fun `given a renamed jvm when onRegistered fires then gradleName is the custom name`(
+        @TempDir dir: Path
+    ) {
+        // Interplay with targetName (issue #49): the carrier reports what registration actually
+        // called — never a name re-derived from the leaf.
+        val project = projectWithSelection(dir, "jvm")
+        project.kmpTargets().targetName(KmpTargetsDsl.jvm, "desktop")
+        val seen = mutableListOf<RegisteredTarget>()
+        project.kmpTargets().onRegistered { seen += it }
+        project.kmpTargets().supports(KmpTargetSet.of(KmpTarget.Jvm.Desktop))
+        assertEquals(listOf(KmpTarget.Jvm.Desktop), seen.map { it.leaf })
+        assertEquals("desktop", seen.single().gradleName)
+        assertEquals("Desktop", seen.single().gradleNameCapitalized)
+    }
+
+    private fun projectWithSelection(dir: Path, selection: String): Project {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=$selection\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        return project
+    }
+
+    private fun Project.kmpTargets(): KmpTargetsExtension =
+        extensions.getByType(KmpTargetsExtension::class.java)
+
+    private fun Project.kotlinTargetNames(): Set<String> =
+        extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .names
+            .filter { it != "metadata" }
+            .toSet()
+}

--- a/samples/hello-world/build-logic/src/main/kotlin/KmpModule.kt
+++ b/samples/hello-world/build-logic/src/main/kotlin/KmpModule.kt
@@ -1,28 +1,30 @@
 import com.rsicarelli.kmptargets.KmpTargetsDsl
 import com.rsicarelli.kmptargets.KmpTargetsExtension
 import com.rsicarelli.kmptargets.model.KmpTargetSet
+import com.rsicarelli.kmptargets.model.RegisteredTarget
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getByType
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 /**
- * Declares this module's supported set, then reads `kotlin.targets` **synchronously** and hands the
- * registered target names to [perTarget].
+ * Declares this module's supported set and hands every registered target to [perTarget] via
+ * [KmpTargetsExtension.onRegistered] — the plugin's query surface (issue #52), the canonical way
+ * to wire per-target things (KSP configurations, per-target tasks) without touching KGP types.
  *
- * This is the capability that removing the after-evaluate pass unlocks: because `supports`
- * registers eagerly, the targets exist the instant this function reads them. Under the old deferred
- * model the same read returned an empty set, which is why convention plugins that wired per-target
- * behaviour right after declaration were fragile. The reactive `targets.configureEach { … }` in the
- * `kmptargets.module` plugin is the ordering-immune alternative shown alongside it.
+ * `onRegistered` has `configureEach` semantics: hooked before `supports`, it fires once per leaf
+ * as registration happens; hooked after, it replays — so this convention never cares about
+ * ordering, and a later `supports { }` union fires only its delta. Each [RegisteredTarget] carries
+ * the Gradle name registration actually used (a jvm leaf renamed via `targetName` reports the
+ * custom name), pre-mangled as `gradleNameCapitalized` for configuration-name wiring.
+ *
+ * The pre-#52 version of this helper read `kotlin.targets.names` synchronously right after
+ * `supports` — possible because registration is eager, but it left every convention re-deriving
+ * name filtering itself (and KSP-style family slicing meant importing KGP konan internals).
  */
 fun Project.kmpModule(
     supported: KmpTargetsDsl.() -> KmpTargetSet,
-    perTarget: (List<String>) -> Unit = {},
+    perTarget: (RegisteredTarget) -> Unit = {},
 ) {
-    extensions.getByType<KmpTargetsExtension>().supports(supported)
-    val targets =
-        extensions.getByType<KotlinMultiplatformExtension>().targets.names.filter {
-            it != "metadata"
-        }
-    perTarget(targets)
+    val kmpTargets = extensions.getByType<KmpTargetsExtension>()
+    kmpTargets.onRegistered(perTarget)
+    kmpTargets.supports(supported)
 }

--- a/samples/hello-world/build-logic/src/main/kotlin/KmpModulePlugin.kt
+++ b/samples/hello-world/build-logic/src/main/kotlin/KmpModulePlugin.kt
@@ -16,8 +16,11 @@ class KmpModulePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.pluginManager.apply("com.rsicarelli.kmptargets")
 
-        // The ordering-immune counterpart to `kmpModule`'s eager read: react to each target as it is
-        // registered. Fires when the consumer's `supports { … }` runs, regardless of order.
+        // KGP-native contrast to `kmpModule`'s `onRegistered` wiring: `targets.configureEach`
+        // reacts to every target in `kotlin.targets`, however it was registered. Prefer
+        // `onRegistered` when wiring off what *kmp-targets* registered (it carries the model leaf
+        // and the actual Gradle name); reach for `configureEach` when you need the KotlinTarget
+        // object itself.
         val log = project.logger
         project.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
             project.extensions.getByType<KotlinMultiplatformExtension>().targets.configureEach {

--- a/samples/hello-world/eager-conventions/build.gradle.kts
+++ b/samples/hello-world/eager-conventions/build.gradle.kts
@@ -5,18 +5,16 @@ plugins {
     id("kmptargets.module")
 }
 
-// EAGER PROOF. `kmpModule` declares the supported set and then reads `kotlin.targets`
-// synchronously,
-// wiring one task per registered target. With kmptargets.targets=jvm,iosArm64,iosSimulatorArm64
-// intersected
+// EAGER PROOF. `kmpModule` declares the supported set and wires one task per registered target
+// through the plugin's `onRegistered` hook (issue #52) — each carrier arrives with the actual
+// Gradle name pre-mangled (`gradleNameCapitalized`), the same shape KSP-style `ksp<Target>`
+// configuration wiring needs. With kmptargets.targets=jvm,iosArm64,iosSimulatorArm64 intersected
 // against supports { jvm + iosArm64 }, the convention sees exactly [iosArm64, jvm] — at
-// configuration
-// time, in the same pass. Under the old after-evaluate model this read would have been empty.
-kmpModule(supported = { jvm + iosArm64 }) { targets ->
-    targets.forEach { target ->
-        tasks.register("describe${target.replaceFirstChar(Char::uppercase)}") {
-            doLast { logger.lifecycle("eager-wired target: $target") }
-        }
+// configuration time, in the same pass. (Pre-#52 this read `kotlin.targets.names` by hand.)
+kmpModule(supported = { jvm + iosArm64 }) { target ->
+    tasks.register("describe${target.gradleNameCapitalized}") {
+        val gradleName = target.gradleName
+        doLast { logger.lifecycle("eager-wired target: $gradleName") }
     }
 }
 


### PR DESCRIPTION
## Problem

Convention plugins routinely wire *per-target* things after registration — the canonical case is KSP, where each target gets its own configuration (`kspIosArm64`, `kspIosSimulatorArm64`, …). Today every build-logic author re-derives family matching + name mangling by importing KGP internals:

```kotlin
kotlin.targets.withType<KotlinNativeTarget>()
    .matching { it.konanTarget.family == Family.IOS }
    .forEach { add("ksp${it.targetName.replaceFirstChar(Char::titlecase)}", dep) }
```

That couples consumers to `konanTarget`/`Family`, and it must stay in sync with what kmp-targets actually registered.

## Design note (the issue's open questions, settled)

**1. Snapshot vs callback → both.** Registration is eager but *additive* (multiple `supports {}` calls union), so a snapshot taken between two calls is stale. The surface is:

- `registered(): KmpTargetSet` — what actually registered, one call instead of intersecting `resolvedSelection()`/`resolvedSupported()` by hand
- `registered(slice: KmpTargetSet)` — family slicing via the existing set algebra (`registered(KmpTargetSet.appleMobile)`), no konan types
- `onRegistered(action: (RegisteredTarget) -> Unit)` — `configureEach` semantics: replays immediately for already-registered leaves, fires per delta of later unions. Ordering-immune for convention plugins. Configuration-time only — KDoc mirrors the `supports` discipline (never held by a task); re-entrant actions are guarded (snapshot iteration) but documented as unsupported.

**2. Leaf vs Gradle name → a small immutable carrier, name sourced from KGP truth.** #49 (`targetName`, PR #55) merged before this PR, so the helper must report the *actual* registered name:

```kotlin
public data class RegisteredTarget(val leaf: KmpTarget, val gradleName: String) {
    public val gradleNameCapitalized: String get() = …  // computed — can't be constructed inconsistent
}
```

`gradleName` is read off the `KotlinTarget` each KGP factory returns (`registerTarget` now returns it) — never re-derived from the leaf. A jvm leaf renamed via `targetName(jvm, "desktop")` reports `gradleName == "desktop"`, so `add("ksp${it.gradleNameCapitalized}", dep)` works for both `jvm` and `desktop` without the consumer knowing about the rename. The carrier holds a `data object` leaf + strings: config-cache safe by construction.

**3. Live intersection vs registration bookkeeping → bookkeeping.** `registered()` mirrors what *actually registered*, not the abstract `selection ∩ supported` plan. The differences are deliberate, documented in KDoc, and tested:

- **KGP absent**: `supports` declared but nothing registers → `registered()` is empty, `onRegistered` never fires (no crash).
- **androidTarget without AGP (#51 skip)**: stays absent from `registered()`.

Justification: the name says *registered*, and the KSP use case must never wire a `kspAndroid` configuration for a target that doesn't exist. The abstract plan remains available as `resolvedSelection() intersect resolvedSupported()` (which is also what `kmpTargetsInfo` keeps reporting — unchanged).

## Sample before/after

The `kmpModule` convention in `samples/hello-world/build-logic` is now the canonical pattern:

```kotlin
// Before — synchronous read, hand-rolled filtering + mangling:
fun Project.kmpModule(supported: …, perTarget: (List<String>) -> Unit = {}) {
    extensions.getByType<KmpTargetsExtension>().supports(supported)
    val targets = extensions.getByType<KotlinMultiplatformExtension>()
        .targets.names.filter { it != "metadata" }
    perTarget(targets)
}

// After — ordering-immune, carrier-typed:
fun Project.kmpModule(supported: …, perTarget: (RegisteredTarget) -> Unit = {}) {
    val kmpTargets = extensions.getByType<KmpTargetsExtension>()
    kmpTargets.onRegistered(perTarget)
    kmpTargets.supports(supported)
}
```

`eager-conventions` wires `describe${target.gradleNameCapitalized}` through it; the `verifyEagerTargets` regression gate is unchanged and still passes. `KmpModulePlugin`'s `targets.configureEach` stays as deliberate KGP-native contrast.

## Implementation notes

- Internal `registered` set renamed `registeredLeaves` (avoids collision with the new public `registered()`); it remains the idempotency/ordering detail, while a new ordered `registeredLog` of carriers is the single source for snapshots and replay.
- `recordRegistration` appends to the log *before* firing and iterates an actions snapshot — re-entrancy can't trip a `ConcurrentModificationException`.
- No new Gradle properties; pure API surface. No `kmpTargetsInfo` changes.

## Tests

16 new/extended (GIVEN-WHEN-THEN): snapshot = selection ∩ supported under narrowing; `appleMobile` slicing; hook-before-supports firing; hook-after-supports replay; delta-only across two `supports` calls; KGP-absent semantics; KSP config names matching `kotlin.targets` (`kspIosArm64`); renamed-jvm carrier (`desktop`); re-entrancy guards. `task ci` green (plugin suite + both samples incl. `verifyEagerTargets`).

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)