### PR TITLE
feat: add prepare-next-release.sh + shared composite CI actions (#62)

### DIFF
--- a/.github/actions/configure-release-bot/action.yml
+++ b/.github/actions/configure-release-bot/action.yml
@@ -1,0 +1,26 @@
+name: Configure Release Bot Identity
+description: Configures Git with the release bot credentials for commits
+
+inputs:
+  bot-name:
+    description: 'Release bot name (e.g., fakt-release-bot[bot])'
+    required: true
+  bot-app-id:
+    description: 'GitHub App ID for the release bot'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Git with Release Bot Identity
+      shell: bash
+      env:
+        RELEASE_BOT_NAME: ${{ inputs.bot-name }}
+        RELEASE_BOT_APP_ID: ${{ inputs.bot-app-id }}
+      run: |
+        # Ensure bot name ends with [bot] for proper GitHub attribution
+        # Note: Must quote '[bot]' to match literal string, not glob pattern
+        BOT_DISPLAY_NAME="${RELEASE_BOT_NAME%'[bot]'}[bot]"
+        git config --global user.name "$BOT_DISPLAY_NAME"
+        git config --global user.email "${RELEASE_BOT_APP_ID}+${BOT_DISPLAY_NAME}@users.noreply.github.com"
+        echo "✅ Git configured with bot identity: $BOT_DISPLAY_NAME"

--- a/.github/actions/create-github-release/action.yml
+++ b/.github/actions/create-github-release/action.yml
@@ -1,0 +1,32 @@
+name: Create GitHub Release
+description: Create a GitHub Release with auto-generated changelog
+
+inputs:
+  tag:
+    description: 'Git tag for the release'
+    required: true
+  github-token:
+    description: 'GitHub token for creating release'
+    required: true
+  is-prerelease:
+    description: 'Mark as pre-release'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Create GitHub Release
+      shell: bash
+      run: |
+        PRERELEASE_FLAG=""
+        if [[ "${{ inputs.is-prerelease }}" == "true" ]]; then
+          PRERELEASE_FLAG="--prerelease"
+        fi
+
+        gh release create "${{ inputs.tag }}" \
+          --title "${{ inputs.tag }}" \
+          --generate-notes \
+          $PRERELEASE_FLAG
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,0 +1,11 @@
+name: Run Tests
+description: Execute the full verification suite (compile, tests, ktfmt, compat floors)
+
+runs:
+  using: 'composite'
+  steps:
+    # `check` aggregates everything across modules: unit tests, ktfmtCheck, and the
+    # compat-floors verification on the built jar.
+    - name: Run all checks
+      shell: bash
+      run: ./gradlew check

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,0 +1,26 @@
+name: Setup Environment
+description: Setup common build environment for kmp-targets (Java, Gradle, validation)
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up JDK 23
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '23'
+
+    - name: Cache Gradle wrapper distributions
+      uses: actions/cache@v4
+      with:
+        path: ~/.gradle/wrapper/dists
+        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-wrapper-
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        validate-wrappers: true
+        cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+        add-job-summary: 'never'

--- a/.github/scripts/prepare-next-release.sh
+++ b/.github/scripts/prepare-next-release.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# prepare-next-release.sh - Unified post-release preparation
+# Usage: prepare-next-release.sh <published_version> <bump_type> <release_type>
+
+set -e
+
+PUBLISHED_VERSION=$1
+BUMP_TYPE=$2
+RELEASE_TYPE=$3
+
+if [ -z "$PUBLISHED_VERSION" ] || [ -z "$BUMP_TYPE" ] || [ -z "$RELEASE_TYPE" ]; then
+  echo "❌ Usage: $0 <published_version> <bump_type> <release_type>"
+  echo "   Example: $0 0.1.0-alpha01 patch alpha"
+  exit 1
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🚀 Preparing for next release after $PUBLISHED_VERSION"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Step 1: Sync documentation to published version
+echo ""
+echo "📚 Step 1/3: Syncing docs to published version..."
+kotlin .github/scripts/sync-docs-version.main.kts "$PUBLISHED_VERSION"
+echo "  ✓ Documentation synced to $PUBLISHED_VERSION"
+
+# Step 2: Bump to next development version (NO SNAPSHOT)
+echo ""
+echo "⬆️  Step 2/3: Bumping to next development version..."
+kotlin .github/scripts/bump-version.main.kts "$BUMP_TYPE" "$RELEASE_TYPE"
+NEXT_VERSION=$(grep "version=" gradle.properties | cut -d'=' -f2)
+echo "  ✓ Bumped to $NEXT_VERSION"
+
+# Step 3: Stage all changes for commit
+echo ""
+echo "📝 Step 3/3: Staging changes..."
+# Stage each path independently: one missing path (e.g. docs/ before the site exists) must
+# not abort staging of the others — `git add a missing-b c` stages nothing at all.
+for path in gradle.properties gradle/libs.versions.toml docs/ samples/ README.md; do
+  git add "$path" 2>/dev/null || true
+done
+
+# Check if there are changes to commit
+if git diff --cached --quiet; then
+  echo "  ⚠ No changes to commit"
+  exit 0
+fi
+
+# Create unified commit
+echo ""
+echo "💾 Creating unified commit..."
+# --no-verify: the local DOD pre-commit hook builds the samples, which necessarily fails on a
+# version-bump commit (the bumped plugin version is only published by the NEXT release). CI
+# runners have no hooks installed; this keeps local runs behaving identically.
+git commit --no-verify -m "chore: prepare for next version $NEXT_VERSION"
+echo "  ✓ Committed: chore: prepare for next version $NEXT_VERSION"
+
+# Output for GitHub Actions
+if [ -n "$GITHUB_OUTPUT" ]; then
+  echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ Done! Ready to push."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary

Adds the post-publish preparation script and the four shared composite actions the release workflows (#65–#68) build on, adapted from fakt to kmp-targets' simpler layout (JVM-only plugin build, JDK 23, Taskfile, no kotlin-js-store/lockfiles).

## Changes

- `.github/scripts/prepare-next-release.sh <published> <bump> <release_type>` — sync docs to the published version → bump to next dev version → one `chore: prepare for next version X.Y.Z` commit; exits 0 cleanly when nothing changed. Two deliberate adaptations beyond fakt:
  - paths staged **individually** (`docs/` doesn't exist yet; `git add a missing-b c` stages *nothing* — found by actually running the script)
  - `git commit --no-verify` — the local DOD pre-commit hook builds the samples, which necessarily fails on a version-bump commit (the bumped version is only published by the *next* release); CI runners have no hooks, so this makes local behavior identical
- `.github/actions/configure-release-bot/` — verbatim fakt (App noreply email `<app-id>+<bot-name>[bot]@users.noreply.github.com`)
- `.github/actions/create-github-release/` — verbatim fakt (`gh release create --generate-notes`, optional `--prerelease`)
- `.github/actions/setup-environment/` — JDK 23 Temurin, Gradle wrapper validation + cache; Node.js/Konan steps dropped
- `.github/actions/run-tests/` — `./gradlew check`

## Test plan

- [x] `task ci` is green locally (`task dod` + no plugin/sample code touched)
- [x] Added/updated tests where appropriate (script exercised end-to-end below)
- [x] Updated docs/README if user-facing (not user-facing)
- [x] No new public API without explicit intent

Verification:
- Scratch run `prepare-next-release.sh 0.1.0-alpha01 patch alpha` → exactly one commit staging `gradle.properties` + `gradle/libs.versions.toml` + `README.md`, version shows `0.1.0-alpha01`; state reset afterwards
- No-change invocation (both kotlin scripts stubbed to no-ops) → "No changes to commit", exit 0, no empty commit
- All four `action.yml` files parse as valid YAML; `actionlint` clean

## Deferred verification (needs #58)

- Composite actions are exercised end-to-end by the workflows in #65/#66 once secrets exist (`configure-release-bot` needs `RELEASE_BOT_NAME`/`RELEASE_BOT_APP_ID` vars; `create-github-release` needs the App token)

## Related

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)