### PR TITLE
feat: deploy-docs reusable workflow + mkdocs scaffold + GitHub App diagnostic (#63, #64)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,77 @@
+# Reusable workflow for deploying documentation with Mike versioning
+name: Deploy Documentation
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: 'Version to deploy (e.g., 1.0.0, 1.0.0-SNAPSHOT)'
+      alias:
+        required: false
+        type: string
+        default: ''
+        description: 'Alias for this version (e.g., latest). Optional for self-descriptive versions like snapshot'
+      set-default:
+        required: false
+        type: boolean
+        default: true
+        description: 'Set this version as default'
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'deploy-docs'
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.alias || inputs.version }} documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Full history for mike
+
+      - name: Fetch gh-pages branch
+        run: |
+          git fetch origin gh-pages:gh-pages || echo "First deployment - gh-pages branch doesn't exist yet"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install MkDocs dependencies
+        run: |
+          pip install --requirement .github/workflows/mkdocs-requirements.txt
+
+      - name: Configure Git for Mike
+        uses: ./.github/actions/configure-release-bot
+        with:
+          bot-name: ${{ vars.RELEASE_BOT_NAME }}
+          bot-app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+
+      - name: Show current Mike versions
+        run: |
+          echo "Current Mike versions available:"
+          mike list || echo "No docs site versions found (likely first deployment)"
+
+      - name: Deploy documentation with mike
+        run: |
+          if [ -n "${{ inputs.alias }}" ]; then
+            mike deploy --update-aliases --push ${{ inputs.version }} ${{ inputs.alias }}
+          else
+            mike deploy --push ${{ inputs.version }}
+          fi
+
+      - name: Set default version
+        if: inputs.set-default
+        run: |
+          mike set-default --push ${{ inputs.alias || inputs.version }}

--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -1,0 +1,27 @@
+click==8.2.2
+future==1.0.0
+Jinja2==3.1.6
+livereload==2.7.1
+lunr==0.8.0
+Markdown==3.9
+MarkupSafe==3.0.2
+mike==2.1.3
+mkdocs==1.6.1
+mkdocs-get-deps==0.2.0
+mkdocs-macros-plugin==1.3.9
+mkdocs-material==9.6.16
+mkdocs-material-extensions==1.3.1
+mkdocs-callouts==1.16.0
+Pygments==2.20.0
+pymdown-extensions==10.16.1
+python-dateutil==2.9.0.post0
+PyYAML==6.0.2
+repackage==0.7.3
+six==1.17.0
+termcolor==3.1.0
+tornado==6.5.5
+
+# Imaging dependencies for mkdocs-material social plugin
+# https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/
+cairosvg==2.9.0
+pillow==12.2.0

--- a/.github/workflows/test-github-app.yml
+++ b/.github/workflows/test-github-app.yml
@@ -1,0 +1,366 @@
+name: Test GitHub App Integration
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_mode:
+        description: 'Test mode'
+        required: true
+        type: choice
+        default: 'dry-run'
+        options:
+          - dry-run
+          - create-test-branch
+
+concurrency:
+  group: test-github-app-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  validate-secrets:
+    name: Validate Secrets Configuration
+    runs-on: ubuntu-latest
+    outputs:
+      has_app_id: ${{ steps.check.outputs.has_app_id }}
+      has_private_key: ${{ steps.check.outputs.has_private_key }}
+    steps:
+      - name: Check Required Secrets
+        id: check
+        run: |
+          echo "Checking for required GitHub App secrets..."
+
+          if [ -n "${{ secrets.GH_APP_ID }}" ]; then
+            echo "✅ GH_APP_ID is configured"
+            echo "has_app_id=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "❌ GH_APP_ID is NOT configured"
+            echo "has_app_id=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "${{ secrets.GH_APP_PRIVATE_KEY }}" ]; then
+            echo "✅ GH_APP_PRIVATE_KEY is configured"
+            echo "has_private_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "❌ GH_APP_PRIVATE_KEY is NOT configured"
+            echo "has_private_key=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fail if Secrets Missing
+        if: steps.check.outputs.has_app_id != 'true' || steps.check.outputs.has_private_key != 'true'
+        run: |
+          echo "::error::Missing required secrets. Please configure:"
+          echo "  - GH_APP_ID: GitHub App ID"
+          echo "  - GH_APP_PRIVATE_KEY: GitHub App private key (PEM format)"
+          echo ""
+          echo "To set up:"
+          echo "1. Go to repository Settings > Secrets and variables > Actions"
+          echo "2. Add the required secrets"
+          exit 1
+
+  test-authentication:
+    name: Test GitHub App Authentication
+    runs-on: ubuntu-latest
+    needs: validate-secrets
+    outputs:
+      token_works: ${{ steps.verify.outputs.token_works }}
+      app_login: ${{ steps.verify.outputs.app_login }}
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Verify Token
+        id: verify
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "Testing GitHub App token..."
+
+          # Test authentication
+          if gh auth status; then
+            echo "✅ GitHub App authentication successful"
+            echo "token_works=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "❌ GitHub App authentication failed"
+            echo "token_works=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          # Get app information
+          APP_LOGIN=$(gh api /app | jq -r '.slug // .name // "unknown"')
+          echo "✅ GitHub App login: $APP_LOGIN"
+          echo "app_login=$APP_LOGIN" >> "$GITHUB_OUTPUT"
+
+  test-permissions:
+    name: Test GitHub App Permissions
+    runs-on: ubuntu-latest
+    needs: test-authentication
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Test Repository Read Access
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "Testing repository read access..."
+
+          # Test repo info access (output unused — the call succeeding is the test)
+          gh api repos/${{ github.repository }} > /dev/null
+          echo "✅ Can read repository information"
+
+          # Test branch listing
+          BRANCHES=$(gh api repos/${{ github.repository }}/branches --jq '.[].name' | head -5)
+          echo "✅ Can list branches:"
+          echo "$BRANCHES"
+
+      - name: Test Git Configuration
+        run: |
+          echo "Testing Git configuration..."
+
+          # Use the actual release bot configuration
+          BOT_NAME="${{ vars.RELEASE_BOT_NAME }}"
+          BOT_USER_ID="${{ vars.RELEASE_BOT_APP_ID }}"
+
+          # Ensure bot name ends with [bot] for proper GitHub attribution
+          BOT_DISPLAY_NAME="${BOT_NAME%'[bot]'}[bot]"
+
+          git config --global user.name "$BOT_DISPLAY_NAME"
+          git config --global user.email "${BOT_USER_ID}+${BOT_DISPLAY_NAME}@users.noreply.github.com"
+
+          echo "✅ Git user configured:"
+          echo "   Name: $(git config user.name)"
+          echo "   Email: $(git config user.email)"
+
+  test-commit-capability:
+    name: Test Commit and Push Capability
+    runs-on: ubuntu-latest
+    needs: test-permissions
+    if: inputs.test_mode == 'create-test-branch'
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Configure Git with Release Bot Identity
+        uses: ./.github/actions/configure-release-bot
+        with:
+          bot-name: ${{ vars.RELEASE_BOT_NAME }}
+          bot-app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+
+      - name: Create Test Branch
+        id: branch
+        run: |
+          BRANCH_NAME="test/github-app-$(date +%s)"
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+          git checkout -b "$BRANCH_NAME"
+          echo "✅ Created test branch: $BRANCH_NAME"
+
+      - name: Create Test Commit
+        run: |
+          # Create a test file
+          mkdir -p .github/test
+          echo "GitHub App Test - $(date)" > .github/test/test-commit.txt
+
+          git add .github/test/test-commit.txt
+          git commit -m "test: validate GitHub App commit capability [skip ci]"
+
+          echo "✅ Created test commit"
+
+      - name: Push Test Branch
+        run: |
+          git push origin ${{ steps.branch.outputs.branch_name }}
+          echo "✅ Successfully pushed test branch"
+
+      - name: Verify Push
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Verify branch exists on remote
+          BRANCH_EXISTS=$(gh api repos/${{ github.repository }}/branches/${{ steps.branch.outputs.branch_name }} --jq '.name // ""')
+
+          if [ "$BRANCH_EXISTS" = "${{ steps.branch.outputs.branch_name }}" ]; then
+            echo "✅ Branch verified on remote"
+          else
+            echo "❌ Branch not found on remote"
+            exit 1
+          fi
+
+      - name: Clean Up Test Branch
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Delete the test branch
+          gh api repos/${{ github.repository }}/git/refs/heads/${{ steps.branch.outputs.branch_name }} -X DELETE || true
+          echo "✅ Cleaned up test branch"
+
+  test-release-capability:
+    name: Test Release Creation Capability
+    runs-on: ubuntu-latest
+    needs: test-permissions
+    if: inputs.test_mode == 'create-test-branch'
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Create Draft Release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        id: release
+        run: |
+          echo "Testing draft release creation..."
+
+          TAG_NAME="test-release-$(date +%s)"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+
+          RELEASE_OUTPUT=$(gh release create "$TAG_NAME" \
+            --title "Test Release - GitHub App Validation" \
+            --notes "This is a test release to validate GitHub App permissions. It will be deleted automatically." \
+            --draft \
+            --repo ${{ github.repository }})
+
+          echo "✅ Draft release created successfully"
+          echo "$RELEASE_OUTPUT"
+
+      - name: Verify Release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          RELEASE_INFO=$(gh release view ${{ steps.release.outputs.tag_name }} \
+            --repo ${{ github.repository }} \
+            --json isDraft,tagName)
+          IS_DRAFT=$(echo "$RELEASE_INFO" | jq -r '.isDraft')
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "✅ Release verified as draft"
+          else
+            echo "❌ Release is not a draft"
+            exit 1
+          fi
+
+      - name: Clean Up Draft Release
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh release delete ${{ steps.release.outputs.tag_name }} \
+            --yes \
+            --cleanup-tag \
+            --repo ${{ github.repository }} || true
+          echo "✅ Cleaned up draft release"
+
+  summary:
+    name: Test Summary
+    runs-on: ubuntu-latest
+    needs: [validate-secrets, test-authentication, test-permissions, test-commit-capability, test-release-capability]
+    if: always()
+    steps:
+      - name: Generate Summary
+        run: |
+          {
+            echo "# GitHub App Integration Test Results"
+            echo ""
+
+            echo "## Test Mode: ${{ inputs.test_mode }}"
+            echo ""
+
+            echo "## Results"
+            echo ""
+
+            # Secrets validation
+            if [ "${{ needs.validate-secrets.result }}" = "success" ]; then
+              echo "✅ **Secrets Configuration**: PASSED"
+            else
+              echo "❌ **Secrets Configuration**: FAILED"
+            fi
+
+            # Authentication
+            if [ "${{ needs.test-authentication.result }}" = "success" ]; then
+              echo "✅ **Authentication**: PASSED"
+              echo "   - App Login: ${{ needs.test-authentication.outputs.app_login }}"
+            else
+              echo "❌ **Authentication**: FAILED"
+            fi
+
+            # Repository Access
+            if [ "${{ needs.test-permissions.result }}" = "success" ]; then
+              echo "✅ **Repository Access**: PASSED"
+              echo "   - Can read repository and list branches"
+            else
+              echo "❌ **Repository Access**: FAILED"
+            fi
+
+            # Commit capability (only if create-test-branch mode)
+            if [ "${{ inputs.test_mode }}" = "create-test-branch" ]; then
+              if [ "${{ needs.test-commit-capability.result }}" = "success" ]; then
+                echo "✅ **Commit & Push**: PASSED"
+              else
+                echo "❌ **Commit & Push**: FAILED"
+              fi
+
+              if [ "${{ needs.test-release-capability.result }}" = "success" ]; then
+                echo "✅ **Release Creation**: PASSED"
+              else
+                echo "❌ **Release Creation**: FAILED"
+              fi
+            else
+              echo "⏭️  **Commit & Push**: SKIPPED (dry-run mode)"
+              echo "⏭️  **Release Creation**: SKIPPED (dry-run mode)"
+            fi
+
+            echo ""
+            echo "## Next Steps"
+            echo ""
+
+            if [ "${{ needs.validate-secrets.result }}" = "success" ] && \
+               [ "${{ needs.test-authentication.result }}" = "success" ] && \
+               [ "${{ needs.test-permissions.result }}" = "success" ]; then
+              echo "🎉 All basic tests passed! Your GitHub App is properly configured."
+              echo ""
+
+              if [ "${{ inputs.test_mode }}" = "dry-run" ]; then
+                echo "💡 **Tip**: Run this workflow again with mode 'create-test-branch' to test commit/push capabilities."
+              else
+                echo "✅ Your GitHub App can commit, push, and create releases."
+                echo ""
+                echo "You're ready to use the publish workflow!"
+              fi
+            else
+              echo "⚠️  Some tests failed. Please review the logs above and fix the issues."
+              echo ""
+              echo "### Common Issues:"
+              echo "- Missing secrets: Add GH_APP_ID and GH_APP_PRIVATE_KEY in repository settings"
+              echo "- App not installed: Install the GitHub App on this repository"
+              echo "- Wrong permissions: Ensure the GitHub App has 'contents: write' permission"
+              echo ""
+              echo "**Note:** Write permissions are validated by actually testing commit/push operations in 'create-test-branch' mode."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -74,6 +74,11 @@ tasks:
       - git config --unset core.hooksPath
       - echo "✓ git hooks disabled (back to .git/hooks/)."
 
+  docs:serve:
+    desc: Serve the docs site locally (needs `pip install -r .github/workflows/mkdocs-requirements.txt`)
+    cmds:
+      - mkdocs serve
+
   clean:
     desc: Clean root build + sample build artifacts
     cmds:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,6 @@
+# Compatibility
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -1,0 +1,6 @@
+# Installation
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#69](https://github.com/rsicarelli/kmp-targets/issues/69).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -1,0 +1,6 @@
+# Quick Start
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#69](https://github.com/rsicarelli/kmp-targets/issues/69).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1,0 +1,6 @@
+# FAQ
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -1,0 +1,6 @@
+# Troubleshooting
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# kmp-targets
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#69](https://github.com/rsicarelli/kmp-targets/issues/69).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -1,0 +1,6 @@
+# Samples
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/stylesheets/kmp-targets-brand.css
+++ b/docs/stylesheets/kmp-targets-brand.css
@@ -1,0 +1,39 @@
+/* kmp-targets Brand Colors for Material Theme
+ *
+ * Placeholder palette (Kotlin-adjacent hues) until a real brand lands:
+ * - Purple (primary): #7F52FF
+ * - Deep Purple: #5C3DBC
+ * - Coral (accent): #FF6F61
+ */
+
+/* ========================================
+   LIGHT THEME (default)
+   ======================================== */
+[data-md-color-scheme="default"] {
+  /* Primary Colors */
+  --md-primary-fg-color: #5C3DBC;              /* Deep purple - header, navigation */
+  --md-primary-fg-color--light: #7F52FF;       /* Lighter purple - hover states */
+  --md-primary-fg-color--dark: #452E91;        /* Darker purple - active states */
+
+  /* Accent Colors */
+  --md-accent-fg-color: #FF6F61;               /* Coral - accents, highlights */
+
+  /* Links */
+  --md-typeset-a-color: #5C3DBC;               /* Link color - deep purple */
+}
+
+/* ========================================
+   DARK THEME (slate)
+   ======================================== */
+[data-md-color-scheme="slate"] {
+  /* Primary Colors - Lighter Purple for Dark Backgrounds */
+  --md-primary-fg-color: #9D7AFF;              /* Lighter purple - better contrast */
+  --md-primary-fg-color--light: #B79AFF;       /* Even lighter - hover states */
+  --md-primary-fg-color--dark: #7F52FF;        /* Original purple - active states */
+
+  /* Accent Colors */
+  --md-accent-fg-color: #FF8A7E;               /* Lighter coral - vibrant on dark */
+
+  /* Links */
+  --md-typeset-a-color: #9D7AFF;               /* Link color - light purple */
+}

--- a/docs/user-guide/advisories.md
+++ b/docs/user-guide/advisories.md
@@ -1,0 +1,6 @@
+# Advisories & Strict Mode
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/user-guide/build-logic.md
+++ b/docs/user-guide/build-logic.md
@@ -1,0 +1,6 @@
+# Build-Logic Conventions
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/user-guide/ci-matrix.md
+++ b/docs/user-guide/ci-matrix.md
@@ -1,0 +1,6 @@
+# CI Matrix
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/user-guide/hierarchy-template.md
+++ b/docs/user-guide/hierarchy-template.md
@@ -1,0 +1,6 @@
+# Hierarchy Template
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/user-guide/jvm-rename.md
+++ b/docs/user-guide/jvm-rename.md
@@ -1,0 +1,6 @@
+# Renaming the JVM Target
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/user-guide/kmp-targets-info.md
+++ b/docs/user-guide/kmp-targets-info.md
@@ -1,0 +1,6 @@
+# Inspecting with kmpTargetsInfo
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/user-guide/no-collapse-mode.md
+++ b/docs/user-guide/no-collapse-mode.md
@@ -1,0 +1,6 @@
+# No-Collapse Mode
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/user-guide/recipes.md
+++ b/docs/user-guide/recipes.md
@@ -1,0 +1,6 @@
+# Recipes
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/user-guide/selection-dsl.md
+++ b/docs/user-guide/selection-dsl.md
@@ -1,0 +1,6 @@
+# Selection DSL
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/user-guide/selection-layers.md
+++ b/docs/user-guide/selection-layers.md
@@ -1,0 +1,6 @@
+# Selection Layers
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/user-guide/targets-reference.md
+++ b/docs/user-guide/targets-reference.md
@@ -1,0 +1,6 @@
+# Targets Reference
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/docs/why-kmp-targets.md
+++ b/docs/why-kmp-targets.md
@@ -1,0 +1,6 @@
+# Why kmp-targets?
+
+!!! note "Under construction"
+    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+
+Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,103 @@
+# kmp-targets Documentation Site
+# To serve locally: task docs:serve
+# Deployed by .github/workflows/deploy-docs.yml (mike, versioned on gh-pages)
+
+site_name: kmp-targets
+repo_name: kmp-targets
+repo_url: https://github.com/rsicarelli/kmp-targets
+site_url: https://rsicarelli.github.io/kmp-targets/
+site_description: "Dynamically select which Kotlin Multiplatform targets to build via the kmptargets.targets Gradle property"
+site_author: Rodrigo Sicarelli
+remote_branch: gh-pages
+
+copyright: 'Copyright &copy; 2026 Rodrigo Sicarelli'
+
+theme:
+  name: 'material'
+  palette:
+    - media: '(prefers-color-scheme: light)'
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: '(prefers-color-scheme: dark)'
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: 'Inter'
+    code: 'Fira Code'
+  features:
+    - content.code.copy
+    - content.code.select
+    - search.suggest
+    - search.highlight
+    - content.tabs.link
+
+plugins:
+  - search
+  - mike
+  - callouts
+
+markdown_extensions:
+  - smarty
+  - codehilite:
+      guess_lang: false
+  - footnotes
+  - meta
+  - toc:
+      permalink: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.inlinehilite
+  - pymdownx.magiclink
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.emoji
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - tables
+  - admonition
+  - attr_list
+  - md_in_html
+  - nl2br
+
+extra_css:
+  - stylesheets/kmp-targets-brand.css
+
+extra:
+  version:
+    provider: mike
+
+nav:
+  - 'Home': index.md
+  - 'Why kmp-targets?': why-kmp-targets.md
+  - 'Get Started':
+      - 'Installation': get-started/index.md
+      - 'Quick Start': get-started/quick-start.md
+  - 'User Guide':
+      - 'Selection DSL': user-guide/selection-dsl.md
+      - 'Selection Layers': user-guide/selection-layers.md
+      - 'Targets Reference': user-guide/targets-reference.md
+      - 'Hierarchy Template': user-guide/hierarchy-template.md
+      - 'No-Collapse Mode': user-guide/no-collapse-mode.md
+      - 'Build-Logic Conventions': user-guide/build-logic.md
+      - 'Recipes': user-guide/recipes.md
+      - 'Advisories & Strict Mode': user-guide/advisories.md
+      - 'Inspecting with kmpTargetsInfo': user-guide/kmp-targets-info.md
+      - 'CI Matrix': user-guide/ci-matrix.md
+      - 'Renaming the JVM Target': user-guide/jvm-rename.md
+  - 'Samples': samples/index.md
+  - 'Compatibility': compatibility.md
+  - 'Help':
+      - 'FAQ': help/faq.md
+      - 'Troubleshooting': help/troubleshooting.md


### PR DESCRIPTION
## Summary

Docs-deployment infrastructure (no real content — that's #69/#70): the reusable mike-versioned deploy workflow, the MkDocs Material scaffold with the full #70 nav as stubs, and the GitHub App credential diagnostic workflow.

## Changes

- `.github/workflows/deploy-docs.yml` — fakt verbatim: `workflow_call` with `version`/`alias`/`set-default` inputs; Python 3.13; `mike deploy --update-aliases --push` + conditional `mike set-default --push`; bot identity via `configure-release-bot` (#62)
- `.github/workflows/mkdocs-requirements.txt` — fakt verbatim, pinned (mkdocs 1.6.1, mkdocs-material 9.6.16, mike 2.1.3, mkdocs-callouts, …)
- `mkdocs.yml` — Material theme (Inter/Fira Code), plugins search+mike+callouts, `extra.version.provider: mike`, `site_url: https://rsicarelli.github.io/kmp-targets/`; nav covers every #70 page plus a `user-guide/recipes.md` hub (seeded from the consumer-validation comment on #70)
- `docs/` — one stub per nav entry (19 pages, each linking to its content issue) + `docs/stylesheets/kmp-targets-brand.css` placeholder palette
- `Taskfile.yml` — `docs:serve`
- `.github/workflows/test-github-app.yml` — fakt's dry-run / create-test-branch diagnostic; adapted only for shell hygiene (quoted `$GITHUB_OUTPUT`/`$GITHUB_STEP_SUMMARY`, grouped summary redirects) so `actionlint` is fully clean

## Test plan

- [x] `task ci` is green locally (`task dod`; no plugin/sample code touched)
- [x] Added/updated tests where appropriate (infra only)
- [x] Updated docs/README if user-facing (stubs only by design)
- [x] No new public API without explicit intent

Verification:
- `pip install -r .github/workflows/mkdocs-requirements.txt && mkdocs build --strict` → clean (isolated venv)
- `actionlint` → zero findings across all workflows
- Stub pages render with the version selector wiring in place (mike provider configured)

## Deferred verification (needs #58)

- First real `deploy-docs.yml` invocation (via #65) creating `gh-pages` and the live site (needs Pages config + `RELEASE_BOT_*` vars)
- `test-github-app.yml` dry-run dispatch (needs `GH_APP_ID`/`GH_APP_PRIVATE_KEY`; before secrets exist it fails at the secrets check — expected and informative)
- New workflows don't execute on this PR (workflow_call / workflow_dispatch triggers) — PR-green covers existing ci.yml + sample-matrix.yml only

## Related

Closes #63
Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)