### PR TITLE
feat: wire vanniktech maven-publish + POM metadata (#59)

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.ktfmt)
+    alias(libs.plugins.mavenPublish)
     `java-gradle-plugin`
-    `maven-publish`
 }
 
 // No toolchain on purpose: build with the locally installed (mise-pinned) JDK, target the oldest
@@ -61,12 +61,38 @@ gradlePlugin {
     }
 }
 
-publishing {
-    publications.withType<MavenPublication>().configureEach {
-        if (name == "pluginMaven") {
-            artifactId = "kmp-targets-gradle-plugin"
-        }
+// Maven Central publishing (Central Portal via vanniktech maven-publish). The plugin publishes the
+// artifact under the coordinates below plus the `com.rsicarelli.kmptargets.gradle.plugin` marker —
+// vanniktech leaves marker publications' coordinates untouched, which is exactly what Gradle's
+// plugin resolution requires.
+//
+// RELEASE_MODE=true  → automatic release to Maven Central (release/hotfix workflows)
+// RELEASE_MODE=false → staged/SNAPSHOT publishing only (continuous-deploy workflow)
+val isReleaseMode = findProperty("RELEASE_MODE")?.toString()?.toBoolean() ?: false
+val isSnapshot = version.toString().endsWith("-SNAPSHOT")
+val skipSigning = findProperty("SKIP_SIGNING")?.toString()?.toBoolean() ?: false
+val isCI = System.getenv("IS_CI")?.toBoolean() ?: false
+
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = isReleaseMode)
+
+    // Signing logic:
+    // - If IS_CI is absent (false) → skip signing (local development)
+    // - If SKIP_SIGNING flag is set → skip signing
+    // - If IS_CI is true AND not skipped AND not snapshot → sign
+    // This avoids requiring GPG credentials for local publishToMavenLocal.
+    if (isCI && !skipSigning && !isSnapshot) {
+        signAllPublications()
     }
+
+    // POM metadata (name, description, url, licenses, developers, scm) comes from the POM_* keys
+    // in gradle.properties — the vanniktech plugin maps them automatically. Declaring them here
+    // too would duplicate the <license>/<developer> list entries in the published POM.
+    coordinates(
+        groupId = group.toString(),
+        artifactId = "kmp-targets-gradle-plugin",
+        version = version.toString(),
+    )
 }
 
 tasks.test { useJUnitPlatform() }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,20 @@
 group=com.rsicarelli
 version=0.1.0-SNAPSHOT
 
+POM_NAME=KMP Targets
+POM_DESCRIPTION=Dynamically select which Kotlin Multiplatform targets to build via the kmptargets.targets Gradle property.
+POM_INCEPTION_YEAR=2026
+POM_URL=https://github.com/rsicarelli/kmp-targets/
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+POM_SCM_URL=https://github.com/rsicarelli/kmp-targets/
+POM_SCM_CONNECTION=scm:git:git://github.com/rsicarelli/kmp-targets.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/rsicarelli/kmp-targets.git
+POM_DEVELOPER_ID=rsicarelli
+POM_DEVELOPER_NAME=Rodrigo Sicarelli
+POM_DEVELOPER_URL=https://github.com/rsicarelli
+
 org.gradle.jvmargs=-Xmx2g -XX:+UseG1GC
 org.gradle.caching=true
 org.gradle.configuration-cache=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlin = "2.3.21"
 junit = "6.1.0"
 ktfmt = "0.26.0"
 asm = "9.8"
+mavenPublish = "0.35.0"
 
 [libraries]
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -13,3 +14,4 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jun
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }


### PR DESCRIPTION
## Summary

Wires Maven Central publishing into `:gradle-plugin` via vanniktech maven-publish 0.35.0 (Central Portal, plugin marker included — no Gradle Plugin Portal), so the release workflows in this milestone have a publishable artifact with a complete POM.

## Changes

- `gradle/libs.versions.toml`: add `com.vanniktech.maven.publish` 0.35.0 (`mavenPublish`)
- `gradle-plugin/build.gradle.kts`: apply the plugin; `mavenPublishing { }` with `publishToMavenCentral(automaticRelease = RELEASE_MODE)`, signing gated on `IS_CI && !SKIP_SIGNING && !isSnapshot`, and `coordinates("com.rsicarelli", "kmp-targets-gradle-plugin", version)` — **replaces** the manual `pluginMaven` artifactId rename (vanniktech overrides the main publication's artifactId and leaves the marker's coordinates untouched, which is what Gradle plugin resolution requires)
- `gradle.properties`: full `POM_*` block (name, description, inception year, url, licence, scm, developer) — mapped into the POM automatically by the plugin. No explicit `pom {}` block: declaring licenses/developers both ways duplicated the list entries (verified in `~/.m2`).

## Test plan

- [x] `task ci` is green locally
- [x] Added/updated tests where appropriate (no behavior change in plugin code — publishing wiring only, proven via artifact inspection below)
- [x] Updated docs/README if user-facing (not user-facing yet; README install docs land in #69)
- [x] No new public API without explicit intent

Verification performed:
- `./gradlew :gradle-plugin:publishToMavenLocal` with **no credentials/signing** → BUILD SUCCESSFUL
- `~/.m2/repository/com/rsicarelli/kmp-targets-gradle-plugin/0.1.0-SNAPSHOT/` contains jar + sources jar + javadoc jar + POM with name/description/url/inceptionYear/licenses/developers/scm (single entries each)
- `~/.m2/repository/com/rsicarelli/kmptargets/com.rsicarelli.kmptargets.gradle.plugin/...pom` marker exists and depends on `com.rsicarelli:kmp-targets-gradle-plugin:0.1.0-SNAPSHOT`
- `publishToMavenLocal --configuration-cache` twice → second run "Configuration cache entry reused"
- `task ci` (check + both samples consuming from mavenLocal) green

## Deferred verification (needs #58)

- Real `publishAndReleaseToMavenCentral` against the Central Portal (needs `MAVEN_CENTRAL_*` + `GPG_SIGNING_*` secrets)
- Signed-artifact validation (signing is intentionally skipped locally and for snapshots)

## Related

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)