### PR TITLE
feat: version bump + docs sync scripts; samples consume plugin via catalog (#60, #61)

### DIFF
--- a/.github/scripts/bump-version.main.kts
+++ b/.github/scripts/bump-version.main.kts
@@ -1,0 +1,341 @@
+#!/usr/bin/env kotlin
+
+/**
+ * Version Bump Script for kmp-targets
+ *
+ * Usage:
+ *   kotlin bump-version.main.kts snapshot
+ *   kotlin bump-version.main.kts <bump_type> <release_type> [current_version]
+ *
+ * SNAPSHOT Mode:
+ *   snapshot: Adds -SNAPSHOT suffix to current version without commit
+ *
+ * Bump Mode Arguments:
+ *   bump_type: major, minor, or patch
+ *   release_type: alpha, beta, or stable
+ *   current_version: (optional) If not provided, reads from gradle.properties
+ *
+ * Examples:
+ *   kotlin bump-version.main.kts snapshot        # 1.0.0-alpha01 → 1.0.0-alpha01-SNAPSHOT
+ *   kotlin bump-version.main.kts minor alpha     # 1.0.0 → 1.1.0-alpha01
+ *   kotlin bump-version.main.kts patch beta      # 1.0.0-alpha03 → 1.0.0-beta01
+ *   kotlin bump-version.main.kts patch stable    # 1.0.0-beta02 → 1.0.0
+ *   kotlin bump-version.main.kts major stable    # 1.0.0 → 2.0.0
+ *
+ * Updated files:
+ *   - gradle.properties (version=)
+ *   - gradle/libs.versions.toml (kmpTargets entry — the samples consume the plugin
+ *     through this catalog via `alias(libs.plugins.kmpTargets)`)
+ *   - samples/**/build.gradle.kts — safety net for any hardcoded plugin-id form
+ *     `id("com.rsicarelli.kmptargets") version "..."` or coordinate form
+ *     `com.rsicarelli:kmp-targets-gradle-plugin:...` that bypasses the catalog
+ */
+
+import java.io.File
+import kotlin.system.exitProcess
+
+data class SemanticVersion(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+    val preRelease: String? = null,
+    val increment: Int? = null
+) {
+    override fun toString(): String = when {
+        preRelease != null && increment != null -> "$major.$minor.$patch-$preRelease${increment.toString().padStart(2, '0')}"
+        preRelease != null -> "$major.$minor.$patch-$preRelease"
+        else -> "$major.$minor.$patch"
+    }
+
+    fun bump(bumpType: String, releaseType: String): SemanticVersion {
+        // Validate bump type first
+        if (bumpType.lowercase() !in listOf("major", "minor", "patch")) {
+            throw IllegalArgumentException("Invalid bump type: $bumpType. Must be major, minor, or patch.")
+        }
+
+        return when (releaseType.lowercase()) {
+            "alpha" -> {
+                when {
+                    // Current version has no pre-release (e.g., 1.0.0 -> 1.0.0-alpha01, 2.5.3 + minor -> 2.6.0-alpha01)
+                    preRelease == null -> when (bumpType.lowercase()) {
+                        "major" -> copy(major = major + 1, minor = 0, patch = 0, preRelease = "alpha", increment = 1)
+                        "minor" -> copy(minor = minor + 1, patch = 0, preRelease = "alpha", increment = 1)
+                        "patch" -> copy(preRelease = "alpha", increment = 1) // Keep current version frozen, add alpha01
+                        else -> throw IllegalArgumentException("Invalid bump type: $bumpType. Must be major, minor, or patch.")
+                    }
+
+                    // Current is already alpha, increment the number (e.g., alpha01 -> alpha02)
+                    preRelease == "alpha" -> copy(increment = (increment ?: 0) + 1)
+
+                    // Current is beta, switch to alpha01 for next cycle
+                    preRelease == "beta" -> when (bumpType.lowercase()) {
+                        "major" -> copy(major = major + 1, minor = 0, patch = 0, preRelease = "alpha", increment = 1)
+                        "minor" -> copy(minor = minor + 1, patch = 0, preRelease = "alpha", increment = 1)
+                        "patch" -> copy(patch = patch + 1, preRelease = "alpha", increment = 1)
+                        else -> throw IllegalArgumentException("Invalid bump type: $bumpType. Must be major, minor, or patch.")
+                    }
+
+                    else -> throw IllegalArgumentException("Invalid current pre-release: $preRelease")
+                }
+            }
+
+            "beta" -> {
+                when {
+                    // Current version has no pre-release (e.g., 1.0.0 -> 1.0.0-beta01, 2.5.3 + minor -> 2.6.0-beta01)
+                    preRelease == null -> when (bumpType.lowercase()) {
+                        "major" -> copy(major = major + 1, minor = 0, patch = 0, preRelease = "beta", increment = 1)
+                        "minor" -> copy(minor = minor + 1, patch = 0, preRelease = "beta", increment = 1)
+                        "patch" -> copy(preRelease = "beta", increment = 1) // Keep current version frozen, add beta01
+                        else -> throw IllegalArgumentException("Invalid bump type: $bumpType. Must be major, minor, or patch.")
+                    }
+
+                    // Current is alpha, switch to beta01
+                    preRelease == "alpha" -> copy(preRelease = "beta", increment = 1)
+
+                    // Current is already beta, increment the number (e.g., beta01 -> beta02)
+                    preRelease == "beta" -> copy(increment = (increment ?: 0) + 1)
+
+                    else -> throw IllegalArgumentException("Invalid current pre-release: $preRelease")
+                }
+            }
+
+            "stable" -> {
+                when {
+                    // Release from pre-release (e.g., alpha03/beta02 -> 1.0.0)
+                    preRelease != null -> copy(preRelease = null, increment = null)
+
+                    // Normal version bump for stable releases
+                    else -> when (bumpType.lowercase()) {
+                        "major" -> copy(major = major + 1, minor = 0, patch = 0)
+                        "minor" -> copy(minor = minor + 1, patch = 0)
+                        "patch" -> copy(patch = patch + 1)
+                        else -> throw IllegalArgumentException("Invalid bump type: $bumpType. Must be major, minor, or patch.")
+                    }
+                }
+            }
+
+            else -> throw IllegalArgumentException("Invalid release type: $releaseType. Must be alpha, beta, or stable.")
+        }
+    }
+
+    companion object {
+        fun parse(version: String): SemanticVersion {
+            // Remove SNAPSHOT suffix if present
+            val cleanVersion = version.replace("-SNAPSHOT", "")
+
+            // Check for pre-release suffix (alpha, beta, etc.)
+            val versionAndPreRelease = if (cleanVersion.contains("-")) {
+                val parts = cleanVersion.split("-", limit = 2)
+                parts[0] to parts[1]
+            } else {
+                cleanVersion to null
+            }
+
+            val versionParts = versionAndPreRelease.first.split(".")
+
+            require(versionParts.size == 3) {
+                "Invalid version format: $version. Expected format: X.Y.Z, X.Y.Z-alpha01, X.Y.Z-beta02, or with -SNAPSHOT suffix"
+            }
+
+            // Parse pre-release with optional increment (e.g., "alpha01", "beta02")
+            var preRelease: String? = null
+            var increment: Int? = null
+
+            versionAndPreRelease.second?.let { preReleaseString ->
+                // Check if it's exactly 2-digit increment format (e.g., "alpha01", "beta02")
+                val incrementPattern = Regex("""^(alpha|beta)(\d{2})$""")
+                val match = incrementPattern.find(preReleaseString)
+
+                if (match != null) {
+                    preRelease = match.groupValues[1]
+                    increment = match.groupValues[2].toInt()
+                } else {
+                    // Legacy format without increment (e.g., "alpha", "beta")
+                    // Validate that it's a supported pre-release type
+                    if (preReleaseString !in listOf("alpha", "beta")) {
+                        throw IllegalArgumentException("Invalid version format: $version. Unsupported pre-release type: $preReleaseString. Only 'alpha' and 'beta' are supported.")
+                    }
+                    preRelease = preReleaseString
+                }
+            }
+
+            try {
+                return SemanticVersion(
+                    major = versionParts[0].toInt(),
+                    minor = versionParts[1].toInt(),
+                    patch = versionParts[2].toInt(),
+                    preRelease = preRelease,
+                    increment = increment
+                )
+            } catch (e: NumberFormatException) {
+                throw IllegalArgumentException("Invalid version format: $version. Version parts must be numeric.", e)
+            }
+        }
+    }
+}
+
+fun readCurrentVersion(gradlePropertiesFile: File): SemanticVersion {
+    val content = gradlePropertiesFile.readText()
+    val versionLine = content.lines().find { it.startsWith("version=") }
+        ?: error("version not found in gradle.properties")
+
+    val versionString = versionLine.substringAfter("version=").trim()
+    return SemanticVersion.parse(versionString)
+}
+
+fun updateGradlePropertiesWithString(gradlePropertiesFile: File, versionString: String) {
+    val content = gradlePropertiesFile.readText()
+    val updatedContent = content.lines().joinToString("\n") { line ->
+        if (line.startsWith("version=")) {
+            "version=$versionString"
+        } else {
+            line
+        }
+    }
+    gradlePropertiesFile.writeText(updatedContent)
+}
+
+fun updateLibsVersionsToml(newVersion: String) {
+    val tomlFile = File("gradle/libs.versions.toml")
+    if (!tomlFile.exists()) {
+        println("Warning: gradle/libs.versions.toml not found, skipping kmpTargets version update")
+        return
+    }
+
+    val content = tomlFile.readText()
+    val versionPattern = Regex("""(kmpTargets = )"[^"]+"""")
+    val updatedContent = versionPattern.replace(content) { matchResult ->
+        """${matchResult.groupValues[1]}"$newVersion""""
+    }
+
+    if (content != updatedContent) {
+        tomlFile.writeText(updatedContent)
+        println("Updated kmpTargets version in libs.versions.toml to $newVersion")
+    }
+}
+
+/**
+ * Rewrites any hardcoded plugin version left in sample build files. The samples consume the
+ * plugin through the shared version catalog (updated above), so normally this finds nothing —
+ * it is a safety net for snippets that bypass the catalog. Idempotent: writing the version
+ * already present is a no-op.
+ */
+fun updateSampleBuildFiles(newVersion: String) {
+    val samplesDir = File("samples")
+    if (!samplesDir.exists()) {
+        println("Warning: samples/ not found, skipping sample build file update")
+        return
+    }
+
+    val pluginIdPattern = Regex("""(id\("com\.rsicarelli\.kmptargets"\)\s+version\s+)"[^"]*"""")
+    val coordinatePattern = Regex("""(com\.rsicarelli:kmp-targets-gradle-plugin:)[^"\s)]+""")
+
+    var filesUpdated = 0
+    samplesDir.walkTopDown()
+        .filter { it.isFile && it.name == "build.gradle.kts" && !it.path.contains("/build/") }
+        .forEach { file ->
+            val content = file.readText()
+            val updatedContent = content
+                .replace(pluginIdPattern) { """${it.groupValues[1]}"$newVersion"""" }
+                .replace(coordinatePattern) { "${it.groupValues[1]}$newVersion" }
+
+            if (updatedContent != content) {
+                file.writeText(updatedContent)
+                filesUpdated++
+                println("Updated ${file.path} to $newVersion")
+            }
+        }
+
+    println("Sample build files updated: $filesUpdated")
+}
+
+fun addSnapshotSuffix(version: SemanticVersion): String {
+    val versionString = version.toString()
+    return if (versionString.endsWith("-SNAPSHOT")) {
+        versionString
+    } else {
+        "$versionString-SNAPSHOT"
+    }
+}
+
+fun main(args: Array<String>) {
+    if (args.isEmpty()) {
+        println("Error: At least one argument required")
+        println("Usage:")
+        println("  kotlin bump-version.main.kts snapshot")
+        println("  kotlin bump-version.main.kts <major|minor|patch> <alpha|beta|stable> [current_version]")
+        exitProcess(1)
+    }
+
+    val gradlePropertiesFile = File("gradle.properties")
+    if (!gradlePropertiesFile.exists()) {
+        println("Error: gradle.properties not found in current directory")
+        exitProcess(1)
+    }
+
+    // Handle SNAPSHOT mode
+    if (args[0].lowercase() == "snapshot") {
+        val currentVersion = readCurrentVersion(gradlePropertiesFile)
+        val snapshotVersion = addSnapshotSuffix(currentVersion)
+
+        // Update gradle.properties with SNAPSHOT version
+        updateGradlePropertiesWithString(gradlePropertiesFile, snapshotVersion)
+
+        // Update kmpTargets version in libs.versions.toml (samples consume via the catalog)
+        updateLibsVersionsToml(snapshotVersion)
+
+        // Update any hardcoded plugin versions left in sample build files
+        updateSampleBuildFiles(snapshotVersion)
+
+        // Output for GitHub Actions (if needed)
+        println("VERSION_SNAPSHOT=$snapshotVersion")
+        println("Current version converted to SNAPSHOT: $snapshotVersion")
+        return
+    }
+
+    // Handle regular version bump mode
+    if (args.size < 2) {
+        println("Error: Bump type and release type arguments required")
+        println("Usage: kotlin bump-version.main.kts <major|minor|patch> <alpha|beta|stable> [current_version]")
+        exitProcess(1)
+    }
+
+    val bumpType = args[0]
+    val releaseType = args[1]
+
+    val currentVersion = if (args.size > 2) {
+        SemanticVersion.parse(args[2])
+    } else {
+        readCurrentVersion(gradlePropertiesFile)
+    }
+
+    val newVersion = currentVersion.bump(bumpType, releaseType)
+
+    // Update gradle.properties
+    updateGradlePropertiesWithString(gradlePropertiesFile, newVersion.toString())
+
+    // Update kmpTargets version in libs.versions.toml (samples consume via the catalog)
+    updateLibsVersionsToml(newVersion.toString())
+
+    // Update any hardcoded plugin versions left in sample build files
+    updateSampleBuildFiles(newVersion.toString())
+
+    // Output for GitHub Actions
+    println("VERSION_CURRENT=$currentVersion")
+    println("VERSION_NEW=$newVersion")
+    println("TAG=v$newVersion")
+
+    // Set GitHub Actions output if running in CI
+    val githubOutput = System.getenv("GITHUB_OUTPUT")
+    if (githubOutput != null) {
+        File(githubOutput).appendText(
+            """
+            version_current=$currentVersion
+            version_new=$newVersion
+            tag=v$newVersion
+            """.trimIndent() + "\n"
+        )
+    }
+}
+
+main(args)

--- a/.github/scripts/sync-docs-version.main.kts
+++ b/.github/scripts/sync-docs-version.main.kts
@@ -1,0 +1,150 @@
+#!/usr/bin/env kotlin
+
+/**
+ * Documentation Version Sync Script for kmp-targets
+ *
+ * Updates all hardcoded kmp-targets versions in documentation and sample files to the
+ * just-released version, so published docs/samples always show real coordinates.
+ *
+ * Usage:
+ *   kotlin sync-docs-version.main.kts [version]
+ *
+ * Arguments:
+ *   version: (optional) If not provided, reads from gradle.properties
+ *
+ * Examples:
+ *   kotlin sync-docs-version.main.kts           # Use gradle.properties version
+ *   kotlin sync-docs-version.main.kts 0.1.0     # Use specific version
+ *
+ * Scanned files:
+ *   - docs/**/*.md (gracefully skipped while docs/ does not exist yet)
+ *   - README.md
+ *   - samples/**/build.gradle.kts
+ *   - gradle/libs.versions.toml (kmpTargets entry — the samples' single declaration point)
+ *
+ * Replaced patterns:
+ *   - id("com.rsicarelli.kmptargets") version "..."
+ *   - com.rsicarelli:kmp-targets-gradle-plugin:...
+ *   - kmpTargets = "..." (version catalog entries shown in docs)
+ *
+ * Idempotent: re-running with the same version rewrites nothing and exits 0.
+ */
+
+import java.io.File
+import kotlin.system.exitProcess
+
+fun readCurrentVersion(gradlePropertiesFile: File): String {
+    val content = gradlePropertiesFile.readText()
+    val versionLine = content.lines().find { it.startsWith("version=") }
+        ?: error("version not found in gradle.properties")
+
+    return versionLine.substringAfter("version=").trim()
+}
+
+fun syncVersionCatalog(projectDir: File, newVersion: String): Boolean {
+    val versionCatalogFile = File(projectDir, "gradle/libs.versions.toml")
+    if (!versionCatalogFile.exists()) return false
+
+    val content = versionCatalogFile.readText()
+    val pattern = Regex("""(kmpTargets\s*=\s*)"[^"]*"""")
+
+    val updatedContent = pattern.replace(content) { """${it.groupValues[1]}"$newVersion"""" }
+    if (updatedContent != content) {
+        versionCatalogFile.writeText(updatedContent)
+        println("✅ Updated gradle/libs.versions.toml")
+        return true
+    }
+    return false
+}
+
+fun syncDocumentationVersions(projectDir: File, newVersion: String) {
+    var filesUpdated = 0
+    var totalReplacements = 0
+
+    if (syncVersionCatalog(projectDir, newVersion)) filesUpdated++
+
+    // Files to update
+    val filesToUpdate = mutableListOf<File>()
+
+    // Documentation files — docs/ may not exist yet (the site lands in a later issue);
+    // that is fine, we just have 0 docs files to update.
+    val docsDir = File(projectDir, "docs")
+    if (docsDir.exists()) {
+        docsDir.walkTopDown()
+            .filter { it.isFile && it.name.endsWith(".md") }
+            .forEach { filesToUpdate.add(it) }
+    }
+
+    // README installation snippet
+    val readme = File(projectDir, "README.md")
+    if (readme.exists()) filesToUpdate.add(readme)
+
+    // Sample build files that still use hardcoded versions (normally none — samples consume
+    // the plugin through the version catalog synced above)
+    File(projectDir, "samples").takeIf { it.exists() }?.walkTopDown()
+        ?.filter { it.isFile && it.name == "build.gradle.kts" && !it.path.contains("/build/") }
+        ?.forEach { filesToUpdate.add(it) }
+
+    // Patterns to replace
+    val replacementPatterns = listOf(
+        // Plugin version declarations
+        Regex("""(id\("com\.rsicarelli\.kmptargets"\)\s+version\s+)"[^"]*"""") to { m: MatchResult -> """${m.groupValues[1]}"$newVersion"""" },
+
+        // Version catalog entries shown in docs
+        Regex("""(kmpTargets\s*=\s*)"[^"]*"""") to { m: MatchResult -> """${m.groupValues[1]}"$newVersion"""" },
+
+        // Maven coordinates, quoted or bare (supports alpha/beta/stable + -SNAPSHOT formats)
+        Regex("""(com\.rsicarelli:kmp-targets-gradle-plugin:)[^"\s)]+""") to { m: MatchResult -> "${m.groupValues[1]}$newVersion" },
+    )
+
+    filesToUpdate.forEach { file ->
+        val content = file.readText()
+        var updatedContent = content
+        var fileReplacements = 0
+
+        replacementPatterns.forEach { (pattern, replacement) ->
+            val matches = pattern.findAll(updatedContent).count()
+            if (matches > 0) {
+                updatedContent = pattern.replace(updatedContent, replacement)
+                fileReplacements += matches
+            }
+        }
+
+        // Only rewrite when the content actually changed — keeps re-runs a true no-op
+        if (updatedContent != content) {
+            file.writeText(updatedContent)
+            filesUpdated++
+            totalReplacements += fileReplacements
+            println("✅ Updated ${file.relativeTo(projectDir)}")
+        }
+    }
+
+    println("\n📊 Summary:")
+    println("  Files updated: $filesUpdated")
+    println("  Total replacements: $totalReplacements")
+    println("  New version: $newVersion")
+}
+
+fun main(args: Array<String>) {
+    val projectDir = File(".").absoluteFile
+    val gradlePropertiesFile = File("gradle.properties")
+
+    if (!gradlePropertiesFile.exists()) {
+        println("Error: gradle.properties not found in current directory")
+        exitProcess(1)
+    }
+
+    val newVersion = if (args.isNotEmpty()) {
+        args[0]
+    } else {
+        readCurrentVersion(gradlePropertiesFile)
+    }
+
+    println("🔄 Syncing documentation versions to: $newVersion")
+
+    syncDocumentationVersions(projectDir, newVersion)
+
+    println("\n✅ Documentation sync completed!")
+}
+
+main(args)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,9 +4,14 @@ junit = "6.1.0"
 ktfmt = "0.26.0"
 asm = "9.8"
 mavenPublish = "0.35.0"
+# The plugin's own published version — single declaration point for the standalone samples
+# (they import this catalog and consume the plugin via `alias(libs.plugins.kmpTargets)`).
+# Kept in lockstep with `version=` in gradle.properties by .github/scripts/bump-version.main.kts.
+kmpTargets = "0.1.0-SNAPSHOT"
 
 [libraries]
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kmpTargets-gradlePlugin = { module = "com.rsicarelli:kmp-targets-gradle-plugin", version.ref = "kmpTargets" }
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
@@ -15,3 +20,4 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jun
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+kmpTargets = { id = "com.rsicarelli.kmptargets", version.ref = "kmpTargets" }

--- a/samples/hello-world/build-logic/build.gradle.kts
+++ b/samples/hello-world/build-logic/build.gradle.kts
@@ -5,7 +5,7 @@ dependencies {
     // consuming module's plugin classpath (the convention applies it by id) and so this build can
     // reference its DSL types. kmp-targets declares KGP `compileOnly`, so this does NOT drag a second
     // copy of KGP onto the consumer.
-    implementation("com.rsicarelli:kmp-targets-gradle-plugin:0.1.0-SNAPSHOT")
+    implementation(libs.kmpTargets.gradlePlugin)
     // KGP types for compile only. KGP itself is applied by each consuming module's
     // `kotlin("multiplatform")`, keeping a single shared KGP classloader in the sample.
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}")

--- a/samples/hello-world/core-and-apple/build.gradle.kts
+++ b/samples/hello-world/core-and-apple/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     // set algebra in the block. The template yields jvm at common + a single `iosMain` (no
     // `appleMain`/`nativeMain`).
     kotlin("multiplatform")
-    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    alias(libs.plugins.kmpTargets)
 }
 
 kmpTargets { supports { apple + jvm } }

--- a/samples/hello-world/desktop-named/build.gradle.kts
+++ b/samples/hello-world/desktop-named/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     // artifact suffixes, and CI task names (`compileKotlinDesktop`) keyed off that name. The rename
     // keeps all of those stable while the selection token stays `jvm`.
     kotlin("multiplatform")
-    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    alias(libs.plugins.kmpTargets)
 }
 
 kmpTargets {

--- a/samples/hello-world/escape-hatch-dsl/build.gradle.kts
+++ b/samples/hello-world/escape-hatch-dsl/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     // whole target vocabulary is in scope as set algebra. (KGP version comes from the root build's
     // `apply false` declaration, so it isn't repeated here.)
     kotlin("multiplatform")
-    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    alias(libs.plugins.kmpTargets)
 }
 
 kmpTargets {

--- a/samples/hello-world/feature-mobile/build.gradle.kts
+++ b/samples/hello-world/feature-mobile/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     //   ./gradlew :feature-mobile:kmpTargetsInfo -Pkmptargets.targets=android
     // (add -Pkmptargets.strict=true to make it fail with the same text)
     kotlin("multiplatform")
-    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    alias(libs.plugins.kmpTargets)
 }
 
 kmpTargets { supports { mobile } }

--- a/samples/hello-world/jvm-tools/build.gradle.kts
+++ b/samples/hello-world/jvm-tools/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     // dropped
     // and only `jvm` registers.
     kotlin("multiplatform")
-    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    alias(libs.plugins.kmpTargets)
 }
 
 kmpTargets { supports { jvm } }

--- a/samples/hello-world/legacy-default/build.gradle.kts
+++ b/samples/hello-world/legacy-default/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     // side-by-side proof of what the feature removes. It still `supports { all }`, like
     // :shared-core.
     kotlin("multiplatform")
-    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    alias(libs.plugins.kmpTargets)
 }
 
 kmpTargets {

--- a/samples/hello-world/pinned-intermediates/build.gradle.kts
+++ b/samples/hello-world/pinned-intermediates/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     // `nativeMain` all exist, and they survive a single-leaf selection. The empty parents are
     // inert. What REGISTERS never changes — only which intermediate source sets materialize.
     kotlin("multiplatform")
-    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    alias(libs.plugins.kmpTargets)
 }
 
 kmpTargets {

--- a/samples/hello-world/shared-core/build.gradle.kts
+++ b/samples/hello-world/shared-core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     // redundant `appleMain`/`nativeMain`). Compare with :legacy-default, which opts out and keeps
     // both.
     kotlin("multiplatform")
-    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    alias(libs.plugins.kmpTargets)
 }
 
 // Targets are explicit: with no `supports` nothing would register. `supports { all }` is the opt-in

--- a/samples/isolated-projects/app/build.gradle.kts
+++ b/samples/isolated-projects/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     // dependency — a real cross-project edge that Isolated Projects must wire while keeping each
     // project's configuration isolated.
     kotlin("multiplatform")
-    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    alias(libs.plugins.kmpTargets)
     id("com.ncorti.ktfmt.gradle")
 }
 

--- a/samples/isolated-projects/lib/build.gradle.kts
+++ b/samples/isolated-projects/lib/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     // under Isolated
     // Projects — proof the plugin applies without reaching across projects.
     kotlin("multiplatform")
-    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+    alias(libs.plugins.kmpTargets)
     id("com.ncorti.ktfmt.gradle")
 }
 


### PR DESCRIPTION
## Summary

Adds the two version-management scripts the release workflows depend on (adapted from fakt), and brings fakt's sample-versioning pattern over: samples now declare the plugin version **once**, in the shared version catalog, instead of hardcoding it in 11 build files.

## Changes

- `.github/scripts/bump-version.main.kts` — `snapshot` mode (in-place `-SNAPSHOT`, idempotent, no commit) + `major|minor|patch` × `alpha|beta|stable` ladder (zero-padded counters, alpha→beta resets, stable strips suffix); writes `GITHUB_OUTPUT` keys `version_current`/`version_new`/`tag` identical to fakt. Updates `gradle.properties`, the `kmpTargets` catalog entry, and (safety net) any hardcoded sample versions.
- `.github/scripts/sync-docs-version.main.kts` — rewrites `id("com.rsicarelli.kmptargets") version "…"`, catalog `kmpTargets = "…"` entries, and `com.rsicarelli:kmp-targets-gradle-plugin:…` coordinates across `docs/**/*.md` (gracefully no-ops while `docs/` doesn't exist), `README.md`, and `samples/**/build.gradle.kts`. Idempotent; reports file/replacement counts.
- Samples: `id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"` (10 files) → `alias(libs.plugins.kmpTargets)`; build-logic's coordinate dependency → `libs.kmpTargets.gradlePlugin`; new `kmpTargets` version/plugin/library entries in `gradle/libs.versions.toml` (kept in lockstep with `gradle.properties` by the bump script — same as fakt's `fakt` entry).

## Test plan

- [x] `task ci` is green locally (samples build via the catalog alias from mavenLocal)
- [x] Added/updated tests where appropriate (scripts exercised end-to-end below; no plugin code touched)
- [x] Updated docs/README if user-facing (README untouched — installation rework is #69)
- [x] No new public API without explicit intent

Script verification (all on a scratch state, restored after):
- `snapshot` on `0.1.0-SNAPSHOT` → idempotent, no double suffix, 0 sample rewrites
- `minor alpha` → `0.1.0-SNAPSHOT → 0.2.0-alpha01` in `gradle.properties` + catalog; `GITHUB_OUTPUT` got `version_current=0.1.0`, `version_new=0.2.0-alpha01`, `tag=v0.2.0-alpha01`
- Ladder: `0.2.0-alpha01 → alpha02 → beta01 → beta02 → 0.2.0 → 0.2.1`; `1.0.0-beta08 patch stable → 1.0.0` (fakt example)
- Sync `0.1.0`: catalog + README snippet rewritten; re-run = 0 files, exit 0; `docs/` absent handled gracefully

## Related

Closes #60
Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)