### PR TITLE
docs: landing, installation, quick-start + README installation rework (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 > Dynamically select which Kotlin Multiplatform targets to build.
 
-**Status:** alpha (pre-1.0). Shipped and exercised by the multi-module sample plus a real 3-OS CI matrix: the global selector with [try-import-style layering](#selecting-targets) (dedicated config files, unified `kmptargets.*` keys), the automatic [minimal hierarchy template](#minimal-hierarchy-template), the [`kmpTargetsInfo`](#debugging-the-selection) introspection task, [host-compatibility](#host-compatibility), [deprecated-target](#deprecated-targets), [android-without-AGP](#android-target-without-the-android-gradle-plugin), and [inert-module](#inert-modules) advisories, and opt-in [strict mode](#strict-mode). Roadmap: user-defined hierarchy groups, XCFramework helpers, Maven Central / Plugin Portal publishing.
+[![Build](https://img.shields.io/github/actions/workflow/status/rsicarelli/kmp-targets/ci.yml)](https://github.com/rsicarelli/kmp-targets/actions/workflows/ci.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/com.rsicarelli/kmp-targets-gradle-plugin)](https://central.sonatype.com/artifact/com.rsicarelli/kmp-targets-gradle-plugin)
+[![Docs](https://img.shields.io/badge/docs-rsicarelli.github.io%2Fkmp--targets-blue)](https://rsicarelli.github.io/kmp-targets/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+**Status:** alpha (pre-1.0). Shipped and exercised by the multi-module sample plus a real 3-OS CI matrix: the global selector with [try-import-style layering](#selecting-targets) (dedicated config files, unified `kmptargets.*` keys), the automatic [minimal hierarchy template](#minimal-hierarchy-template), the [`kmpTargetsInfo`](#debugging-the-selection) introspection task, [host-compatibility](#host-compatibility), [deprecated-target](#deprecated-targets), [android-without-AGP](#android-target-without-the-android-gradle-plugin), and [inert-module](#inert-modules) advisories, and opt-in [strict mode](#strict-mode). Roadmap: user-defined hierarchy groups, XCFramework helpers.
 
 `kmp-targets` is a Gradle plugin for Kotlin Multiplatform projects that lets each developer (and each CI runner) choose which KMP targets to build, via a single Gradle property:
 
@@ -672,7 +677,27 @@ regress.
 
 ## Installation
 
-The plugin is not yet published to the Gradle Plugin Portal or Maven Central. Track progress in the issues / releases. Locally:
+The plugin is published to **Maven Central** — group `com.rsicarelli`, artifact
+`kmp-targets-gradle-plugin`, plugin id `com.rsicarelli.kmptargets` (no Gradle Plugin Portal). With
+`mavenCentral()` in `pluginManagement.repositories`:
+
+```kotlin
+// build.gradle.kts
+plugins {
+    kotlin("multiplatform")
+    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+}
+```
+
+Build-logic referencing the DSL types depends on the artifact directly:
+`com.rsicarelli:kmp-targets-gradle-plugin:0.1.0-SNAPSHOT`.
+
+Snapshots of every `main` push land at the Central Portal snapshots repository
+(`https://central.sonatype.com/repository/maven-snapshots/`). Full instructions — version catalogs,
+snapshot hygiene, prerequisites — live in the docs:
+**[rsicarelli.github.io/kmp-targets](https://rsicarelli.github.io/kmp-targets/get-started/)**.
+
+For working on the plugin itself:
 
 ```bash
 task publish-local           # publishes the plugin to mavenLocal

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -1,6 +1,111 @@
 # Installation
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#69](https://github.com/rsicarelli/kmp-targets/issues/69).
+## Prerequisites
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+| Requirement | Floor | Notes |
+|---|---|---|
+| Gradle | **8.11+** | the published jar carries Kotlin 2.0 metadata, readable by Gradle 8.x `kotlin-dsl` build-logic |
+| Daemon JVM | **JDK 17** | bytecode is pinned to 17 with `--release` protection |
+| Kotlin Gradle Plugin | **2.2+** | apply `kotlin("multiplatform")` yourself — the plugin never applies KGP for you |
+
+## Apply the plugin
+
+The plugin is published to **Maven Central** (group `com.rsicarelli`, artifact `kmp-targets-gradle-plugin`, plugin id `com.rsicarelli.kmptargets`). Make sure `mavenCentral()` is in your plugin repositories:
+
+```kotlin
+// settings.gradle.kts
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+```
+
+Then apply it next to KGP in each module:
+
+```kotlin
+// build.gradle.kts
+plugins {
+    kotlin("multiplatform")
+    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+}
+
+kmpTargets {
+    supports { mobile }
+}
+```
+
+!!! tip "Version catalog"
+    With a catalog entry the version lives in one place:
+
+    ```toml
+    # gradle/libs.versions.toml
+    [versions]
+    kmpTargets = "0.1.0-SNAPSHOT"
+
+    [plugins]
+    kmpTargets = { id = "com.rsicarelli.kmptargets", version.ref = "kmpTargets" }
+    ```
+
+    ```kotlin
+    plugins {
+        kotlin("multiplatform")
+        alias(libs.plugins.kmpTargets)
+    }
+    ```
+
+Build-logic that references the DSL types directly depends on the artifact:
+
+```kotlin
+// build-logic/build.gradle.kts
+dependencies {
+    implementation("com.rsicarelli:kmp-targets-gradle-plugin:0.1.0-SNAPSHOT")
+}
+```
+
+## Consuming snapshots
+
+Every push to `main` publishes a `-SNAPSHOT` to the Central Portal snapshots repository. To ride the bleeding edge, add the snapshots repo to **both** plugin and dependency resolution:
+
+```kotlin
+// settings.gradle.kts
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
+    }
+}
+```
+
+!!! warning "Snapshot hygiene"
+    Gradle caches changing modules for 24h by default. After a new snapshot lands, refresh explicitly:
+
+    ```bash
+    ./gradlew build --refresh-dependencies
+    ```
+
+    If resolution fails with a bare `Could not find com.rsicarelli:kmp-targets-gradle-plugin:<version>`, the repository list is the first thing to check — snapshots only exist in the snapshots repo, releases only on Maven Central.
+
+## Contributing / local development
+
+Working on the plugin itself? The repo publishes to `mavenLocal()` for the sample dev loop:
+
+```bash
+task publish-local           # publishes the plugin (and marker) to ~/.m2
+task sample                  # smoke test against samples/hello-world
+```
+
+This is a contributor workflow — consumers should use Maven Central or the snapshots repo above.
+
+---
+
+**Next: [Quick Start →](quick-start.md)**

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -1,6 +1,88 @@
 # Quick Start
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#69](https://github.com/rsicarelli/kmp-targets/issues/69).
+Five minutes from apply to a narrowed build. Each step builds on the previous one.
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+## 1. Apply and declare what the module *can* build
+
+```kotlin
+// feature-mobile/build.gradle.kts
+plugins {
+    kotlin("multiplatform")
+    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+}
+
+kmpTargets {
+    supports { mobile }   // androidTarget + the iOS leaves
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            // ...
+        }
+    }
+}
+```
+
+`supports { }` is the module's *supported set* — the complete list of targets this module is ever allowed to register. The vocabulary is type-safe set algebra: presets (`all`, `mobile`, `apple`, `web`, `jvmFamily`, …) and leaves (`jvm`, `iosArm64`, `linuxX64`, …) compose with `+` and `-`.
+
+!!! warning "Ordering: apply everything first, then `supports`"
+    `supports` registers targets **eagerly**, the moment it runs. Apply all plugins that influence registration **before** the `kmpTargets { }` block — most importantly the Android Gradle plugin when the module supports `androidTarget`. Calling `supports` more than once unions; a registered target can't be retracted.
+
+## 2. Build everything (default)
+
+With no selection configured, every supported target registers:
+
+```bash
+./gradlew :feature-mobile:build
+```
+
+## 3. Narrow the build to what you need *now*
+
+```bash
+./gradlew :feature-mobile:build -Pkmptargets.targets=iosArm64
+```
+
+Only `iosArm64` registers — `selection ∩ supported`. The Android/JVM/simulator tasks don't run slow; they *don't exist*.
+
+For a durable choice, use the config files instead of the flag:
+
+```properties
+# kmp-targets.properties — committed team default
+kmptargets.targets=jvm,iosSimulatorArm64
+```
+
+```properties
+# kmp-targets.local.properties — git-ignored personal override (beats the committed default)
+kmptargets.targets=iosArm64
+```
+
+## 4. Inspect what the plugin decided
+
+```bash
+./gradlew :feature-mobile:kmpTargetsInfo -q
+```
+
+```console
+kmp-targets — :feature-mobile
+
+Selection (what to build now)
+  targets:  iosArm64
+  source:   command line (-Pkmptargets.targets)
+
+Supported (what this module can build)
+  declared: yes
+  targets:  androidTarget, iosArm64, iosSimulatorArm64, iosX64
+
+Registered (selection ∩ supported)
+  targets:  iosArm64
+```
+
+The `source` line names the winning [selection layer](../user-guide/selection-layers.md), so a surprising selection is a one-command diagnosis.
+
+## Where to next
+
+- **[Selection DSL](../user-guide/selection-dsl.md)** — the full `supports { }` story: eagerness, unions, escape hatches
+- **[Selection Layers](../user-guide/selection-layers.md)** — the precedence chain in detail
+- **[Targets Reference](../user-guide/targets-reference.md)** — every preset and leaf
+- **[CI Matrix](../user-guide/ci-matrix.md)** — per-host selections on a 3-OS matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,69 @@
 # kmp-targets
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#69](https://github.com/rsicarelli/kmp-targets/issues/69).
+**Dynamically select which Kotlin Multiplatform targets to build.**
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+[![Build](https://img.shields.io/github/actions/workflow/status/rsicarelli/kmp-targets/ci.yml)](https://github.com/rsicarelli/kmp-targets/actions/workflows/ci.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/com.rsicarelli/kmp-targets-gradle-plugin)](https://central.sonatype.com/artifact/com.rsicarelli/kmp-targets-gradle-plugin)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Kotlin](https://img.shields.io/badge/KGP-2.2%2B-blue)](https://kotlinlang.org)
+
+One Gradle property decides what your build registers. Targets you don't select are never registered with KGP, so their compile/link/KSP/publish tasks never exist — cutting sync and build times whenever you only need a subset.
+
+```properties
+# kmp-targets.properties (committed), kmp-targets.local.properties (personal), or -P
+kmptargets.targets=jvm,iosArm64
+```
+
+```kotlin
+// build.gradle.kts
+plugins {
+    kotlin("multiplatform")
+    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+}
+
+kmpTargets {
+    supports { mobile + web - iosX64 }   // presets and leaves compose as set algebra
+}
+```
+
+The plugin registers `selection ∩ supported` per module: the module declares what it *can* build, the global selection decides what you *want* right now.
+
+**[Why explicit selection? →](why-kmp-targets.md)**
+
+---
+
+## ✨ What you get
+
+- ✅ **Explicit, type-safe target declaration** — the whole vocabulary (`all`, `mobile`, `apple`, `jvm`, `iosArm64`, …) in scope as set algebra; no strings, no imports
+- ✅ **Three-layer selection** — committed team default → git-ignored personal override → per-invocation flag, all through the single `kmptargets.targets` key
+- ✅ **Minimal hierarchy template** — only the intermediate source sets your registered targets need
+- ✅ **`kmpTargetsInfo`** — a read-only report of the resolved selection, its winning source, and the registered intersection
+- ✅ **Advisories, promotable to errors** — host-compatibility, deprecated targets, Android-without-AGP, inert modules; strict mode turns them into failures in CI
+- ✅ **Build-logic friendly** — `registered()` / `onRegistered` expose the registered set without touching KGP internals; configuration-cache and Isolated Projects compatible
+
+---
+
+## 🚀 Start here
+
+1. **[Installation](get-started/index.md)** — coordinates, repositories, prerequisites
+2. **[Quick Start](get-started/quick-start.md)** — apply, declare, select, inspect, in 5 minutes
+3. **[Selection DSL](user-guide/selection-dsl.md)** — `supports { }`, eagerness, set algebra
+4. **[CI Matrix](user-guide/ci-matrix.md)** — one selection vocabulary across every CI host
+
+---
+
+## Requirements
+
+| Consumer surface | Floor |
+|---|---|
+| Gradle (`kotlin-dsl` build-logic) | **8.11+** |
+| Daemon JVM | **JDK 17** |
+| Kotlin Gradle Plugin | **2.2+** |
+
+**[Full compatibility story →](compatibility.md)**
+
+---
+
+## License
+
+kmp-targets is licensed under the [Apache License 2.0](https://github.com/rsicarelli/kmp-targets/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

The pages a prospective user reads first, plus the README's installation story moving from "not yet published" to real Maven Central coordinates. Voice follows fakt: code-first, concise, admonitions, tables.

## Changes

- `docs/index.md` — badges (CI, Maven Central, License, KGP), one-paragraph explicit-selection pitch with the property + DSL side by side, value bullets, links into get-started/user-guide, requirements table
- `docs/get-started/index.md` — prerequisites table (Gradle 8.11+ / JDK 17 / KGP 2.2+ floors), `mavenCentral()` in `pluginManagement`, plugins-block + version-catalog installation, **consuming snapshots** section (Central Portal snapshots repo + `--refresh-dependencies` hygiene + the bare `Could not find …` failure mode, per the onboarding note on the issue), mavenLocal demoted to contributor workflow
- `docs/get-started/quick-start.md` — apply → `supports { mobile }` → `-Pkmptargets.targets=iosArm64` → `kmpTargetsInfo`, with the **apply-before-supports ordering rule** (Android) called out early per the issue comment
- `README.md` — installation section gets real coordinates + docs-site link; CI/Central/docs/license badges added; publishing removed from the Status roadmap

## Test plan

- [x] `task ci` is green locally (`task dod`; docs + README only)
- [x] Added/updated tests where appropriate (n/a)
- [x] Updated docs/README if user-facing (this is the docs PR)
- [x] No new public API without explicit intent

Verification:
- `mkdocs build --strict` → clean, no broken links
- `kotlin .github/scripts/sync-docs-version.main.kts 9.9.9` → 9 replacements across the new pages + README + catalog, then restored — proving releases will keep every version string current
- Coordinates everywhere: group `com.rsicarelli`, artifact `kmp-targets-gradle-plugin`, plugin id `com.rsicarelli.kmptargets`

## Deferred verification (needs #58)

- Badges resolve once the first artifact + Pages deploy exist (Maven Central badge shows "not found" until then)
- Live-site review at https://rsicarelli.github.io/kmp-targets/ after the first docs deploy

## Related

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)