### PR TITLE
feat: release, hotfix, and recovery workflows + plugin-bundle actions (#66, #67, #68)

### DIFF
--- a/.github/actions/publish-plugin-bundle/action.yml
+++ b/.github/actions/publish-plugin-bundle/action.yml
@@ -1,0 +1,28 @@
+name: Publish Plugin Bundle
+description: Build the kmp-targets plugin, publish to Maven Local, and upload the artifacts as a workflow artifact for downstream sample jobs
+
+inputs:
+  artifact-name:
+    description: Name of the workflow artifact that holds the published Maven Local subtree
+    required: false
+    default: kmp-targets-plugin-maven-local
+
+runs:
+  using: composite
+  steps:
+    - name: Publish kmp-targets plugin to Maven Local
+      shell: bash
+      env:
+        ORG_GRADLE_PROJECT_SKIP_SIGNING: true
+      run: ./gradlew publishToMavenLocal
+
+    # The whole com/rsicarelli subtree: it holds both the plugin artifact
+    # (com/rsicarelli/kmp-targets-gradle-plugin) and its marker
+    # (com/rsicarelli/kmptargets/com.rsicarelli.kmptargets.gradle.plugin).
+    - name: Upload plugin Maven Local subtree
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ~/.m2/repository/com/rsicarelli/
+        retention-days: 1
+        if-no-files-found: error

--- a/.github/actions/restore-plugin-bundle/action.yml
+++ b/.github/actions/restore-plugin-bundle/action.yml
@@ -1,0 +1,23 @@
+name: Restore Plugin Bundle
+description: Download the kmp-targets plugin Maven Local subtree published by the upstream publish-plugin-bundle job and install it into the runner's local Maven repository
+
+inputs:
+  artifact-name:
+    description: Name of the workflow artifact that holds the published Maven Local subtree
+    required: false
+    default: kmp-targets-plugin-maven-local
+
+runs:
+  using: composite
+  steps:
+    - name: Download plugin Maven Local subtree
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ runner.temp }}/kmp-targets-plugin
+
+    - name: Install into local Maven repository
+      shell: bash
+      run: |
+        mkdir -p ~/.m2/repository/com/rsicarelli
+        cp -R "${{ runner.temp }}/kmp-targets-plugin/." ~/.m2/repository/com/rsicarelli/

--- a/.github/workflows/fix-publication.yml
+++ b/.github/workflows/fix-publication.yml
@@ -1,0 +1,156 @@
+name: Fix Publication
+
+on:
+  workflow_dispatch:
+    inputs:
+      published_version:
+        required: true
+        type: string
+        description: 'Version published to Maven Central (e.g., 0.1.0-alpha01)'
+      bump:
+        required: true
+        type: choice
+        description: 'Version bump type for next development version'
+        default: 'minor'
+        options:
+          - major
+          - minor
+          - patch
+      release_type:
+        required: true
+        type: choice
+        description: 'Release type for next development version'
+        default: 'alpha'
+        options:
+          - alpha
+          - beta
+          - stable
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IS_CI: true
+
+jobs:
+  fix-publication:
+    name: Fix Post-Publish Steps
+    runs-on: ubuntu-latest
+    outputs:
+      version_published: ${{ github.event.inputs.published_version }}
+    steps:
+      - name: Fail if branch is not main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "This workflow should only be triggered from the main branch"
+          exit 1
+
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Configure Release Bot
+        uses: ./.github/actions/configure-release-bot
+        with:
+          bot-name: ${{ vars.RELEASE_BOT_NAME }}
+          bot-app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+
+      # publish-release produces the release version in-place on the runner, so main's
+      # gradle.properties holds the DEV version before the post-publish commit lands and the
+      # NEXT dev version after. "Already bumped" therefore means: current version equals what
+      # bump(published_version, bump, release_type) predicts — computed with the bump script
+      # itself (run against the explicit published version, then restored).
+      - name: Verify version
+        id: verify
+        run: |
+          CURRENT=$(grep "version=" gradle.properties | cut -d'=' -f2)
+          echo "current_version=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "Published version (input): ${{ github.event.inputs.published_version }}"
+          echo "Current version (gradle.properties): $CURRENT"
+
+          PREDICTED_NEXT=$(kotlin .github/scripts/bump-version.main.kts \
+            "${{ github.event.inputs.bump }}" \
+            "${{ github.event.inputs.release_type }}" \
+            "${{ github.event.inputs.published_version }}" \
+            | grep '^VERSION_NEW=' | cut -d'=' -f2)
+          git checkout -- .
+          echo "Predicted next dev version: $PREDICTED_NEXT"
+
+          if [ "$CURRENT" = "$PREDICTED_NEXT" ]; then
+            echo "::warning::gradle.properties already shows the next dev version ($CURRENT) — skipping the version bump."
+            echo "version_already_bumped=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version not bumped yet. Proceeding with full post-publish recovery."
+            echo "version_already_bumped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag if missing
+        run: |
+          TAG="v${{ github.event.inputs.published_version }}"
+          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists on remote. Skipping."
+          else
+            echo "Creating tag $TAG..."
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "Tag $TAG created and pushed."
+          fi
+
+      - name: Check if GitHub Release exists
+        id: check-release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          TAG="v${{ github.event.inputs.published_version }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub Release for $TAG already exists. Skipping."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "GitHub Release for $TAG does not exist. Will create it."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.check-release.outputs.exists != 'true'
+        uses: ./.github/actions/create-github-release
+        with:
+          tag: "v${{ github.event.inputs.published_version }}"
+          github-token: ${{ steps.app-token.outputs.token }}
+          is-prerelease: ${{ contains(github.event.inputs.published_version, '-alpha') || contains(github.event.inputs.published_version, '-beta') }}
+
+      - name: Prepare for Next Version
+        if: steps.verify.outputs.version_already_bumped != 'true'
+        run: |
+          bash .github/scripts/prepare-next-release.sh \
+            "${{ github.event.inputs.published_version }}" \
+            "${{ github.event.inputs.bump }}" \
+            "${{ github.event.inputs.release_type }}"
+
+      - name: Push Changes
+        if: steps.verify.outputs.version_already_bumped != 'true'
+        run: git push origin HEAD
+
+  deploy-docs:
+    name: Deploy Release Documentation
+    needs: fix-publication
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy-docs.yml
+    with:
+      version: ${{ needs.fix-publication.outputs.version_published }}
+      alias: 'latest'
+      set-default: true

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -1,0 +1,197 @@
+name: Publish Hotfix
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IS_CI: true
+  ORG_GRADLE_PROJECT_RELEASE_MODE: true
+
+jobs:
+  guard-release:
+    name: Guard Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if branch is main
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "Hotfix workflow should not be triggered from the main branch"
+          echo "Please create a hotfix branch (e.g., hotfix/0.1.x) with the patched version in gradle.properties and run from there"
+          exit 1
+
+  validate-tests:
+    name: Validate Tests
+    needs: [guard-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Execute Tests
+        uses: ./.github/actions/run-tests
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-gradle-plugin
+          path: |
+            **/build/test-results/**/TEST-*.xml
+            !samples/**/build/test-results/**
+          retention-days: 1
+
+  publish-plugin-bundle:
+    name: Publish Plugin Bundle
+    needs: [guard-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Publish Plugin Bundle
+        uses: ./.github/actions/publish-plugin-bundle
+
+  validate-samples:
+    name: Sample (${{ matrix.os }})
+    needs: [guard-release, publish-plugin-bundle]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            targets: jvm,iosArm64,linuxX64,linuxArm64
+          - os: macos-latest
+            targets: appleMobile,jvm
+          - os: windows-latest
+            targets: windows,jvm,iosArm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Restore Plugin Bundle
+        uses: ./.github/actions/restore-plugin-bundle
+
+      # The -P flag is quoted because PowerShell (windows-latest) splits unquoted commas into
+      # an array — the quotes are harmless on bash.
+      - name: Show resolved targets (kmpTargetsInfo)
+        run: ./gradlew -p samples/hello-world :shared-core:kmpTargetsInfo -q "-Pkmptargets.targets=${{ matrix.targets }}"
+
+      - name: Build sample with host-appropriate selection
+        run: ./gradlew -p samples/hello-world build "-Pkmptargets.targets=${{ matrix.targets }}"
+
+  validation-summary:
+    name: Validation Summary
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - guard-release
+      - validate-tests
+      - publish-plugin-bundle
+      - validate-samples
+    steps:
+      - name: Check validation status
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "❌ Some validation jobs failed"
+            exit 1
+          fi
+
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "⚠️  Some validation jobs were cancelled"
+            exit 1
+          fi
+
+          if [[ "${{ contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "⚠️  Some validation jobs were skipped (upstream guard likely failed)"
+            exit 1
+          fi
+
+          echo "✅ All validation jobs passed successfully"
+          exit 0
+
+  publish:
+    name: Publish Hotfix to Maven Central
+    runs-on: ubuntu-latest
+    needs: validation-summary
+    permissions:
+      contents: write
+    outputs:
+      version_published: ${{ steps.published.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Configure Release Bot
+        uses: ./.github/actions/configure-release-bot
+        with:
+          bot-name: ${{ vars.RELEASE_BOT_NAME }}
+          bot-app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+
+      # The hotfix branch carries the patched version in gradle.properties — published as-is.
+      - name: Publish to Maven Central
+        run: |
+          ./gradlew publishAndReleaseToMavenCentral --no-daemon
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
+
+      - name: Capture Published Version
+        id: published
+        run: |
+          CURRENT=$(grep "version=" gradle.properties | cut -d'=' -f2)
+          echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "tag=v$CURRENT" >> "$GITHUB_OUTPUT"
+
+      - name: Create Tag for Published Version
+        run: |
+          git tag "${{ steps.published.outputs.tag }}"
+          git push origin "${{ steps.published.outputs.tag }}"
+
+      - name: Create GitHub Release
+        uses: ./.github/actions/create-github-release
+        with:
+          tag: ${{ steps.published.outputs.tag }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare for Next Hotfix Version
+        id: prepare
+        run: |
+          bash .github/scripts/prepare-next-release.sh \
+            "${{ steps.published.outputs.version }}" \
+            "patch" \
+            "stable"
+
+      - name: Push Changes
+        run: git push origin HEAD
+
+  deploy-docs:
+    name: Deploy Hotfix Documentation
+    needs: publish
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy-docs.yml
+    with:
+      version: ${{ needs.publish.outputs.version_published }}
+      alias: 'latest'
+      set-default: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,232 @@
+name: Publish Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        required: true
+        type: choice
+        description: 'Version bump type'
+        default: 'minor'
+        options:
+          - major
+          - minor
+          - patch
+      release_type:
+        required: true
+        type: choice
+        description: 'Release type'
+        default: 'alpha'
+        options:
+          - alpha
+          - beta
+          - stable
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IS_CI: true
+  ORG_GRADLE_PROJECT_RELEASE_MODE: true
+
+jobs:
+  guard-release:
+    name: Guard Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if branch is not main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "This workflow should only be triggered from the main branch"
+          exit 1
+
+  validate-tests:
+    name: Validate Tests
+    needs: [guard-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Execute Tests
+        uses: ./.github/actions/run-tests
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-gradle-plugin
+          path: |
+            **/build/test-results/**/TEST-*.xml
+            !samples/**/build/test-results/**
+          retention-days: 1
+
+  publish-plugin-bundle:
+    name: Publish Plugin Bundle
+    needs: [guard-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Publish Plugin Bundle
+        uses: ./.github/actions/publish-plugin-bundle
+
+  validate-samples:
+    name: Sample (${{ matrix.os }})
+    needs: [guard-release, publish-plugin-bundle]
+    strategy:
+      # Same per-host selection vocabulary as sample-matrix.yml — a Windows konan hiccup must
+      # not cancel the macOS job (the one with real Apple compilation coverage).
+      fail-fast: false
+      matrix:
+        include:
+          # Real Linux-native compilation; iosArm64 is gate-only on this host.
+          - os: ubuntu-latest
+            targets: jvm,iosArm64,linuxX64,linuxArm64
+          # The only host that can compile/link Apple targets.
+          - os: macos-latest
+            targets: appleMobile,jvm
+          # The only host for MinGW. iosArm64 is gate-only, as on ubuntu.
+          - os: windows-latest
+            targets: windows,jvm,iosArm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      # The samples consume the plugin from mavenLocal — restore the bundle built once by
+      # publish-plugin-bundle instead of republishing per matrix job.
+      - name: Restore Plugin Bundle
+        uses: ./.github/actions/restore-plugin-bundle
+
+      # The -P flag is quoted because PowerShell (windows-latest) splits unquoted commas into
+      # an array — the quotes are harmless on bash.
+      - name: Show resolved targets (kmpTargetsInfo)
+        run: ./gradlew -p samples/hello-world :shared-core:kmpTargetsInfo -q "-Pkmptargets.targets=${{ matrix.targets }}"
+
+      - name: Build sample with host-appropriate selection
+        run: ./gradlew -p samples/hello-world build "-Pkmptargets.targets=${{ matrix.targets }}"
+
+  validation-summary:
+    name: Validation Summary
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - guard-release
+      - validate-tests
+      - publish-plugin-bundle
+      - validate-samples
+    steps:
+      - name: Check validation status
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "❌ Some validation jobs failed"
+            exit 1
+          fi
+
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "⚠️  Some validation jobs were cancelled"
+            exit 1
+          fi
+
+          if [[ "${{ contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "⚠️  Some validation jobs were skipped (upstream guard likely failed)"
+            exit 1
+          fi
+
+          echo "✅ All validation jobs passed successfully"
+          exit 0
+
+  publish:
+    name: Publish to Maven Central
+    runs-on: ubuntu-latest
+    needs: validation-summary
+    outputs:
+      version_published: ${{ steps.bump.outputs.version_new }}
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Configure Release Bot
+        uses: ./.github/actions/configure-release-bot
+        with:
+          bot-name: ${{ vars.RELEASE_BOT_NAME }}
+          bot-app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+
+      # gradle.properties carries the dev version (e.g. 0.1.0-SNAPSHOT); the release version is
+      # produced in-place on the runner (no commit) — e.g. `patch alpha` → 0.1.0-alpha01.
+      - name: Bump to release version
+        id: bump
+        run: |
+          kotlin .github/scripts/bump-version.main.kts \
+            "${{ github.event.inputs.bump }}" \
+            "${{ github.event.inputs.release_type }}"
+          echo "📦 Publishing version: $(grep 'version=' gradle.properties | cut -d'=' -f2)"
+
+      - name: Publish to Maven Central
+        run: |
+          ./gradlew publishAndReleaseToMavenCentral --no-daemon
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
+
+      - name: Create Tag for Published Version
+        run: |
+          git tag "${{ steps.bump.outputs.tag }}"
+          git push origin "${{ steps.bump.outputs.tag }}"
+
+      - name: Create GitHub Release
+        uses: ./.github/actions/create-github-release
+        with:
+          tag: ${{ steps.bump.outputs.tag }}
+          github-token: ${{ steps.app-token.outputs.token }}
+          is-prerelease: ${{ github.event.inputs.release_type != 'stable' }}
+
+      - name: Prepare for Next Version
+        id: prepare
+        run: |
+          bash .github/scripts/prepare-next-release.sh \
+            "${{ steps.bump.outputs.version_new }}" \
+            "${{ github.event.inputs.bump }}" \
+            "${{ github.event.inputs.release_type }}"
+
+      - name: Push Changes
+        run: git push origin HEAD
+
+  deploy-docs:
+    name: Deploy Release Documentation
+    needs: publish
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy-docs.yml
+    with:
+      version: ${{ needs.publish.outputs.version_published }}
+      alias: 'latest'
+      set-default: true


### PR DESCRIPTION
## Summary

The three release paths, completing the fakt-parity automation: dispatched versioned releases, stable hotfixes from a branch, and idempotent partial-failure recovery. Plus the `publish-plugin-bundle`/`restore-plugin-bundle` composite actions that let the 3-OS sample matrix consume a once-built plugin instead of republishing per job.

## Changes

- `.github/workflows/publish-release.yml` — `workflow_dispatch` (`bump` × `release_type`); main-only guard; parallel `validate-tests` (`./gradlew check`) + `publish-plugin-bundle` → `validate-samples` (ubuntu `jvm,iosArm64,linuxX64,linuxArm64` / macos `appleMobile,jvm` / windows `windows,jvm,iosArm64` — copied from `sample-matrix.yml`, restoring the bundle); `validation-summary` gate; `publish`: App-token checkout → **bump to release version in-place** (e.g. `patch alpha` → `0.1.0-alpha01`, no commit) → `publishAndReleaseToMavenCentral` → tag `v<version>` → GitHub Release (`--generate-notes`, prerelease for alpha/beta) → `prepare-next-release.sh` → push next-dev commit; final `deploy-docs` with `alias=latest`, `set-default=true`
- `.github/workflows/publish-hotfix.yml` — guard **not**-main; same validation shape; publishes the hotfix branch's `gradle.properties` version as-is; Release via `GITHUB_TOKEN`; `prepare-next-release.sh patch stable` pushed to the hotfix branch
- `.github/workflows/fix-publication.yml` — inputs `published_version`/`bump`/`release_type`; tag-if-missing, Release-if-missing (prerelease inferred from the version string), bump-if-not-already-bumped, push; always re-deploys docs
- `.github/actions/publish-plugin-bundle/` + `restore-plugin-bundle/` — upload/restore the `~/.m2/repository/com/rsicarelli/` subtree (covers both the artifact **and** the plugin marker), `SKIP_SIGNING=true` for the local publish

### Deliberate adaptation (flagging for review)

fakt's `fix-publication.yml` treats "gradle.properties == published_version" as not-yet-bumped. That assumption doesn't hold here because `publish-release.yml` produces the release version **on the runner** (main holds the dev version before the post-publish commit and the next-dev version after). The recovery check is therefore: *already bumped ⇔ current == bump(published_version, bump, release_type)*, computed by running the bump script against the explicit published version and restoring. Verified locally: `bump(0.1.0-alpha01, patch, alpha) = 0.1.0-alpha02`, so a second dispatch with the same inputs skips the bump — the idempotency the issue requires.

## Test plan

- [x] `task ci` is green locally (`task dod`; workflows + actions only)
- [x] Added/updated tests where appropriate (recovery prediction simulated locally)
- [x] Updated docs/README if user-facing (not user-facing)
- [x] No new public API without explicit intent

Verification: `actionlint` → zero findings; both new `action.yml` files parse as valid YAML; bump-prediction pipeline exercised locally with state restored.

## Deferred verification (needs #58)

All three workflows are `workflow_dispatch`-only — nothing here executes on this PR; PR-green covers existing CI only. After #58:
- First `publish-release` dispatch (`patch alpha`) doubles as the launch: Central artifact, tag `v0.1.0-alpha01`, pre-release GitHub Release, next-dev commit on `main`, docs at `latest`
- Hotfix smoke (branch from a tag, dispatch, verify, delete branch)
- `fix-publication` skip-behavior smoke against a pre-created tag

## Related

Closes #66
Closes #67
Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)