### PR TITLE
feat: inert-module advisory — signal when supports {} registers zero targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ changes may land in any release.
 
 ### Added
 
+- **Inert-module advisory** ([#71]): when a module that declared `supports { }` ends a
+  registration pass with **zero** targets registered — a disjoint selection, an explicitly-empty
+  selection (`jvm,-jvm`, where the empty-overlap advisory is silent by design), or an android-only
+  overlap skipped by the AGP guard — the plugin logs a one-line advisory naming the consequence:
+  KGP still materializes the commonMain metadata compilation, which fails on a platform-less
+  module, and the recommended build-logic gate is `kmpTargets.registered().isEmpty()`. Signal
+  only, never filtering; promoted to a build failure under `kmptargets.strict=true` with the
+  identical text (the cause advisories — empty-overlap, android-without-AGP — are emitted first
+  and win the strict exception where they apply). Fires at most once per module (a later
+  `supports { }` union that registers a leaf un-inerts it permanently); a module that never calls
+  `supports { }` is deliberately not flagged. `kmpTargetsInfo` renders the same decision as an
+  `inert:` line in its registered section.
 - **Per-module JVM target name override** ([#49]): `kmpTargets { targetName(jvm, "desktop") }`
   registers the jvm leaf under a custom Gradle target name, so legacy `jvm("desktop")` codebases
   keep their `src/desktopMain` dirs, `-desktop` artifact suffixes, and `compileKotlinDesktop` task
@@ -86,3 +98,4 @@ changes may land in any release.
 [#50]: https://github.com/rsicarelli/kmp-targets/issues/50
 [#51]: https://github.com/rsicarelli/kmp-targets/issues/51
 [#52]: https://github.com/rsicarelli/kmp-targets/issues/52
+[#71]: https://github.com/rsicarelli/kmp-targets/issues/71

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Dynamically select which Kotlin Multiplatform targets to build.
 
-**Status:** alpha (pre-1.0). Shipped and exercised by the multi-module sample plus a real 3-OS CI matrix: the global selector with [try-import-style layering](#selecting-targets) (dedicated config files, unified `kmptargets.*` keys), the automatic [minimal hierarchy template](#minimal-hierarchy-template), the [`kmpTargetsInfo`](#debugging-the-selection) introspection task, [host-compatibility](#host-compatibility), [deprecated-target](#deprecated-targets), and [android-without-AGP](#android-target-without-the-android-gradle-plugin) advisories, and opt-in [strict mode](#strict-mode). Roadmap: user-defined hierarchy groups, XCFramework helpers, Maven Central / Plugin Portal publishing.
+**Status:** alpha (pre-1.0). Shipped and exercised by the multi-module sample plus a real 3-OS CI matrix: the global selector with [try-import-style layering](#selecting-targets) (dedicated config files, unified `kmptargets.*` keys), the automatic [minimal hierarchy template](#minimal-hierarchy-template), the [`kmpTargetsInfo`](#debugging-the-selection) introspection task, [host-compatibility](#host-compatibility), [deprecated-target](#deprecated-targets), [android-without-AGP](#android-target-without-the-android-gradle-plugin), and [inert-module](#inert-modules) advisories, and opt-in [strict mode](#strict-mode). Roadmap: user-defined hierarchy groups, XCFramework helpers, Maven Central / Plugin Portal publishing.
 
 `kmp-targets` is a Gradle plugin for Kotlin Multiplatform projects that lets each developer (and each CI runner) choose which KMP targets to build, via a single Gradle property:
 
@@ -488,13 +488,57 @@ leaf normally. [`kmpTargetsInfo`](#debugging-the-selection) marks the leaf
 `androidTarget (skipped: no Android plugin applied)` in its registered section while the condition
 holds.
 
+### Inert modules
+
+A module that declared `supports { … }` can still end up registering **zero** targets — that is
+explicit selection working as intended, and it happens three ways: the selection is disjoint from
+the supported set (the everyday narrowed-lane case), the selection is explicitly empty
+(`kmptargets.targets=jvm,-jvm` — the honored "build nothing" of the
+[selection grammar](#selection-grammar)), or the only overlap was an `androidTarget` that the
+[AGP guard](#android-target-without-the-android-gradle-plugin) skipped. The trap: KGP still
+materializes the **commonMain metadata compilation** (`compileCommonMainKotlinMetadata`) for every
+module that applies `kotlin("multiplatform")`, and on a module with no platform targets that
+compilation **fails** — a platform-less commonMain has no legal platform context, so declarations
+relying on `@OptionalExpectation` (and friends) are rejected. Any aggregate invocation (`build`,
+`check`, `publishToMavenLocal`) then trips over every inert module with an opaque compiler error.
+
+So whenever a registration pass leaves such a module with zero registrations, the plugin logs a
+one-line advisory naming the consequence and the gate:
+
+```
+kmp-targets: ':shared' declared supports { } but registered zero targets — the module is inert.
+KGP still materializes the commonMain metadata compilation, which fails with no platform targets.
+Gate it in build-logic when kmpTargets.registered().isEmpty().
+```
+
+Like its siblings (and unlike the AGP guard): **signal only, never filtering** — the plugin does
+not disable any task. The recommended gate lives in your build-logic, right after the module's
+`supports { }` (or in a convention plugin), keyed off the same
+[`registered()`](#querying-what-registered) query the advisory checks:
+
+```kotlin
+// after supports { } — disable the doomed compilations when nothing registered
+if (kmpTargets.registered().isEmpty()) {
+    tasks.withType(KotlinCompilationTask::class.java).configureEach { enabled = false }
+}
+```
+
+A module that **never calls** `supports { }` registers nothing *by definition* and is deliberately
+not flagged — that is the explicit-selection baseline, not the trap. The advisory fires at most
+once per module; a later `supports { }` union that registers a leaf un-inerts the module
+permanently (registration is one-way). It is host-blind like registration itself: a registered
+target the current host [cannot compile](#host-compatibility) still counts as registered.
+[`kmpTargetsInfo`](#debugging-the-selection) renders the same decision as an `inert:` line in its
+registered section while the condition holds.
+
 ### Strict mode
 
-By default all four advisories — the **empty-overlap** warning (a non-empty selection that matches
+By default all five advisories — the **empty-overlap** warning (a non-empty selection that matches
 nothing a module `supports`, so the module registers zero targets), the
 [**android-without-AGP**](#android-target-without-the-android-gradle-plugin) advisory, the
-[**host-impossible**](#host-compatibility) warning, and the
-[**deprecated-target**](#deprecated-targets) advisory — are just that: warnings. Right for local
+[**host-impossible**](#host-compatibility) warning, the
+[**deprecated-target**](#deprecated-targets) advisory, and the
+[**inert-module**](#inert-modules) advisory — are just that: warnings. Right for local
 iteration, easy to miss in CI, where a module silently building nothing is usually a real
 configuration bug.
 
@@ -517,6 +561,13 @@ env:
 > **Heads-up for cross-host CI:** with strict on, a selection that includes targets the agent
 > cannot compile (e.g. iOS leaves on a Linux runner) fails the build by design. Strict CI pairs
 > with per-host selections — see [CI](#ci) for the matrix pattern.
+
+> **Heads-up for explicitly-empty selections:** with strict on, a selection narrowed to nothing
+> (`kmptargets.targets=jvm,-jvm`) makes the [inert-module](#inert-modules) advisory fail **every**
+> module that declares `supports { }` at configuration time, by design — the other advisories stay
+> silent there, but every one of those modules carries a doomed metadata compilation. A
+> build-nothing lane that really wants to configure successfully should not pair the empty
+> selection with strict.
 
 ## CI
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -173,6 +173,13 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     internal var androidAgpWarned: Boolean = false
 
     /**
+     * True once the inert-module advisory (#71) fired, so it fires at most once per module. A
+     * boolean (not a set) on purpose: inertness is a whole-module property, and registration is
+     * one-way — once [registered] goes non-empty the module can never turn inert again.
+     */
+    internal var inertWarned: Boolean = false
+
+    /**
      * The resolved supported set: the declared value (unioned across [supports] calls), or
      * [KmpTargetSet.empty] if none was declared. Public so build-logic (and consumers) can read
      * what this module ended up declaring.

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -162,6 +162,16 @@ public class KmpTargetsPlugin : Plugin<Project> {
                         )
                 }
             )
+            // Inert annotation (#71): same decision source as the advisory
+            // (`shouldWarnInertModule` over `registered()`), realized lazily post-body and guarded
+            // by the same runtime KGP check as the host data — without KGP no metadata compilation
+            // exists, so there is no trap to report.
+            task.inertModule.set(
+                target.provider {
+                    target.pluginManager.hasPlugin(KGP_ID) &&
+                        shouldWarnInertModule(ext.supportsProperty.isPresent, ext.registered())
+                }
+            )
             // The config-layer origin is fixed at apply time, but the fallback labels must read
             // `defaultSelection` lazily — the body may override it after apply.
             task.originLabel.set(
@@ -426,6 +436,25 @@ public class KmpTargetsPlugin : Plugin<Project> {
             ext.deprecatedWarned += freshDeprecated
         }
 
+        // Inert-module advisory (#71): the pass ended with zero registrations for a module that
+        // declared supports { } — KGP still materializes the commonMain metadata compilation,
+        // which fails on a platform-less module, so the doomed task deserves a signal. Keyed off
+        // registered() — the exact query the message tells build-logic to gate on — so it covers
+        // every cause uniformly: a disjoint overlap, an explicitly-empty selection (where
+        // empty-overlap is silent by design, issue #9), and an android-only overlap skipped by the
+        // #51 guard. Ordered LAST on purpose: under strict the cause advisories above (empty-
+        // overlap, android-without-AGP) win the exception, and inert — the consequence channel —
+        // is the thrown text only where no cause advisory covers the state. Deduped once per
+        // module (registration is one-way, so a module that un-inerts can never re-inert),
+        // recorded AFTER warnOrFail so a strict failure leaves no bookkeeping behind.
+        if (
+            !ext.inertWarned &&
+                shouldWarnInertModule(ext.supportsProperty.isPresent, ext.registered())
+        ) {
+            warnOrFail(strict, inertModuleWarning(project.path)) { project.logger.warn(it) }
+            ext.inertWarned = true
+        }
+
         // Deliberately receives the unfiltered active set even when android was skipped above:
         // android is ungrouped in the hierarchy taxonomy (it attaches straight to common and
         // never affects the native collapse), so filtering would change nothing.
@@ -600,5 +629,33 @@ internal fun deprecatedTargetsWarning(path: String, deprecated: KmpTargetSet): S
     "kmp-targets: '$path' registers ${ids(deprecated)} which Kotlin marks deprecated " +
         "(since Kotlin 2.3.20, see https://kotlinlang.org/docs/native-target-support.html) — " +
         "still registered (selection is unchanged), but consider migrating off them."
+
+/**
+ * Whether to emit [inertModuleWarning] (#71): the module declared `supports { }` yet ended a
+ * registration pass with zero actual registrations. Keyed off [registered] — the
+ * `KmpTargetsExtension.registered()` snapshot, i.e. what truly registered with KGP — rather than
+ * `selection ∩ supported`, so the condition is provably the same one the message tells build-logic
+ * to gate on, and the #51 android skip counts as inert. Deliberately host-free: registration is
+ * host-blind, so a registered-but-uncompilable module is NOT inert on any host. A module that never
+ * declared `supports { }` registers nothing *intentionally* (explicit-selection doctrine) and is
+ * never flagged. Pure over its inputs, so it is unit-testable without Gradle; the same decision
+ * drives the `kmpTargetsInfo` inert line.
+ */
+internal fun shouldWarnInertModule(supportsDeclared: Boolean, registered: KmpTargetSet): Boolean =
+    supportsDeclared && registered.isEmpty()
+
+/**
+ * The inert-module advisory (#71). Mirrors its siblings in shape; serves as both the warning and
+ * the strict-mode failure text through [warnOrFail]. Unlike them it names a *task-level
+ * consequence* — KGP materializes `compileCommonMainKotlinMetadata` for every module applying the
+ * KMP plugin, and that compilation fails when no platform target exists — and the build-logic gate.
+ * Deliberately set-free: the advisory is cause-agnostic (disjoint overlap, explicitly-empty
+ * selection, android-only AGP skip all fire it), so naming the selection or supported sets would
+ * mislead in at least one of those cases; the cause advisories above it name the sets.
+ */
+internal fun inertModuleWarning(path: String): String =
+    "kmp-targets: '$path' declared supports { } but registered zero targets — the module is " +
+        "inert. KGP still materializes the commonMain metadata compilation, which fails with no " +
+        "platform targets. Gate it in build-logic when kmpTargets.registered().isEmpty()."
 
 private fun ids(set: KmpTargetSet): List<String> = set.members.map { it.id }.sorted()

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
@@ -23,6 +23,7 @@ internal fun formatKmpTargetsInfo(
     deprecatedIds: List<String>,
     jvmRegisteredAs: String? = null,
     androidWithoutAgp: Boolean = false,
+    inertModule: Boolean = false,
 ): String = buildString {
     appendLine("kmp-targets — $projectPath")
     appendLine()
@@ -63,6 +64,16 @@ internal fun formatKmpTargetsInfo(
                 markers.takeIf { it.isNotEmpty() }?.joinToString(" ")
             }
     )
+    // The inert line (#71) is its own row, not a per-leaf marker: it describes the whole module
+    // (zero actual registrations → doomed commonMain metadata compilation), and it must also
+    // render when the abstract `selection ∩ supported` line is non-empty but registration skipped
+    // everything (the #51 android case).
+    if (inertModule) {
+        appendLine(
+            "  inert:    zero targets registered — commonMain metadata compilation will fail; " +
+                "gate on registered().isEmpty()"
+        )
+    }
     appendLine()
     appendLine("Vocabulary")
     appendLine("  presets:  ${presetNames.joinToString(", ")}")

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
@@ -75,6 +75,16 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
      */
     @get:Internal public abstract val androidWithoutAgp: Property<Boolean>
 
+    /**
+     * True when this module declared `supports { }` yet registered zero targets (#71) — the inert
+     * state whose commonMain metadata compilation is doomed. Keyed off the same decision as the
+     * inert-module advisory (actual registrations, not `selection ∩ supported`), so the report's
+     * inert line appears exactly when the advisory fired. False when something registered, when
+     * `supports { }` was never declared (intentional, explicit-selection doctrine) — or when KGP is
+     * absent, in which case no metadata compilation exists and there is no trap to report.
+     */
+    @get:Internal public abstract val inertModule: Property<Boolean>
+
     @TaskAction
     public fun report() {
         println(
@@ -92,6 +102,7 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
                 deprecatedIds = deprecatedIds.get(),
                 jvmRegisteredAs = jvmRegisteredAs.orNull?.takeIf { it.isNotBlank() },
                 androidWithoutAgp = androidWithoutAgp.get(),
+                inertModule = inertModule.get(),
             )
         )
     }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/InertModuleAdvisoryInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/InertModuleAdvisoryInProcessTest.kt
@@ -1,0 +1,278 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.info.KmpTargetsInfoTask
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * The inert-module advisory (#71) wired into eager registration: when a module declared `supports {
+ * }` but a registration pass ends with zero targets registered, the advisory names the consequence
+ * — KGP's commonMain metadata compilation is doomed on a platform-less module — and the build-logic
+ * gate (`registered().isEmpty()`), failing with the identical text under `kmptargets.strict=true`
+ * through the same [warnOrFail] escalation point as every other advisory.
+ *
+ * Ordering doctrine under strict: the cause advisories (empty-overlap, android-without-AGP) are
+ * emitted first and win the exception; inert is the consequence channel and the sole signal only
+ * where no cause advisory covers the state (the explicitly-empty selection of issue #9).
+ */
+class InertModuleAdvisoryInProcessTest {
+
+    @Test
+    fun `given a disjoint selection when supports is declared then the inert advisory fires and nothing registers`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=wasmJs\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { jvm }
+        assertEquals(emptySet(), registeredTargets(project))
+        assertTrue(extension.inertWarned)
+    }
+
+    @Test
+    fun `given supports never called when the project configures then no inert signal fires`(
+        @TempDir dir: Path
+    ) {
+        // Explicit-selection doctrine: never declaring supports { } is the intentional way to
+        // register nothing — register() never runs, so the advisory cannot fire, and the info
+        // input reports false for the same reason (supportsDeclared gates the predicate).
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        assertFalse(extension.inertWarned)
+        val task = project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+        assertFalse(task.inertModule.get())
+    }
+
+    @Test
+    fun `given an explicitly empty selection when supports is declared then the inert advisory fires`(
+        @TempDir dir: Path
+    ) {
+        // `jvm,-jvm` parses to the explicit "build nothing" selection (issue #9). Empty-overlap is
+        // silent here by design; inert is the sole signal for the doomed metadata compilation.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,-jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { jvm }
+        assertEquals(emptySet(), registeredTargets(project))
+        assertTrue(extension.inertWarned)
+    }
+
+    @Test
+    fun `given strict on and an explicitly empty selection when supports is declared then the build fails with the inert text`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm,-jvm\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val ex = assertFailsWith<GradleException> { ext(project).supports { jvm } }
+        // Verbatim equality also proves empty-overlap stayed silent: had it fired, its text would
+        // have won the exception (it is emitted first).
+        assertEquals(inertModuleWarning(project.path), ex.message)
+    }
+
+    @Test
+    fun `given strict on and a disjoint selection when supports is declared then the build fails with the empty-overlap text`(
+        @TempDir dir: Path
+    ) {
+        // Ordering: the cause advisory wins the strict exception; inert (the consequence) is
+        // emitted after it and never reached once empty-overlap throws.
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=wasmJs\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        val ex = assertFailsWith<GradleException> { extension.supports { jvm } }
+        assertEquals(
+            emptyOverlapWarning(
+                path = project.path,
+                selection = KmpTargetSet.of(KmpTarget.Web.WasmJs),
+                supported = KmpTargetSet.of(KmpTarget.Jvm.Desktop),
+            ),
+            ex.message,
+        )
+        assertFalse(extension.inertWarned)
+    }
+
+    @Test
+    fun `given strict on when the inert advisory throws then it leaves no dedup bookkeeping behind`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm,-jvm\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        assertFailsWith<GradleException> { extension.supports { jvm } }
+        // Mirrors the host/deprecated/android doctrine: the flag is recorded AFTER warnOrFail, so a
+        // strict failure does not mark the module as already-warned.
+        assertFalse(extension.inertWarned)
+    }
+
+    @Test
+    fun `given the advisory already fired when a second still-inert supports union runs then it does not repeat`(
+        @TempDir dir: Path
+    ) {
+        // Strict makes "does not repeat" assertable: pre-seeding the dedup flag must leave the
+        // second pass with nothing to throw (mirrors the android suite's pre-seed pattern). The
+        // explicitly-empty selection keeps empty-overlap out of the way — inert is the only
+        // advisory in play.
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm,-jvm\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.inertWarned = true
+        extension.supports { jvm }
+        assertEquals(emptySet(), registeredTargets(project))
+    }
+
+    @Test
+    fun `given an inert module when a later supports union registers a leaf then the module un-inerts`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { iosArm64 }
+        assertTrue(extension.inertWarned)
+        // Registration is one-way: the union registers jvm, registered() goes (permanently)
+        // non-empty, and the predicate can never flag this module again.
+        extension.supports { jvm }
+        assertEquals(setOf("jvm"), registeredTargets(project))
+        assertEquals(KmpTargetSet.of(KmpTarget.Jvm.Desktop), extension.registered())
+    }
+
+    @Test
+    fun `given a first supports pass that registers a leaf when a later disjoint union runs then inert never fires`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { jvm }
+        extension.supports { iosArm64 }
+        assertEquals(setOf("jvm"), registeredTargets(project))
+        assertFalse(extension.inertWarned)
+    }
+
+    @Test
+    fun `given an android-only overlap without AGP when supports is declared then both the android and inert advisories fire`(
+        @TempDir dir: Path
+    ) {
+        // The #51 skip leaves the pass with zero registrations and empty-overlap silent (the
+        // overlap is non-empty) — the state empty-overlap misses and inert covers.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=android\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { androidTarget }
+        assertEquals(emptySet(), registeredTargets(project))
+        assertTrue(extension.androidAgpWarned)
+        assertTrue(extension.inertWarned)
+    }
+
+    @Test
+    fun `given strict on and an android-only overlap without AGP when supports is declared then the build fails with the android text`(
+        @TempDir dir: Path
+    ) {
+        // Cause wins again: android-without-AGP is emitted before inert.
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=android\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val ex = assertFailsWith<GradleException> { ext(project).supports { androidTarget } }
+        assertEquals(androidWithoutAgpWarning(project.path), ex.message)
+    }
+
+    @Test
+    fun `given supports declares an empty set when registration runs then both empty-overlap and inert fire`(
+        @TempDir dir: Path
+    ) {
+        // Pins the declared-but-empty interaction: supportsProperty is present, the overlap with
+        // the (default, non-empty) selection is empty — empty-overlap fires with its "supports []"
+        // text AND inert flags the doomed metadata compilation.
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports(KmpTargetSet.empty)
+        assertEquals(emptySet(), registeredTargets(project))
+        assertTrue(extension.inertWarned)
+    }
+
+    @Test
+    fun `given a host-impossible-only selection that still registers when supports is declared then the module is not inert`(
+        @TempDir dir: Path
+    ) {
+        // Cross-host stability: registration is host-blind, so iosArm64 registers on macOS, Linux,
+        // and Windows alike — a registered-but-uncompilable module is NOT inert on any host.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { iosArm64 }
+        assertEquals(setOf("iosArm64"), registeredTargets(project))
+        assertFalse(extension.inertWarned)
+    }
+
+    @Test
+    fun `given a disjoint module when the inert info input is read then it is true`(
+        @TempDir dir: Path
+    ) {
+        // Same decision source as the advisory (shouldWarnInertModule over registered()), realized
+        // lazily at task-graph calculation.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=wasmJs\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { jvm }
+        val task = project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+        assertTrue(task.inertModule.get())
+    }
+
+    @Test
+    fun `given an overlapping module when the inert info input is read then it is false`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { jvm }
+        val task = project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+        assertFalse(task.inertModule.get())
+    }
+
+    @Test
+    fun `given no KGP applied when the inert info input is read then it is false`(
+        @TempDir dir: Path
+    ) {
+        // Without KGP nothing registers — but no commonMain metadata compilation exists either, so
+        // there is no trap to signal. The provider's KGP guard keeps the report quiet.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=wasmJs\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        ext(project).supports { jvm }
+        val task = project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+        assertFalse(task.inertModule.get())
+    }
+
+    private fun newProjectWithKgp(dir: Path): Project {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        return project
+    }
+
+    private fun ext(project: Project): KmpTargetsExtension =
+        project.extensions.getByType(KmpTargetsExtension::class.java)
+
+    private fun registeredTargets(project: Project): Set<String> =
+        project.extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .names
+            .filter { it != "metadata" }
+            .toSet()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/InertModuleAdvisoryTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/InertModuleAdvisoryTest.kt
@@ -1,0 +1,80 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure decision/message facts of the inert-module advisory (#71): a module that declared `supports
+ * { }` but registered zero targets is inert — KGP still materializes its commonMain metadata
+ * compilation, which fails with no platform targets. The predicate is cause-agnostic (disjoint
+ * overlap, explicitly-empty selection, android-only-without-AGP all flag identically) and host-free
+ * (registration is host-blind, so a registered-but-uncompilable module is NOT inert). No Gradle
+ * here; the wiring (warnOrFail + dedup + ordering) is proven by [InertModuleAdvisoryInProcessTest].
+ */
+class InertModuleAdvisoryTest {
+
+    private val jvm = KmpTarget.Jvm.Desktop
+    private val iosArm64 = KmpTarget.Native.Apple.Ios.Arm64
+    private val wasmJs = KmpTarget.Web.WasmJs
+
+    @Test
+    fun `given supports declared and zero registrations when the policy is computed then it flags`() {
+        assertTrue(shouldWarnInertModule(supportsDeclared = true, registered = KmpTargetSet.empty))
+    }
+
+    @Test
+    fun `given supports declared and a registered leaf when the policy is computed then it does not flag`() {
+        // Also the host-blindness fact: registration is host-independent, so a registered leaf the
+        // current host cannot compile still counts — the module is not inert, on any host.
+        assertFalse(
+            shouldWarnInertModule(supportsDeclared = true, registered = KmpTargetSet.of(iosArm64))
+        )
+    }
+
+    @Test
+    fun `given supports never declared when the policy is computed then it does not flag`() {
+        // Explicit-selection doctrine: a module that never calls supports { } intentionally
+        // registers nothing — that is not the inert trap.
+        assertFalse(
+            shouldWarnInertModule(supportsDeclared = false, registered = KmpTargetSet.empty)
+        )
+    }
+
+    @Test
+    fun `given a disjoint non-empty selection when both policies are computed then empty-overlap and inert both flag`() {
+        // The intended composition: empty-overlap diagnoses the cause (selection vs supported
+        // mismatch), inert names the consequence (doomed metadata compilation). Both fire.
+        val selection = KmpTargetSet.of(wasmJs)
+        val supported = KmpTargetSet.of(jvm)
+        assertTrue(shouldWarnEmptyOverlap(selection, supported))
+        assertTrue(shouldWarnInertModule(supportsDeclared = true, registered = KmpTargetSet.empty))
+    }
+
+    @Test
+    fun `given an explicitly empty selection when both policies are computed then only inert flags`() {
+        // The coverage gap inert closes: empty-overlap is silent on an empty selection by design
+        // (issue #9 — "build nothing" is not a mismatch), but the doomed metadata task exists
+        // regardless of intent, so inert still signals it.
+        assertFalse(shouldWarnEmptyOverlap(KmpTargetSet.empty, KmpTargetSet.of(jvm)))
+        assertTrue(shouldWarnInertModule(supportsDeclared = true, registered = KmpTargetSet.empty))
+    }
+
+    @Test
+    fun `given a module path when the warning is built then it names the inert state the consequence and the gate`() {
+        val message = inertModuleWarning(":shared")
+        assertContains(message, ":shared")
+        assertContains(message, "supports { }")
+        assertContains(message, "inert")
+        assertContains(message, "commonMain metadata compilation")
+        assertContains(message, "registered().isEmpty()")
+        // Deliberately set-free: the message is cause-agnostic (it fires for a disjoint overlap, an
+        // explicitly-empty selection, or an android-only AGP skip alike), so naming the selection
+        // or
+        // supported sets would mislead in at least one of those cases.
+        assertFalse("[" in message, message)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
@@ -162,6 +162,46 @@ class KmpTargetsInfoFormatTest {
     }
 
     @Test
+    fun `given an inert module when formatted then the registered section carries the inert line`() {
+        // The advisory's consequence rendered where debugging starts (#71): the registered section
+        // explains that the metadata compilation is doomed and names the build-logic gate.
+        val output =
+            format(
+                selectionIds = listOf("wasmJs"),
+                supportedIds = listOf("jvm"),
+                registeredIds = emptyList(),
+                inertModule = true,
+            )
+        assertContains(
+            output,
+            "inert:    zero targets registered — commonMain metadata compilation will fail; " +
+                "gate on registered().isEmpty()",
+        )
+    }
+
+    @Test
+    fun `given a non-inert module when formatted then no inert line appears`() {
+        val output = format(registeredIds = listOf("jvm"))
+        assertFalse("inert:" in output, output)
+    }
+
+    @Test
+    fun `given an android-skip inert module when formatted then the skip marker and the inert line compose`() {
+        // The #51 skip can leave the module with zero actual registrations while the abstract
+        // `selection ∩ supported` line still lists androidTarget — both renderings must coexist.
+        val output =
+            format(
+                selectionIds = listOf("androidTarget"),
+                supportedIds = listOf("androidTarget"),
+                registeredIds = listOf("androidTarget"),
+                androidWithoutAgp = true,
+                inertModule = true,
+            )
+        assertContains(output, "androidTarget (skipped: no Android plugin applied)")
+        assertContains(output, "inert:")
+    }
+
+    @Test
     fun `given the vocabulary when formatted then exactly the deprecated leaves carry the marker`() {
         val output = format(deprecatedIds = listOf("macosX64", "tvosX64", "watchosX64"))
         assertContains(output, "macosX64 (deprecated)")
@@ -182,6 +222,7 @@ class KmpTargetsInfoFormatTest {
         deprecatedIds: List<String> = emptyList(),
         jvmRegisteredAs: String? = null,
         androidWithoutAgp: Boolean = false,
+        inertModule: Boolean = false,
     ): String =
         formatKmpTargetsInfo(
             projectPath = ":shared-core",
@@ -197,5 +238,6 @@ class KmpTargetsInfoFormatTest {
             deprecatedIds = deprecatedIds,
             jvmRegisteredAs = jvmRegisteredAs,
             androidWithoutAgp = androidWithoutAgp,
+            inertModule = inertModule,
         )
 }


### PR DESCRIPTION
## Problem

Under partial selection, a module whose `supports { … }` set ends up with **zero** registered targets is *inert* — explicit selection working as intended. But KGP still materializes `compileCommonMainKotlinMetadata` for every module applying `kotlin("multiplatform")`, and that compilation **fails** on a platform-less module (`@OptionalExpectation` and friends are rejected). Aggregate invocations then trip over every inert module with an opaque compiler error, and the plugin emitted no signal. A ~95-module consumer hit this on the very first narrowed lane (#71).

## Chosen direction: (a) signal-only `inert-module` advisory

The 5th member of the advisory family, emitted eagerly inside registration (no `afterEvaluate`) through the single `warnOrFail` escalation point — `kmptargets.strict=true` promotes it to a `GradleException` with the **identical text**. Doctrine-clean: *advisories signal, never filter*. The opt-in disable helper (direction b) is deliberately **not** in this PR (see the follow-up note on #71); the docs ship the build-logic gating recipe (direction c) as part of the advisory's README section.

```
kmp-targets: ':shared' declared supports { } but registered zero targets — the module is inert.
KGP still materializes the commonMain metadata compilation, which fails with no platform targets.
Gate it in build-logic when kmpTargets.registered().isEmpty().
```

The message is deliberately **set-free** (cause-agnostic — naming the selection/supported sets would mislead in at least one covered cause; the cause advisories name them) and keyed off `registered()` — the exact #52 query it tells build-logic to gate on, so the advisory's condition and the recommended gate can never drift.

## Answers to the issue's open questions

1. **Is the failing metadata task ever legitimately wanted on an inert module?** No — under KGP the biconditional holds: `registered()` empty ⇔ the commonMain metadata compilation is platform-less and doomed. That strengthens the case for a blessed disable, but filtering stays out per doctrine; the advisory + documented gate cover the need without a second filtering exception.
2. **Helper shape (`enabled = false` vs `onlyIf`)?** Deferred with the helper itself. The documented recipe uses `tasks.withType(KotlinCompilationTask::class.java).configureEach { enabled = false }` at configuration time — config-cache safe, no `Project` capture.
3. **Distinguish "inert by selection" from "never called `supports { }`"?** Yes, strictly: the predicate is `supportsDeclared && registered().isEmpty()`. A module that never declares `supports { }` registers nothing *intentionally* (explicit-selection doctrine) and is never flagged — proven by test.
4. **Composition with empty-overlap?** The gap is **both** things the issue hypothesized: (a) task-level consequence messaging, and (b) detection coverage — empty-overlap requires a non-empty selection and a genuinely disjoint overlap, so it misses the explicitly-empty selection (`jvm,-jvm`, issue #9) *and* the android-only overlap skipped by the #51 AGP guard. Inert covers all three causes uniformly. In the disjoint case **both fire** — complementary content (cause vs consequence), not duplication.

## Advisory ordering

`empty-overlap → android-without-AGP → host-impossible → deprecated → inert` (new, last, before the hierarchy template). Inert must observe the pass's final `registered()` state, and under strict the root-**cause** advisory wins the exception — inert is the thrown text only where no cause advisory covers the state (the explicitly-empty selection, previously fully silent). Non-strict logs read cause-then-consequence. Host/deprecated never co-fire with inert (they require a registered leaf).

## Semantics

- **Dedup**: once per module via `inertWarned` (boolean — inertness is a whole-module property), recorded **after** `warnOrFail` so a strict failure leaves no bookkeeping.
- **Un-inert**: registration is one-way, so a later `supports { }` union that registers a leaf un-inerts the module permanently; it can never re-fire.
- **Host-blind**: the predicate has no host input; a registered-but-uncompilable target still counts as registered (cross-host stable, like the rest of the family).
- **`kmpTargetsInfo`**: new `inert:` line in the registered section, wired from the same decision (`shouldWarnInertModule` over `registered()`), KGP-guarded like the host annotations.
- **Docs**: new README "Inert modules" section with the gating recipe; strict section updated (four → five advisories) plus a heads-up that strict + explicitly-empty selection fails every `supports`-declaring module by design.

## Test evidence

`task dod` green (fmt + build + test). Full suite: **380 tests, 0 failures, 0 errors, 0 skipped**, including:

- new `InertModuleAdvisoryTest` (6 pure tests: predicate, composition with `shouldWarnEmptyOverlap`, message facts)
- new `InertModuleAdvisoryInProcessTest` (16 in-process tests: disjoint fire, never-declared silence, explicitly-empty selection as sole strict signal with verbatim text, strict ordering vs empty-overlap and android-without-AGP, no-bookkeeping-on-strict-throw, dedup pre-seed, un-inert union, `supports(empty)` double-fire pin, host-impossible-still-registered not inert, info-input true/false/no-KGP)
- `KmpTargetsInfoFormatTest` +3 (inert line, absence, android-skip composition)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)