### PR TITLE
feat: native-only-metadata advisory — signal when jvmFamily is supported but unregistered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,23 @@ changes may land in any release.
 
 ### Added
 
+- **Native-only-metadata advisory** ([#72]): when a module **supports** the JVM family
+  (`androidTarget`/`jvm`) yet a registration pass ends with **no** JVM-family target registered
+  while other targets did register, the plugin logs a one-line advisory. The module is alive — the
+  platform klibs compile — but commonMain collapses to a JVM-less shared fragment, so the
+  `*KotlinMetadata*` compilations reject JVM-flavored constructs (`@JvmInline` and friends): the
+  paradoxical "klibs build, metadata fails". Disjoint from the inert-module advisory by
+  construction (inert = zero registrations; this fires only when something *did* register —
+  exactly one of the two per module state). Signal only, never filtering; promoted to a build
+  failure under `kmptargets.strict=true` with the identical text (the cause advisories —
+  empty-overlap, android-without-AGP — are emitted first and win the strict exception where they
+  apply; an android leaf skipped by the AGP guard still counts as supported-but-unregistered, so
+  both fire in warn mode). The recommended build-logic gate disables only the metadata
+  compilations, keyed off `kmpTargets.registered(jvmFamily).isEmpty()`. Any single JVM-family leaf
+  registered defeats the predicate (android-only included; the renamed jvm leaf counts — the
+  predicate is leaf-based); fires at most once per module, and a later `supports { }` union that
+  registers a JVM-family leaf resolves it permanently. `kmpTargetsInfo` renders the same decision
+  as a `jvm-less:` line in its registered section.
 - **Inert-module advisory** ([#71]): when a module that declared `supports { }` ends a
   registration pass with **zero** targets registered — a disjoint selection, an explicitly-empty
   selection (`jvm,-jvm`, where the empty-overlap advisory is silent by design), or an android-only
@@ -99,3 +116,4 @@ changes may land in any release.
 [#51]: https://github.com/rsicarelli/kmp-targets/issues/51
 [#52]: https://github.com/rsicarelli/kmp-targets/issues/52
 [#71]: https://github.com/rsicarelli/kmp-targets/issues/71
+[#72]: https://github.com/rsicarelli/kmp-targets/issues/72

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Docs](https://img.shields.io/badge/docs-rsicarelli.github.io%2Fkmp--targets-blue)](https://rsicarelli.github.io/kmp-targets/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-**Status:** alpha (pre-1.0). Shipped and exercised by the multi-module sample plus a real 3-OS CI matrix: the global selector with [try-import-style layering](#selecting-targets) (dedicated config files, unified `kmptargets.*` keys), the automatic [minimal hierarchy template](#minimal-hierarchy-template), the [`kmpTargetsInfo`](#debugging-the-selection) introspection task, [host-compatibility](#host-compatibility), [deprecated-target](#deprecated-targets), [android-without-AGP](#android-target-without-the-android-gradle-plugin), and [inert-module](#inert-modules) advisories, and opt-in [strict mode](#strict-mode). Roadmap: user-defined hierarchy groups, XCFramework helpers.
+**Status:** alpha (pre-1.0). Shipped and exercised by the multi-module sample plus a real 3-OS CI matrix: the global selector with [try-import-style layering](#selecting-targets) (dedicated config files, unified `kmptargets.*` keys), the automatic [minimal hierarchy template](#minimal-hierarchy-template), the [`kmpTargetsInfo`](#debugging-the-selection) introspection task, [host-compatibility](#host-compatibility), [deprecated-target](#deprecated-targets), [android-without-AGP](#android-target-without-the-android-gradle-plugin), [inert-module](#inert-modules), and [native-only-metadata](#native-only-metadata-jvm-less-commonmain) advisories, and opt-in [strict mode](#strict-mode). Roadmap: user-defined hierarchy groups, XCFramework helpers.
 
 `kmp-targets` is a Gradle plugin for Kotlin Multiplatform projects that lets each developer (and each CI runner) choose which KMP targets to build, via a single Gradle property:
 
@@ -536,14 +536,72 @@ target the current host [cannot compile](#host-compatibility) still counts as re
 [`kmpTargetsInfo`](#debugging-the-selection) renders the same decision as an `inert:` line in its
 registered section while the condition holds.
 
+### Native-only metadata (JVM-less commonMain)
+
+The [inert trap](#inert-modules) has a subtler sibling: a module that supports the JVM family
+(`androidTarget`, `jvm`) **plus** native targets, under a selection that drops every JVM-family
+leaf (an ios-only lane, say). The module is very much *alive* — the native leaves register and
+their platform klibs compile cleanly — but commonMain is now a **JVM-less shared fragment**, and
+the metadata compiler applies shared-fragment rules to code that was written assuming a JVM
+platform exists: `@JvmInline` and similar JVM-flavored constructs are rejected — but **only** in
+the `*KotlinMetadata*` compilations. The platform compilations succeed, which makes the failure
+look paradoxical ("the klibs build, why does metadata fail?"). The same holds when only web leaves
+register: the predicate is "no JVM-providing leaf", not "natives registered".
+
+So whenever a registration pass leaves such a module with targets registered but none of them
+JVM-family — while the supported set says the JVM family belongs here — the plugin logs a one-line
+advisory naming the symptom and the scoped gate:
+
+```
+kmp-targets: ':shared' supports the JVM family but this selection registered no JVM-family target
+while other targets did — commonMain is now a JVM-less shared fragment. The platform klibs
+compile, but the *KotlinMetadata* compilations reject JVM-flavored constructs (e.g. @JvmInline):
+klibs build, metadata fails. Gate it in build-logic when kmpTargets.registered(jvmFamily).isEmpty(),
+disabling only the *KotlinMetadata* compilations.
+```
+
+Like its siblings: **signal only, never filtering** — the plugin does not disable any task. The
+recommended gate is the *scoped* sibling of the [inert recipe](#inert-modules): where an inert
+module disables everything, this module keeps its alive platform compilations and drops only the
+doomed metadata ones, keyed off the same
+[`registered(slice)`](#querying-what-registered) query the advisory checks:
+
+```kotlin
+// after supports { } — drop the doomed metadata compilations, keep the platform klibs
+if (kmpTargets.registered().isNotEmpty() && kmpTargets.registered(jvmFamily).isEmpty()) {
+    tasks.withType(KotlinCompilationTask::class.java)
+        .matching { it.name.contains("KotlinMetadata") }
+        .configureEach { enabled = false }
+}
+```
+
+The predicate is precise on both sides. *Supported* means `resolvedSupported()` — so an
+`androidTarget` that was selected but [skipped for want of AGP](#android-target-without-the-android-gradle-plugin)
+still counts as "supports JVM, registered none", and in that composition both advisories fire:
+the AGP guard names the cause, this one names the consequence (under
+[strict](#strict-mode), the cause wins the exception). *Registered* means actual registrations,
+leaf-based — any single JVM-family leaf defeats the predicate (an android-only registration keeps
+the fragment JVM-flavored; Android is a JVM platform), and a jvm leaf
+[renamed](#renaming-the-jvm-target) via `targetName` still counts. A module whose `supports { }`
+never names a JVM-family leaf made no JVM promise and is never flagged; a module that registered
+**zero** targets is the [inert](#inert-modules) case — the two advisories are mutually exclusive
+by construction, so exactly one fires per module state.
+
+The advisory fires at most once per module; a later `supports { }` union that registers a
+JVM-family leaf resolves the trap permanently (registration is one-way). It is host-blind like
+registration itself. [`kmpTargetsInfo`](#debugging-the-selection) renders the same decision as a
+`jvm-less:` line in its registered section while the condition holds.
+
 ### Strict mode
 
-By default all five advisories — the **empty-overlap** warning (a non-empty selection that matches
+By default all six advisories — the **empty-overlap** warning (a non-empty selection that matches
 nothing a module `supports`, so the module registers zero targets), the
 [**android-without-AGP**](#android-target-without-the-android-gradle-plugin) advisory, the
 [**host-impossible**](#host-compatibility) warning, the
-[**deprecated-target**](#deprecated-targets) advisory, and the
-[**inert-module**](#inert-modules) advisory — are just that: warnings. Right for local
+[**deprecated-target**](#deprecated-targets) advisory, the
+[**inert-module**](#inert-modules) advisory, and the
+[**native-only-metadata**](#native-only-metadata-jvm-less-commonmain) advisory — are just that:
+warnings. Right for local
 iteration, easy to miss in CI, where a module silently building nothing is usually a real
 configuration bug.
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -180,6 +180,14 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     internal var inertWarned: Boolean = false
 
     /**
+     * True once the native-only-metadata advisory (#72) fired, so it fires at most once per module.
+     * A boolean (not a set) on purpose: the JVM-less-fragment trap is a whole-module property, and
+     * it resolves permanently once any JVM-family leaf registers (registration is one-way) — the
+     * flag only suppresses repeat firing across [supports] unions while the condition persists.
+     */
+    internal var nativeOnlyMetadataWarned: Boolean = false
+
+    /**
      * The resolved supported set: the declared value (unioned across [supports] calls), or
      * [KmpTargetSet.empty] if none was declared. Public so build-logic (and consumers) can read
      * what this module ended up declaring.

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -172,6 +172,16 @@ public class KmpTargetsPlugin : Plugin<Project> {
                         shouldWarnInertModule(ext.supportsProperty.isPresent, ext.registered())
                 }
             )
+            // Native-only-metadata annotation (#72): same decision source as the advisory
+            // (`shouldWarnNativeOnlyMetadata` over `resolvedSupported()`/`registered()`), realized
+            // lazily post-body and guarded by the same runtime KGP check — without KGP nothing
+            // registers, so no JVM-less fragment exists and there is no trap to report.
+            task.nativeOnlyMetadata.set(
+                target.provider {
+                    target.pluginManager.hasPlugin(KGP_ID) &&
+                        shouldWarnNativeOnlyMetadata(ext.resolvedSupported(), ext.registered())
+                }
+            )
             // The config-layer origin is fixed at apply time, but the fallback labels must read
             // `defaultSelection` lazily — the body may override it after apply.
             task.originLabel.set(
@@ -455,6 +465,28 @@ public class KmpTargetsPlugin : Plugin<Project> {
             ext.inertWarned = true
         }
 
+        // Native-only-metadata advisory (#72): the module SUPPORTS the JVM family (androidTarget
+        // and/or jvm) yet this pass ends with no JVM-family leaf registered while OTHER targets
+        // did register. The module is alive — the platform klibs compile — but commonMain
+        // collapses to a JVM-less shared fragment, so the *KotlinMetadata* compilations reject
+        // JVM-flavored constructs (@JvmInline and friends): klibs build, metadata fails. Keyed off
+        // resolvedSupported() (not the active overlap), so an android leaf the #51 guard skipped
+        // still counts as "supports JVM, registered none". The registered-non-empty conjunct makes
+        // this disjoint from inert (#71, registered empty) by construction — exactly one of the
+        // two consequence advisories fires per module state, so their relative order can never
+        // matter under strict; inert stays textually first (whole-module-dead before
+        // fragment-flavor). Like inert, it is a consequence channel evaluated last: under strict
+        // the cause advisories above (empty-overlap, android-without-AGP) win the exception.
+        // Deduped once per module, recorded AFTER warnOrFail so a strict failure leaves no
+        // bookkeeping behind.
+        if (
+            !ext.nativeOnlyMetadataWarned &&
+                shouldWarnNativeOnlyMetadata(ext.resolvedSupported(), ext.registered())
+        ) {
+            warnOrFail(strict, nativeOnlyMetadataWarning(project.path)) { project.logger.warn(it) }
+            ext.nativeOnlyMetadataWarned = true
+        }
+
         // Deliberately receives the unfiltered active set even when android was skipped above:
         // android is ungrouped in the hierarchy taxonomy (it attaches straight to common and
         // never affects the native collapse), so filtering would change nothing.
@@ -657,5 +689,47 @@ internal fun inertModuleWarning(path: String): String =
     "kmp-targets: '$path' declared supports { } but registered zero targets — the module is " +
         "inert. KGP still materializes the commonMain metadata compilation, which fails with no " +
         "platform targets. Gate it in build-logic when kmpTargets.registered().isEmpty()."
+
+/**
+ * Whether to emit [nativeOnlyMetadataWarning] (#72): the module supports the JVM family
+ * ([KmpTargetSet.jvmFamily]) yet registered no JVM-family leaf while registering at least one other
+ * target. Keyed off [supported] — `resolvedSupported()`, not the active overlap — so a
+ * selected-but-skipped android leaf (the #51 guard) still counts as "supports JVM, registered
+ * none"; and off [registered] — the actual registrations — which is leaf-based, so a jvm leaf
+ * renamed via `targetName` (issue #49) still keeps the fragment JVM-flavored. The
+ * registered-non-empty conjunct makes it disjoint from [shouldWarnInertModule] (#71, registered
+ * empty): an inert module is whole-module-dead, this one is alive with a JVM-less commonMain. Any
+ * single JVM-family leaf registered — android-only or jvm-only — defeats the predicate (Android is
+ * a JVM platform). Deliberately host-free: registration is host-blind, and a JVM-less fragment is
+ * JVM-less on every host. Pure over its inputs, so it is unit-testable without Gradle; the same
+ * decision drives the `kmpTargetsInfo` jvm-less line.
+ */
+internal fun shouldWarnNativeOnlyMetadata(
+    supported: KmpTargetSet,
+    registered: KmpTargetSet,
+): Boolean =
+    (supported intersect KmpTargetSet.jvmFamily).isNotEmpty() &&
+        registered.isNotEmpty() &&
+        (registered intersect KmpTargetSet.jvmFamily).isEmpty()
+
+/**
+ * The native-only-metadata advisory (#72). Mirrors its siblings in shape; serves as both the
+ * warning and the strict-mode failure text through [warnOrFail]. Like inert (#71) it names a
+ * *task-level consequence* — here the paradoxical half-failure where every platform klib compiles
+ * but the `*KotlinMetadata*` compilations reject JVM-flavored constructs — and it deliberately
+ * names the greppable symptom (`@JvmInline`) so a user arriving from the raw compiler error finds
+ * it. The gate it points at is the *scoped* sibling of inert's: disable only the metadata
+ * compilations, keep the alive platform ones. Deliberately set-free: the advisory is cause-agnostic
+ * (a narrowed lane and an android-only AGP skip fire it alike), so naming the selection or
+ * supported sets would mislead in at least one of those cases; the cause advisories above it name
+ * the sets.
+ */
+internal fun nativeOnlyMetadataWarning(path: String): String =
+    "kmp-targets: '$path' supports the JVM family but this selection registered no JVM-family " +
+        "target while other targets did — commonMain is now a JVM-less shared fragment. The " +
+        "platform klibs compile, but the *KotlinMetadata* compilations reject JVM-flavored " +
+        "constructs (e.g. @JvmInline): klibs build, metadata fails. Gate it in build-logic when " +
+        "kmpTargets.registered(jvmFamily).isEmpty(), disabling only the *KotlinMetadata* " +
+        "compilations."
 
 private fun ids(set: KmpTargetSet): List<String> = set.members.map { it.id }.sorted()

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
@@ -24,6 +24,7 @@ internal fun formatKmpTargetsInfo(
     jvmRegisteredAs: String? = null,
     androidWithoutAgp: Boolean = false,
     inertModule: Boolean = false,
+    nativeOnlyMetadata: Boolean = false,
 ): String = buildString {
     appendLine("kmp-targets — $projectPath")
     appendLine()
@@ -72,6 +73,16 @@ internal fun formatKmpTargetsInfo(
         appendLine(
             "  inert:    zero targets registered — commonMain metadata compilation will fail; " +
                 "gate on registered().isEmpty()"
+        )
+    }
+    // The jvm-less line (#72) is likewise a whole-module row, mutually exclusive with inert by
+    // construction (it requires registrations, inert requires none): targets registered, but no
+    // JVM-family leaf among them, so the metadata compilations reject JVM-flavored constructs
+    // while the platform klibs compile.
+    if (nativeOnlyMetadata) {
+        appendLine(
+            "  jvm-less: no JVM-family target registered — *KotlinMetadata* compilations reject " +
+                "@JvmInline etc. while the klibs compile; gate on registered(jvmFamily).isEmpty()"
         )
     }
     appendLine()

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
@@ -85,6 +85,18 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
      */
     @get:Internal public abstract val inertModule: Property<Boolean>
 
+    /**
+     * True when this module supports the JVM family yet registered no JVM-family leaf while other
+     * targets registered (#72) — the JVM-less commonMain whose `*KotlinMetadata*` compilations
+     * reject JVM-flavored constructs (`@JvmInline` and friends) while the platform klibs compile.
+     * Keyed off the same decision as the native-only-metadata advisory (actual registrations, not
+     * `selection ∩ supported`), so the report's jvm-less line appears exactly when the advisory
+     * fired. False when a JVM-family leaf registered, when nothing registered at all (that is the
+     * inert trap, #71 — the two are mutually exclusive) — or when KGP is absent, in which case
+     * nothing registers and there is no trap to report.
+     */
+    @get:Internal public abstract val nativeOnlyMetadata: Property<Boolean>
+
     @TaskAction
     public fun report() {
         println(
@@ -103,6 +115,7 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
                 jvmRegisteredAs = jvmRegisteredAs.orNull?.takeIf { it.isNotBlank() },
                 androidWithoutAgp = androidWithoutAgp.get(),
                 inertModule = inertModule.get(),
+                nativeOnlyMetadata = nativeOnlyMetadata.get(),
             )
         )
     }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/NativeOnlyMetadataAdvisoryInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/NativeOnlyMetadataAdvisoryInProcessTest.kt
@@ -1,0 +1,286 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.info.KmpTargetsInfoTask
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * The native-only-metadata advisory (#72) wired into eager registration: when a module supports the
+ * JVM family but a registration pass ends with no JVM-family leaf registered while other targets
+ * did register, the advisory names the trap — the platform klibs compile, but the
+ * `*KotlinMetadata*` compilations reject JVM-flavored constructs — and the scoped build-logic gate
+ * (`registered(jvmFamily).isEmpty()`), failing with the identical text under
+ * `kmptargets.strict=true` through the same [warnOrFail] escalation point as every other advisory.
+ *
+ * Ordering doctrine under strict: the cause advisories (empty-overlap, android-without-AGP) are
+ * emitted first and win the exception; native-only-metadata is a consequence channel, evaluated
+ * last next to its mutually-exclusive sibling inert (#71).
+ *
+ * Strict tests register `wasmJs` (host-agnostic) on purpose: a strict test registering a native
+ * leaf would trip the host-impossible advisory's exception first on a host that cannot compile it
+ * (CI runs on Linux). Warn-mode tests may register `iosArm64` — the host advisory only warns there.
+ */
+class NativeOnlyMetadataAdvisoryInProcessTest {
+
+    @Test
+    fun `given jvm family and ios supported when an ios-only selection registers then the native-only advisory fires`(
+        @TempDir dir: Path
+    ) {
+        // The issue's headline case: an android-less lane drops every JVM-family leaf, the native
+        // leaf registers fine, and commonMain silently becomes a JVM-less shared fragment.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { androidTarget + jvm + iosArm64 }
+        assertEquals(setOf("iosArm64"), registeredTargets(project))
+        assertTrue(extension.nativeOnlyMetadataWarned)
+    }
+
+    @Test
+    fun `given a selection that registers the jvm leaf when supports is declared then the advisory stays silent`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { jvm + iosArm64 }
+        assertEquals(setOf("jvm", "iosArm64"), registeredTargets(project))
+        assertFalse(extension.nativeOnlyMetadataWarned)
+    }
+
+    @Test
+    fun `given a fully inert module when supports is declared then inert fires and native-only does not`(
+        @TempDir dir: Path
+    ) {
+        // Disjointness with #71 in-process: zero registrations is the inert state; this advisory
+        // requires something to have registered. Exactly one of the two signals per module state.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,-jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { jvm }
+        assertEquals(emptySet(), registeredTargets(project))
+        assertTrue(extension.inertWarned)
+        assertFalse(extension.nativeOnlyMetadataWarned)
+    }
+
+    @Test
+    fun `given no jvm-family leaf in supports when a native-only selection registers then the advisory stays silent`(
+        @TempDir dir: Path
+    ) {
+        // A pure-native/web module under a native lane never promised a JVM-flavored commonMain.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { iosArm64 + wasmJs }
+        assertEquals(setOf("iosArm64"), registeredTargets(project))
+        assertFalse(extension.nativeOnlyMetadataWarned)
+    }
+
+    @Test
+    fun `given supports never called when the project configures then no native-only signal fires`(
+        @TempDir dir: Path
+    ) {
+        // Explicit-selection doctrine: never declaring supports { } registers nothing on purpose —
+        // register() never runs, so the advisory cannot fire, and the info input reports false.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        assertFalse(extension.nativeOnlyMetadataWarned)
+        val task = project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+        assertFalse(task.nativeOnlyMetadata.get())
+    }
+
+    @Test
+    fun `given strict on and a web-only selection when jvm is supported then the build fails with the native-only text`(
+        @TempDir dir: Path
+    ) {
+        // wasmJs keeps this cross-host stable (see the class KDoc). Verbatim equality also proves
+        // every sibling stayed silent: had one fired, its text would have won the exception.
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=wasmJs\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val ex = assertFailsWith<GradleException> { ext(project).supports { jvm + wasmJs } }
+        assertEquals(nativeOnlyMetadataWarning(project.path), ex.message)
+    }
+
+    @Test
+    fun `given strict on when the native-only advisory throws then it leaves no dedup bookkeeping behind`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=wasmJs\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        assertFailsWith<GradleException> { extension.supports { jvm + wasmJs } }
+        // Mirrors the family doctrine: the flag is recorded AFTER warnOrFail, so a strict failure
+        // does not mark the module as already-warned.
+        assertFalse(extension.nativeOnlyMetadataWarned)
+    }
+
+    @Test
+    fun `given the advisory already fired when a second still-jvm-less supports union runs then it does not repeat`(
+        @TempDir dir: Path
+    ) {
+        // Strict makes "does not repeat" assertable: pre-seeding the dedup flag must leave both
+        // passes with nothing to throw (mirrors the inert suite's pre-seed pattern). The condition
+        // stays true across both unions — jvm supported, only wasmJs registered.
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=wasmJs\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.nativeOnlyMetadataWarned = true
+        extension.supports { jvm + wasmJs }
+        extension.supports { wasmJs }
+        assertEquals(setOf("wasmJs"), registeredTargets(project))
+    }
+
+    @Test
+    fun `given a later supports union that registers the jvm leaf then the advisory never fires`(
+        @TempDir dir: Path
+    ) {
+        // The resolution guarantee: once a JVM-family leaf registers, the predicate is permanently
+        // false (registration is one-way). The first union has no JVM-family leaf in supported, so
+        // it is silent; the second registers jvm and the module can never trip the trap again.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { iosArm64 }
+        assertFalse(extension.nativeOnlyMetadataWarned)
+        extension.supports { jvm }
+        assertEquals(setOf("jvm", "iosArm64"), registeredTargets(project))
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Jvm.Desktop),
+            extension.registered(KmpTargetSet.jvmFamily),
+        )
+        assertFalse(extension.nativeOnlyMetadataWarned)
+    }
+
+    @Test
+    fun `given an android overlap skipped by the AGP guard when ios also registers then both advisories fire`(
+        @TempDir dir: Path
+    ) {
+        // Cause and consequence compose: the #51 skip keeps androidTarget out of registered(), so
+        // the pass ends alive (ios registered) but JVM-less — android-without-AGP names why the
+        // leaf is missing, native-only-metadata names what that does to commonMain.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=android,iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { androidTarget + iosArm64 }
+        assertEquals(setOf("iosArm64"), registeredTargets(project))
+        assertTrue(extension.androidAgpWarned)
+        assertTrue(extension.nativeOnlyMetadataWarned)
+    }
+
+    @Test
+    fun `given strict on and the AGP-skip composition when supports is declared then the build fails with the android text`(
+        @TempDir dir: Path
+    ) {
+        // Cause wins: android-without-AGP is emitted before the consequence advisories, so under
+        // strict its text takes the exception and native-only is never reached.
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=android,wasmJs\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        val ex = assertFailsWith<GradleException> { extension.supports { androidTarget + wasmJs } }
+        assertEquals(androidWithoutAgpWarning(project.path), ex.message)
+        assertFalse(extension.nativeOnlyMetadataWarned)
+    }
+
+    @Test
+    fun `given a renamed jvm target when it registers then the advisory stays silent`(
+        @TempDir dir: Path
+    ) {
+        // The predicate is leaf-based, not name-based: a jvm leaf renamed via targetName still
+        // carries KmpTarget.Jvm.Desktop in registered(), so the fragment stays JVM-flavored.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.targetName(KmpTargetsDsl.jvm, "desktop")
+        extension.supports { jvm + iosArm64 }
+        assertEquals(setOf("desktop", "iosArm64"), registeredTargets(project))
+        assertFalse(extension.nativeOnlyMetadataWarned)
+    }
+
+    @Test
+    fun `given an ios-only registration when configured on any host then the advisory fires host-blind`(
+        @TempDir dir: Path
+    ) {
+        // Cross-host stability: registration is host-blind, so iosArm64 registers on macOS, Linux,
+        // and Windows alike — and a JVM-less fragment is JVM-less on every one of them. The
+        // predicate never consults the host.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { jvm + iosArm64 }
+        assertEquals(setOf("iosArm64"), registeredTargets(project))
+        assertTrue(extension.nativeOnlyMetadataWarned)
+    }
+
+    @Test
+    fun `given a jvm-less module when the native-only info input is read then it is true`(
+        @TempDir dir: Path
+    ) {
+        // Same decision source as the advisory (shouldWarnNativeOnlyMetadata over
+        // resolvedSupported()/registered()), realized lazily at task-graph calculation.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { jvm + iosArm64 }
+        val task = project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+        assertTrue(task.nativeOnlyMetadata.get())
+    }
+
+    @Test
+    fun `given a module with a registered jvm leaf when the native-only info input is read then it is false`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { jvm + iosArm64 }
+        val task = project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+        assertFalse(task.nativeOnlyMetadata.get())
+    }
+
+    @Test
+    fun `given no KGP applied when the native-only info input is read then it is false`(
+        @TempDir dir: Path
+    ) {
+        // Without KGP nothing registers — no metadata compilation exists either, so there is no
+        // trap to signal. The provider's KGP guard keeps the report quiet.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        ext(project).supports { jvm + iosArm64 }
+        val task = project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+        assertFalse(task.nativeOnlyMetadata.get())
+    }
+
+    private fun newProjectWithKgp(dir: Path): Project {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        return project
+    }
+
+    private fun ext(project: Project): KmpTargetsExtension =
+        project.extensions.getByType(KmpTargetsExtension::class.java)
+
+    private fun registeredTargets(project: Project): Set<String> =
+        project.extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .names
+            .filter { it != "metadata" }
+            .toSet()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/NativeOnlyMetadataAdvisoryTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/NativeOnlyMetadataAdvisoryTest.kt
@@ -1,0 +1,145 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure decision/message facts of the native-only-metadata advisory (#72): a module that supports
+ * the JVM family (`androidTarget`/`jvm`) yet registered no JVM-family leaf — while OTHER targets
+ * did register — leaves commonMain a JVM-less shared fragment. The platform klibs compile, but the
+ * `*KotlinMetadata*` compilations reject JVM-flavored constructs (`@JvmInline` and friends): klibs
+ * build, metadata fails. The predicate is host-free (registration is host-blind) and leaf-based
+ * (the renamed jvm leaf still counts). The registered-non-empty conjunct makes it disjoint from the
+ * inert-module advisory (#71) by construction — exactly one of the two fires per module state. No
+ * Gradle here; the wiring (warnOrFail + dedup + ordering) is proven by
+ * [NativeOnlyMetadataAdvisoryInProcessTest].
+ */
+class NativeOnlyMetadataAdvisoryTest {
+
+    private val android = KmpTarget.Jvm.Android
+    private val jvm = KmpTarget.Jvm.Desktop
+    private val iosArm64 = KmpTarget.Native.Apple.Ios.Arm64
+    private val wasmJs = KmpTarget.Web.WasmJs
+
+    @Test
+    fun `given the jvm family supported and only a native leaf registered when the policy is computed then it flags`() {
+        assertTrue(
+            shouldWarnNativeOnlyMetadata(
+                supported = KmpTargetSet.of(android, jvm, iosArm64),
+                registered = KmpTargetSet.of(iosArm64),
+            )
+        )
+    }
+
+    @Test
+    fun `given the jvm leaf registered when the policy is computed then it does not flag`() {
+        assertFalse(
+            shouldWarnNativeOnlyMetadata(
+                supported = KmpTargetSet.of(jvm, iosArm64),
+                registered = KmpTargetSet.of(jvm, iosArm64),
+            )
+        )
+    }
+
+    @Test
+    fun `given only androidTarget registered when the policy is computed then it does not flag`() {
+        // The AGP-applied seam (AGP cannot be applied in-process): Android is a JVM platform, so a
+        // commonMain spanning it is not JVM-less — any single JVM-family leaf keeps the fragment
+        // JVM-flavored, android-only included.
+        assertFalse(
+            shouldWarnNativeOnlyMetadata(
+                supported = KmpTargetSet.of(android, iosArm64),
+                registered = KmpTargetSet.of(android, iosArm64),
+            )
+        )
+    }
+
+    @Test
+    fun `given no jvm-family leaf in supported when the policy is computed then it does not flag`() {
+        // A pure-native/web module never promised a JVM-flavored commonMain — there is no trap.
+        assertFalse(
+            shouldWarnNativeOnlyMetadata(
+                supported = KmpTargetSet.of(iosArm64, wasmJs),
+                registered = KmpTargetSet.of(iosArm64),
+            )
+        )
+    }
+
+    @Test
+    fun `given jvm family supported and zero registrations when both policies are computed then only inert flags`() {
+        // Disjointness with #71 by construction: registered-empty is the inert state (whole module
+        // dead), registered-non-empty-but-JVM-less is this one (alive with a doomed metadata
+        // compilation). Exactly one fires for any module state.
+        assertFalse(
+            shouldWarnNativeOnlyMetadata(
+                supported = KmpTargetSet.of(jvm),
+                registered = KmpTargetSet.empty,
+            )
+        )
+        assertTrue(shouldWarnInertModule(supportsDeclared = true, registered = KmpTargetSet.empty))
+    }
+
+    @Test
+    fun `given an android-only overlap skipped by the AGP guard when both policies are computed then android-without-AGP and native-only both flag`() {
+        // The intended composition: android-without-AGP diagnoses the cause (the leaf was skipped,
+        // #51), native-only-metadata names the consequence (ios registered, the fragment is
+        // JVM-less). Keying off resolvedSupported() — not the active overlap — is what makes the
+        // skipped leaf still count as "supports JVM, registered none".
+        assertTrue(
+            shouldWarnAndroidWithoutAgp(
+                active = KmpTargetSet.of(android, iosArm64),
+                androidPluginApplied = false,
+            )
+        )
+        assertTrue(
+            shouldWarnNativeOnlyMetadata(
+                supported = KmpTargetSet.of(android, iosArm64),
+                registered = KmpTargetSet.of(iosArm64),
+            )
+        )
+    }
+
+    @Test
+    fun `given only a web leaf registered when the policy is computed then it flags`() {
+        // The predicate is "no JVM-providing leaf", not "natives registered": a web-only commonMain
+        // is equally JVM-less, so the same metadata trap applies.
+        assertTrue(
+            shouldWarnNativeOnlyMetadata(
+                supported = KmpTargetSet.of(jvm, wasmJs),
+                registered = KmpTargetSet.of(wasmJs),
+            )
+        )
+    }
+
+    @Test
+    fun `given a host-impossible native leaf registered when the policy is computed then it still flags`() {
+        // Host-blindness: registration is host-independent and the predicate never consults the
+        // host — iosArm64 registered on a Linux host is still a JVM-less fragment there.
+        assertTrue(
+            shouldWarnNativeOnlyMetadata(
+                supported = KmpTargetSet.of(jvm, iosArm64),
+                registered = KmpTargetSet.of(iosArm64),
+            )
+        )
+    }
+
+    @Test
+    fun `given a module path when the warning is built then it names the JVM family the metadata symptom and the scoped gate`() {
+        val message = nativeOnlyMetadataWarning(":shared")
+        assertContains(message, ":shared")
+        assertContains(message, "JVM family")
+        // The greppable symptom: a user arriving from the raw compiler error must find this.
+        assertContains(message, "@JvmInline")
+        assertContains(message, "*KotlinMetadata*")
+        assertContains(message, "klibs")
+        assertContains(message, "registered(jvmFamily).isEmpty()")
+        // Deliberately set-free: the message is cause-agnostic (a narrowed lane and an AGP skip
+        // fire it alike), so naming the selection or supported sets would mislead in at least one
+        // of those cases.
+        assertFalse("[" in message, message)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
@@ -202,6 +202,31 @@ class KmpTargetsInfoFormatTest {
     }
 
     @Test
+    fun `given a jvm-less module when formatted then the registered section carries the jvm-less line`() {
+        // The advisory's consequence rendered where debugging starts (#72): the registered section
+        // explains why the klibs build but the metadata compilation fails, and names the scoped
+        // build-logic gate.
+        val output =
+            format(
+                selectionIds = listOf("iosArm64"),
+                supportedIds = listOf("iosArm64", "jvm"),
+                registeredIds = listOf("iosArm64"),
+                nativeOnlyMetadata = true,
+            )
+        assertContains(
+            output,
+            "jvm-less: no JVM-family target registered — *KotlinMetadata* compilations reject " +
+                "@JvmInline etc. while the klibs compile; gate on registered(jvmFamily).isEmpty()",
+        )
+    }
+
+    @Test
+    fun `given a module with a registered jvm-family leaf when formatted then no jvm-less line appears`() {
+        val output = format(registeredIds = listOf("jvm"))
+        assertFalse("jvm-less:" in output, output)
+    }
+
+    @Test
     fun `given the vocabulary when formatted then exactly the deprecated leaves carry the marker`() {
         val output = format(deprecatedIds = listOf("macosX64", "tvosX64", "watchosX64"))
         assertContains(output, "macosX64 (deprecated)")
@@ -223,6 +248,7 @@ class KmpTargetsInfoFormatTest {
         jvmRegisteredAs: String? = null,
         androidWithoutAgp: Boolean = false,
         inertModule: Boolean = false,
+        nativeOnlyMetadata: Boolean = false,
     ): String =
         formatKmpTargetsInfo(
             projectPath = ":shared-core",
@@ -239,5 +265,6 @@ class KmpTargetsInfoFormatTest {
             jvmRegisteredAs = jvmRegisteredAs,
             androidWithoutAgp = androidWithoutAgp,
             inertModule = inertModule,
+            nativeOnlyMetadata = nativeOnlyMetadata,
         )
 }


### PR DESCRIPTION
## Problem

A module can be *partially* registered: it supports the JVM family (`androidTarget`, `jvm`) plus native targets, but the active selection drops every JVM-family leaf (an ios-only lane, say). The native leaves register and their platform klibs compile fine — but commonMain becomes a **JVM-less shared fragment**, and the metadata compiler rejects JVM-flavored constructs (`@JvmInline` and friends) **only** in the `*KotlinMetadata*` compilations. The paradoxical "klibs build, why does metadata fail?" cost a ~95-module consumer a hand-rolled, subtle gate (#72). The plugin already exposes the exact query surface (`resolvedSupported()`, `registered(slice)` from #52) but offered no signal that this state is hazardous.

## Chosen direction

**(a) Signal-only advisory** — doctrine-clean ("advisories signal, never filter"), through the single `warnOrFail` escalation point; `kmptargets.strict=true` promotes to a `GradleException` with the identical text. The scoped metadata-disable helper (direction b) is deliberately **not** implemented here — noted on #72 as a possible follow-up. The docs recipe (direction c) lands in the new README section.

## Answers to the issue's open questions

1. **Predicate semantics** — `shouldWarnNativeOnlyMetadata(supported, registered)` =
   `(supported ∩ jvmFamily) ≠ ∅ && registered ≠ ∅ && (registered ∩ jvmFamily) = ∅`
   - **Any single JVM-family leaf registered keeps the fragment JVM-flavored** — android-only-registered is safe (Android is a JVM platform), so it does NOT fire. Tested at the pure seam (AGP cannot be applied in-process).
   - **Web-only registration DOES fire**: the predicate is "no JVM-providing leaf", not "natives registered" — a web-only commonMain is equally JVM-less.
   - **Web-asymmetry (web supported but unregistered) is out of scope** — there is no analogous metadata-compiler trap class for a missing web leaf.
   - The predicate is **leaf-based, not name-based**: a jvm leaf renamed via `targetName(jvm, "desktop")` still defeats it (tested).
   - **Host-free**, like registration itself: a JVM-less fragment is JVM-less on every host.
2. **Disjointness with #71** — the `registered ≠ ∅` conjunct makes inert (registered = ∅) and native-only (registered ≠ ∅) **mutually exclusive by construction**: exactly one of the two consequence signals fires per module state. Tested at both the pure seam and in-process.
3. **AGP-skip composition** — keying off `resolvedSupported()` (not the active overlap) means an `androidTarget` skipped by the #51 guard still counts as "supports JVM, registered none". When something else registered, **both** android-without-AGP (cause) and native-only-metadata (consequence) fire in warn mode; under strict the cause is emitted first and **wins the exception** — the same layering #71 established. Tested in both modes.
4. **Greppable symptom** — the message names `@JvmInline`, the `*KotlinMetadata*` compilations, and "klibs build, metadata fails", so a user arriving from the raw compiler error finds it; it points at the **scoped** gate (`kmpTargets.registered(jvmFamily).isEmpty()`, disable only the metadata compilations). Set-free prose like inert (cause-agnostic).
5. **Ordering** — evaluated **last**, immediately after the inert block: it is a consequence channel, so every cause advisory keeps winning the strict exception. Since inert and native-only are disjoint, their relative order can never matter under strict; inert stays textually first (whole-module-dead before fragment-flavor) and #71's code is untouched.

## Implementation

- `shouldWarnNativeOnlyMetadata` + `nativeOnlyMetadataWarning` pure functions next to the family in `KmpTargetsPlugin.kt`; evaluation block in `register()` after inert; `nativeOnlyMetadataWarned` boolean dedup flag (set AFTER `warnOrFail`, so strict failures leave no bookkeeping).
- `kmpTargetsInfo`: new `nativeOnlyMetadata` input wired from the same decision, rendered as a `jvm-less:` row (mutually exclusive with `inert:`).
- Eager, no `afterEvaluate`; configuration-cache safe (primitives/immutable sets only).

## Docs

- README: new "Native-only metadata (JVM-less commonMain)" section after "Inert modules" — trap explanation (why klibs succeed while metadata fails), verbatim advisory text, the scoped recipe disabling only `*KotlinMetadata*` compilations, disjointness/dedup/host-blind behavior; Status line + Strict-mode enumeration updated to six advisories.
- CHANGELOG entry in the family style.

## Test evidence

TDD red→green: 9 pure-seam tests (`NativeOnlyMetadataAdvisoryTest`), 16 in-process tests (`NativeOnlyMetadataAdvisoryInProcessTest`), 2 formatter tests. Strict tests register `wasmJs` (host-agnostic) so they cannot trip host-impossible's strict exception on Linux CI; warn-mode tests exercise the `iosArm64` headline case host-blind.

`task dod` (fmt + build + test across all modules): **BUILD SUCCESSFUL** on every step.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)