### PR TITLE
docs: full user guide, samples catalog, compatibility, help pages (#70)

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,36 @@
 # Compatibility
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+## Floors
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+The published jar targets the **oldest supported consumer**, not the toolchain the repo builds with:
+
+| Consumer surface | Floor |
+|---|---|
+| `kotlin-dsl` build-logic (Gradle-embedded Kotlin) | Gradle **8.11+** / embedded Kotlin **2.0** |
+| Daemon JVM | **JDK 17** |
+| Kotlin Gradle Plugin at runtime | **KGP 2.2+** (developed and tested against 2.3.21) |
+
+## How the floors are enforced
+
+The repo itself builds with the latest mise-pinned JDK and Kotlin — there are **no Gradle toolchains** (see [why toolchains are rarely a good idea](https://jakewharton.com/gradle-toolchains-are-rarely-a-good-idea/)). Instead the build pins the **emitted output**:
+
+- Kotlin `languageVersion`/`apiVersion` **2.0** — metadata the Gradle 8.x embedded compiler can read
+- `jvmTarget` 17 + `-Xjdk-release=17` / `--release 17` — bytecode JDK 17 daemons can load, with accidental-new-API protection
+- a `kotlin-stdlib` **2.0.21** POM dependency — so floor consumers never pull 2.3-metadata stdlib jars onto their `kotlin-dsl` compile classpath
+
+A `verifyCompatFloors` task inspects the **built jar** (bytecode versions, metadata versions, resolved stdlib) on every `check` — the floors are verified artifacts, not promises, and cannot silently regress.
+
+## Philosophy
+
+- **Track KGP's target model, deliberately.** The leaf vocabulary covers every target KGP 2.3.21 ships (minus the removed `linuxArm32Hfp`); the [deprecated set](user-guide/advisories.md#deprecated-targets) is pinned against Kotlin's [target-support page](https://kotlinlang.org/docs/native-target-support.html) and updated intentionally with Kotlin upgrades — never inferred at runtime.
+- **Honor explicit selection everywhere.** No host-specific filtering, no version-specific surprises: the same selection registers the same set on every machine that meets the floors.
+- **The samples are the compat suite.** A 3-OS CI matrix builds the multi-module sample per host on every change, and an Isolated-Projects sample gates that mode — claims in this table are exercised, not asserted.
+
+## Version pairing
+
+| kmp-targets | Kotlin/KGP | Gradle |
+|---|---|---|
+| 0.1.x | 2.2+ (built against 2.3.21) | 8.11+ (repo runs 9.5.1, configuration cache on) |
+
+!!! note
+    Pre-1.0, minor versions may contain breaking changes — they are called out in the [CHANGELOG](https://github.com/rsicarelli/kmp-targets/blob/main/CHANGELOG.md) (e.g. the `KMP_TARGETS` → `kmptargets.targets` key rename).

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1,6 +1,49 @@
 # FAQ
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+## Selection model
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+**Why is the selection global instead of per-module?**
+Because "what to build now" is a property of the *invocation*, not of any module. Modules declare what they *can* build (`supports { }`); one switch narrows the whole build. A per-module selection would recreate the drift the plugin exists to remove.
+
+**What happens to targets I don't select?**
+They are never registered with KGP. Their compile/link/KSP/publish tasks don't exist — nothing is "disabled" or skipped.
+
+**Does selecting a target a host can't compile drop it?**
+No — registration is host-blind by design. It registers, an [advisory](../user-guide/advisories.md#host-compatibility) names the mismatch, and compile/link tasks for it fail or are skipped on that host. Per-host *selection* (the [CI matrix](../user-guide/ci-matrix.md)) is the intended way to vary by host.
+
+**Why did my selection change trigger a full re-configuration?**
+Expected and bounded: each distinct `kmptargets.targets` value is its own configuration-cache entry. Entries coexist, so switching back to a previous value is a cache hit. See [the trade-off](../why-kmp-targets.md#the-trade-off-stated-plainly).
+
+**Is there a "build nothing" selection?**
+Yes — narrow to an empty set, e.g. `kmptargets.targets=jvm,-jvm`. It's honored deterministically; beware that [strict mode](../user-guide/advisories.md#strict-mode) then fails every module declaring `supports { }` (the inert-module advisory, by design).
+
+## DSL
+
+**A module with `supports { }` never registered anything — why?**
+Run [`kmpTargetsInfo`](../user-guide/kmp-targets-info.md): either the global selection is disjoint from the supported set (empty-overlap), or the only overlap was an `androidTarget` skipped by the [AGP guard](../user-guide/advisories.md#android-target-without-agp).
+
+**Can I call `supports { }` twice?**
+Yes — calls **union**. Registration is one-way: an already-registered target can't be retracted.
+
+**Why does `android` need AGP applied before `supports { }`?**
+`kotlin.androidTarget()` is a hard KGP failure without an Android Gradle plugin. The plugin skips the leaf with an advisory instead of crashing — [the ordering rule](../user-guide/advisories.md#android-target-without-agp) is the fix.
+
+**Can I rename targets?**
+Only the `jvm` leaf, via [`targetName(jvm, "desktop")`](../user-guide/jvm-rename.md) — Android's name is fixed by AGP and native/web names are derived by KGP.
+
+**Why doesn't `kmptargets.targets=ios` work?**
+Bare Apple sub-family names are ambiguous (device leaf? all leaves?) and rejected with a hint. Use a leaf (`iosArm64`) or the `appleMobile` preset.
+
+## Ecosystem
+
+**Does it work with the configuration cache and Isolated Projects?**
+Yes — both are exercised in CI (the repo runs Gradle 9.5 with the configuration cache on; an [Isolated Projects sample](../samples/index.md#isolated-projects-the-compatibility-gate) carries a regression gate).
+
+**Does it replace my convention plugins?**
+No — it's the primitive under them. The plugin ships one extension and zero preset plugin ids; [your conventions](../user-guide/build-logic.md) wrap it in your team's vocabulary.
+
+**Does it touch modules that don't apply it?**
+No. The [`plain-kmp` sample](../samples/index.md) exists to prove non-interference.
+
+**Where are the binaries?**
+Maven Central (`com.rsicarelli:kmp-targets-gradle-plugin`), snapshots on the Central Portal snapshots repo — see [Installation](../get-started/index.md). There is no Gradle Plugin Portal listing.

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -1,6 +1,44 @@
 # Troubleshooting
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+First move for anything selection-shaped: **[`kmpTargetsInfo`](../user-guide/kmp-targets-info.md)** — it prints what resolved, which source won, and what registered, per module, at cache-hit speed.
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+## Resolution & installation
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Could not find com.rsicarelli:kmp-targets-gradle-plugin:<v>` | repository list doesn't cover the version's home | releases live on `mavenCentral()`, `-SNAPSHOT`s only on `https://central.sonatype.com/repository/maven-snapshots/` — add the right repo to `pluginManagement` ([Installation](../get-started/index.md)) |
+| Snapshot doesn't update | Gradle caches changing modules for 24h | `./gradlew build --refresh-dependencies` |
+| `Plugin [id: 'com.rsicarelli.kmptargets'] was not found` | `mavenCentral()` missing from `pluginManagement.repositories` (it's not on the Plugin Portal) | add it ([Installation](../get-started/index.md)) |
+
+## Selection
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Build fails at configuration: `Unknown target token '...' — did you mean ...?` | typo in `kmptargets.targets`; the parser is strict so CI can't silently drop a target | accept the suggestion; vocabulary is in [`kmpTargetsInfo`](../user-guide/kmp-targets-info.md) or the [reference](../user-guide/targets-reference.md) |
+| Build fails: unknown key in `kmp-targets.properties` | the config files accept only known `kmptargets.*` keys | fix the key (the error suggests the nearest match) |
+| Selection ignored / surprising value wins | a higher-precedence source is set — often a stale `kmp-targets.local.properties` or an env var | `kmpTargetsInfo` names the winning source; check the [precedence chain](../user-guide/selection-layers.md) |
+| Setting `KMP_TARGETS` does nothing | pre-1.0 breaking rename — the old key is not read at all | use `kmptargets.targets` |
+| A module builds nothing | empty overlap: selection ∩ supported = ∅ | widen the selection or the module's `supports { }`; the [empty-overlap advisory](../user-guide/advisories.md#empty-overlap) names the module |
+| Every sync re-configures after changing selection | each distinct value is its own configuration-cache entry — **only the first** build of a value misses | expected; alternating between known values hits the cache ([the trade-off](../why-kmp-targets.md#the-trade-off-stated-plainly)) |
+
+## Registration
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `androidTarget` missing despite being selected + supported | no Android Gradle plugin applied when `supports { }` ran | apply `com.android.library`/`com.android.application` **before** `supports { }` ([the ordering rule](../user-guide/advisories.md#android-target-without-agp)) |
+| `compileCommonMainKotlinMetadata` fails on a module that registered zero targets | the [inert-module trap](../user-guide/advisories.md#inert-modules): KGP materializes the metadata compilation even with no platform targets | gate compilations on `kmpTargets.registered().isEmpty()` ([recipe](../user-guide/recipes.md#gate-compilation-on-inert-modules)) |
+| Convention plugin misses targets when iterating `kotlin.targets` | eager snapshot raced `supports { }` | use [`onRegistered`](../user-guide/build-logic.md#onregistered-the-ordering-immune-hook) — it replays and fires deltas |
+| `targetName` throws | called after `supports { }`, on a non-jvm leaf, or with a blank name | rename [must precede registration and only applies to `jvm`](../user-guide/jvm-rename.md) |
+
+## Building
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Variant-resolution wall of text on an inter-module dependency | dependency's supported set doesn't cover a target the dependent builds | check both modules with `kmpTargetsInfo`; widen the dependency's `supports { }` ([recipe](../user-guide/recipes.md#selection-vs-the-dependency-graph)) |
+| Unresolved `expect` after narrowing to one iOS leaf | minimal template collapsed the single-child `iosMain` your sources live in | [no-collapse mode](../user-guide/no-collapse-mode.md) |
+| iOS compile/link fails on a Linux/Windows runner | host can't compile the registered Apple target — registration is host-blind | per-host selections ([CI matrix](../user-guide/ci-matrix.md)); the [host advisory](../user-guide/advisories.md#host-compatibility) names the mismatch |
+| CI job fails at configuration with an advisory's text | [strict mode](../user-guide/advisories.md#strict-mode) promotes advisories to failures | that's the point — fix the flagged configuration, or scope strict to lanes the host can fully compile |
+| `apiCheck`/BCV dumps disappear for some targets | BCV ran in a narrowed lane and saw only registered targets | run BCV tasks from a full-selection lane only ([recipe](../user-guide/recipes.md#binary-compatibility-validator-selection)) |
+| KSP-generated symbols missing from commonMain | no native target registered in this selection, so the processing compilation never ran | gate + warn via `registered(KmpTargetSet.native)` ([recipe](../user-guide/recipes.md#commonmain-ksp-needs-a-native-target)) |
+
+Still stuck? [Open an issue](https://github.com/rsicarelli/kmp-targets/issues) with the `kmpTargetsInfo` output for the affected module — it carries exactly the state needed to diagnose.

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -1,6 +1,36 @@
 # Samples
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+Two standalone sample builds live in the repo, consuming the plugin exactly as an external project would. Both share the root version catalog and resolve the plugin by version (mavenLocal in the dev loop, Maven Central for consumers).
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+## hello-world — the multi-module showcase
+
+[`samples/hello-world`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world) is a heterogeneous multi-module project — each module demonstrates one shape:
+
+| Module | Declares | Demonstrates |
+|---|---|---|
+| [`shared-core`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world/shared-core) | `supports { all }` | the opt-in "build whatever is selected" module |
+| [`feature-mobile`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world/feature-mobile) | `supports { mobile }` | a mobile-only feature; selections outside `mobile` leave it empty (no AGP in the sample, so iOS leaves are its registrable shape) |
+| [`jvm-tools`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world/jvm-tools) | `supports { jvm }` | a JVM-only tooling module |
+| [`core-and-apple`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world/core-and-apple) | `supports { apple + jvm }` | preset + leaf composition |
+| [`escape-hatch-dsl`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world/escape-hatch-dsl) | `supports { jvm + linuxX64 }` | mixing the DSL with raw `kotlin { }` target configuration |
+| [`desktop-named`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world/desktop-named) | `targetName(jvm, "desktop")` + `supports { jvm + iosArm64 }` | the [JVM rename](../user-guide/jvm-rename.md): `src/desktopMain`, `compileKotlinDesktop` |
+| [`pinned-intermediates`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world/pinned-intermediates) | `supports { appleMobile }`, collapse off | [no-collapse mode](../user-guide/no-collapse-mode.md): `iosMain` survives a single-leaf selection |
+| [`eager-conventions`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world/eager-conventions) | applies `kmptargets.module` | the [convention-plugin pattern](../user-guide/build-logic.md) with an `onRegistered` regression gate (`verifyEagerTargets`) |
+| [`legacy-default`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world/legacy-default) | `supports { all }`, template off | opting out of the [minimal hierarchy](../user-guide/hierarchy-template.md) — KGP's default tree, side by side |
+| [`plain-kmp`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world/plain-kmp) | *no kmp-targets* | the non-interference proof: a module without the plugin is untouched |
+| [`build-logic`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/hello-world/build-logic) | — | the sample's own convention build: `kmptargets.module` plugin, [`KmpModule.kt`](https://github.com/rsicarelli/kmp-targets/blob/main/samples/hello-world/build-logic/src/main/kotlin/KmpModule.kt) is the canonical `onRegistered` consumer |
+
+Drive it like CI does:
+
+```bash
+./gradlew -p samples/hello-world build "-Pkmptargets.targets=jvm,iosArm64"
+./gradlew -p samples/hello-world :shared-core:kmpTargetsInfo -q
+```
+
+## isolated-projects — the compatibility gate
+
+[`samples/isolated-projects`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/isolated-projects) is a two-module build ([`lib`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/isolated-projects/lib) supports `all`, [`app`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/isolated-projects/app) supports `jvm` and depends on `lib`) running with **Gradle Isolated Projects enabled**. `lib` carries a `verifyIsolatedConfiguration` regression gate, so the plugin's Isolated Projects compatibility is exercised, not claimed.
+
+## CI runs them for real
+
+[`ci.yml`](https://github.com/rsicarelli/kmp-targets/blob/main/.github/workflows/ci.yml) builds both samples on every push; [`sample-matrix.yml`](https://github.com/rsicarelli/kmp-targets/blob/main/.github/workflows/sample-matrix.yml) builds hello-world per host with host-appropriate selections — the [CI matrix](../user-guide/ci-matrix.md) pattern, exercised.

--- a/docs/user-guide/advisories.md
+++ b/docs/user-guide/advisories.md
@@ -1,6 +1,83 @@
 # Advisories & Strict Mode
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+The plugin emits five configuration-time advisories. Four are **signal only — never filtering**; one (android-without-AGP) genuinely skips a leaf because the alternative is a raw KGP crash. [Strict mode](#strict-mode) promotes all five to build failures with identical message text.
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+## Host compatibility
+
+The registered set is **host-blind by design**: selecting `iosArm64` registers it on macOS, Linux, and Windows alike, so configuration-cache keys, task graphs, and published metadata stay identical across CI agents. But not every host can *compile* every native target. When the selection includes a native target the current host can't compile, the plugin warns — and **still registers it**:
+
+```
+kmp-targets: ':shared' selects [iosArm64] which cannot be compiled on this host (LINUX_X64) —
+still registered (selection is host-independent), but compile/link tasks for them will fail or
+be skipped here.
+```
+
+The host → target matrix comes from KGP's own encoding of [Kotlin's native target support](https://kotlinlang.org/docs/native-target-support.html), so it tracks your Kotlin version automatically. JVM and Web targets are host-agnostic and never warned. Fires at most once per target per module.
+
+## Deprecated targets
+
+Kotlin marks `macosX64`, `watchosX64`, and `tvosX64` deprecated (since Kotlin 2.3.20), but KGP emits no configuration-time signal when they register. This plugin does:
+
+```
+kmp-targets: ':shared' registers [macosX64] which Kotlin marks deprecated (since Kotlin 2.3.20,
+see https://kotlinlang.org/docs/native-target-support.html) — still registered (selection is
+unchanged), but consider migrating off them.
+```
+
+Signal only: deprecated leaves stay selectable, stay in every preset, and register exactly as selected. [`kmpTargetsInfo`](kmp-targets-info.md) marks the same leaves `(deprecated)` in its vocabulary listing. (`iosX64` is low-tier but *not* deprecated.)
+
+## Android target without AGP
+
+`androidTarget` is the one leaf whose registration needs more than KGP: `kotlin.androidTarget()` is a **hard KGP failure** (the FATAL `AndroidGradlePluginIsMissing` diagnostic) unless an Android Gradle plugin — `com.android.library`, `com.android.application`, or any other id KGP accepts — is already applied. So when a module both selects and supports `androidTarget` but no Android plugin is applied by the time `supports { }` runs, the plugin **skips registering that leaf** and says so:
+
+```
+kmp-targets: ':feature' selects and supports [androidTarget] but no Android Gradle plugin is
+applied — the target was not registered. Apply com.android.library or com.android.application
+before supports { }.
+```
+
+This is the one advisory that **does filter** — the alternative is KGP's raw crash with no module-level guidance, which during build-logic migrations reads as "kmp-targets dropped my target". The fix is an **ordering rule**: apply the Android plugin *before* `supports { }`. A later `supports { }` union re-checks, so AGP applied between two calls lets the later pass register the leaf normally. Everything else registers exactly as selected.
+
+## Empty overlap
+
+A non-empty selection that matches nothing a module `supports` (so the module registers zero targets) gets its own warning — the everyday symptom of a typo'd lane or an over-narrow selection.
+
+## Inert modules
+
+A module that declared `supports { … }` can still register **zero** targets — disjoint selection, explicitly empty selection (`kmptargets.targets=jvm,-jvm`), or the only overlap being an AGP-skipped `androidTarget`. The trap: KGP still materializes the **commonMain metadata compilation** for every module applying `kotlin("multiplatform")`, and with no platform targets that compilation **fails** — any aggregate invocation (`build`, `check`, `publishToMavenLocal`) then trips over every inert module with an opaque compiler error. So the plugin names the consequence and the gate:
+
+```
+kmp-targets: ':shared' declared supports { } but registered zero targets — the module is inert.
+KGP still materializes the commonMain metadata compilation, which fails with no platform targets.
+Gate it in build-logic when kmpTargets.registered().isEmpty().
+```
+
+The recommended gate lives in your build-logic, right after `supports { }`:
+
+```kotlin
+if (kmpTargets.registered().isEmpty()) {
+    tasks.withType(KotlinCompilationTask::class.java).configureEach { enabled = false }
+}
+```
+
+A module that **never calls** `supports { }` registers nothing *by definition* and is deliberately not flagged — that's the explicit-selection baseline, not the trap. A later `supports { }` union that registers a leaf un-inerts the module permanently.
+
+## Strict mode
+
+By default all five advisories are warnings — right for local iteration, easy to miss in CI, where a module silently building nothing is usually a real configuration bug.
+
+`kmptargets.strict=true` promotes them to configuration-time **build failures** (`GradleException`) with the **identical message text** — severity changes, policy does not. It never changes *which* configurations are flagged and never changes *what registers* (the AGP skip happens with or without strict). Default **off**, deliberately. The flag resolves through the same [precedence chain](selection-layers.md) as every `kmptargets.*` key; anything other than `true`/`false` (case-insensitive) is treated as unset.
+
+The recommended setup keeps local builds advisory and turns CI strict:
+
+```yaml
+# CI only — e.g. a GitHub Actions env block
+env:
+  ORG_GRADLE_PROJECT_kmptargets.strict: "true"   # or: ./gradlew build -Pkmptargets.strict=true
+```
+
+!!! warning "Cross-host CI"
+    With strict on, a selection including targets the agent cannot compile (e.g. iOS leaves on a Linux runner) fails the build by design. Strict CI pairs with per-host selections — see [CI Matrix](ci-matrix.md).
+
+!!! warning "Explicitly-empty selections"
+    With strict on, a selection narrowed to nothing (`kmptargets.targets=jvm,-jvm`) makes the inert-module advisory fail **every** module that declares `supports { }`, by design — each carries a doomed metadata compilation. A build-nothing lane that wants to configure successfully should not pair the empty selection with strict.

--- a/docs/user-guide/build-logic.md
+++ b/docs/user-guide/build-logic.md
@@ -1,6 +1,89 @@
 # Build-Logic Conventions
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+The plugin ships just one extension (`KmpTargetsExtension`) and one set of public types (`KmpTargetSet`, `KmpTarget`) — there are **no bundled "preset" plugin ids**. Teams that want `apply by id, no body` ergonomics build their own conventions in `build-logic/`:
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+```kotlin
+// build-logic/src/main/kotlin/my.mobile-module.gradle.kts
+import com.rsicarelli.kmptargets.KmpTargetsExtension
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+
+plugins {
+    kotlin("multiplatform")
+    id("com.rsicarelli.kmptargets")
+}
+
+extensions.configure<KmpTargetsExtension> {
+    supports(KmpTargetSet.mobile)
+}
+```
+
+```kotlin
+// feature-mobile/build.gradle.kts
+plugins { id("my.mobile-module") }
+```
+
+This is how a team centralizes per-module shape vocabulary in their own naming, instead of taking a vocabulary baked into this plugin's artifact. The DSL stays the primitive; convention plugins are an optional layer you own.
+
+The build-logic build depends on the artifact directly:
+
+```kotlin
+// build-logic/build.gradle.kts
+dependencies {
+    implementation("com.rsicarelli:kmp-targets-gradle-plugin:0.1.0-SNAPSHOT")
+}
+```
+
+## Querying what registered
+
+Conventions routinely need to wire *per-target* things after registration — the canonical case is KSP, where each target gets its own configuration (`kspIosArm64`, `kspIosSimulatorArm64`, …). Without help, every convention re-derives family matching and name mangling from KGP internals:
+
+```kotlin
+// Before — KGP konan types plus hand-rolled name mangling:
+kotlin.targets.withType<KotlinNativeTarget>()
+    .matching { it.konanTarget.family == Family.IOS }
+    .forEach { add("ksp${it.targetName.replaceFirstChar(Char::titlecase)}", dep) }
+```
+
+The extension exposes the **registered** set directly, so build-logic never touches `konanTarget`:
+
+```kotlin
+// After — per-leaf hook with the actual Gradle name, pre-mangled:
+kmpTargets.onRegistered { add("ksp${it.gradleNameCapitalized}", dep) }
+
+// Snapshots, family-sliced with plain set algebra:
+kmpTargets.registered()                          // everything registered so far, as KmpTargetSet
+kmpTargets.registered(KmpTargetSet.appleMobile)  // just the registered iOS leaves
+```
+
+## `onRegistered` — the ordering-immune hook
+
+`onRegistered` has `configureEach` semantics:
+
+- Hooked **before** the module's `supports { }`, it fires as each leaf registers.
+- Hooked **after**, it replays for the leaves already registered.
+- A later `supports { }` union fires only its delta.
+
+That makes it the right choice for convention plugins, which can't control where the consuming module places its blocks. The `registered()` snapshot is the simple read for build-script code that runs after `supports { }` — but remember it's a point-in-time value; a later `supports { }` call can union in more leaves.
+
+## `RegisteredTarget`
+
+Each `onRegistered` callback receives a `RegisteredTarget`: the model leaf plus the Gradle target name registration **actually used**. A jvm leaf renamed via [`targetName(jvm, "desktop")`](jvm-rename.md) reports `gradleName == "desktop"`, so configuration wiring keeps working without the convention knowing about the rename.
+
+`registered()` deliberately mirrors **real registrations**, not the abstract `selection ∩ supported` plan:
+
+- without KGP applied it is empty (and `onRegistered` never fires)
+- an `androidTarget` skipped by the [AGP guard](advisories.md#android-target-without-agp) stays absent
+
+…so KSP wiring can never target a configuration that doesn't exist.
+
+!!! warning "Configuration-time tool"
+    Like `supports`, the callback (and the extension itself) is a configuration-time API — never hold either from a task action; that breaks the configuration cache.
+
+## The canonical sample
+
+The [`eager-conventions` sample](../samples/index.md) applies a `kmptargets.module` convention plugin from the sample's own `build-logic/`, using `onRegistered` as the canonical pattern — plus a regression gate (`verifyEagerTargets`) asserting exactly the expected leaves register.
+
+## Related
+
+- [Recipes](recipes.md) — concrete convention patterns: KSP gates, inert-module gating, AGP ordering
+- [Advisories](advisories.md#inert-modules) — the inert-module trap and its `registered().isEmpty()` gate

--- a/docs/user-guide/ci-matrix.md
+++ b/docs/user-guide/ci-matrix.md
@@ -1,6 +1,59 @@
 # CI Matrix
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+## The cost asymmetry
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+KMP CI has a sharp cost asymmetry: on **private repositories**, GitHub Actions macOS runners bill at roughly **10×** the Ubuntu per-minute rate — and Apple/native compilation, the part that *requires* macOS, is the dominant slice of total CI time. The cost-aware pattern is an **OS × selection matrix**: each runner compiles only the subset of targets it can host.
+
+`kmp-targets` is purpose-built for this. The matrix passes a host-appropriate selection per job — and the values are **literally the same strings** a developer puts in `kmp-targets.local.properties` or `-Pkmptargets.targets` locally. CI never grows its own divergent selection language.
+
+```yaml
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            targets: jvm,android,web,linuxX64,linuxArm64,androidNative
+          - os: macos-latest
+            targets: apple
+          - os: windows-latest
+            targets: windows
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '23'
+      - uses: gradle/actions/setup-gradle@v6
+      # Quoted on purpose: PowerShell (windows-latest) splits unquoted commas into an array.
+      - run: ./gradlew build "-Pkmptargets.targets=${{ matrix.targets }}"
+```
+
+## Host → target mapping
+
+| Runner | `kmptargets.targets` | Rationale |
+|---|---|---|
+| `ubuntu-latest` | `jvm,android,js,wasmJs,wasmWasi,linuxX64,linuxArm64,androidNative` | the cheap runner — every non-Apple, non-MinGW target cross-compiles here (`android` requires AGP in your build; `web` is the `js,wasmJs,wasmWasi` preset) |
+| `macos-latest` | `apple` (or `appleMobile` on PRs) | the only host that can compile/link Apple targets; keep the expensive runner's set minimal |
+| `windows-latest` | `mingwX64` (alias `windows`) | the only host for MinGW |
+
+## Notes
+
+- **Same vocabulary, no drift.** Matrix values are plain [selection grammar](selection-layers.md#selection-grammar) strings — presets, leaves, and `-` exclusions all work. What CI builds is what [`kmpTargetsInfo`](kmp-targets-info.md) prints locally for the same value.
+- **Env form.** `ORG_GRADLE_PROJECT_kmptargets.targets` as a job `env:` is equivalent (dotted env keys work on GitHub Actions); `-P` is the canonical recommendation. Both sit above the committed `kmp-targets.properties` in [precedence](selection-layers.md), so a per-job value always wins over the repo default.
+- **Cost tier (optional).** Restrict the macOS job to `appleMobile` on `pull_request` and run the full `apple` preset only on `push` to `main` — the matrix `targets` value is the only thing that changes.
+- **Strict mode pairs well.** Set [`kmptargets.strict=true`](advisories.md#strict-mode) on jobs whose selection the host can fully compile — a misconfigured module then fails the job instead of silently building nothing.
+- **Configuration cache.** Each distinct selection is a distinct configuration-cache key; matrix jobs with different selections won't share an entry. Expected, not a regression — the same bounded cost described in [Why kmp-targets?](../why-kmp-targets.md#the-trade-off-stated-plainly).
+
+## The living example
+
+This repo runs the pattern for real: [`sample-matrix.yml`](https://github.com/rsicarelli/kmp-targets/blob/main/.github/workflows/sample-matrix.yml) builds the hello-world sample per host — the macOS job is the only place Apple targets get genuinely compiled — so the example above can't rot.

--- a/docs/user-guide/hierarchy-template.md
+++ b/docs/user-guide/hierarchy-template.md
@@ -1,6 +1,46 @@
 # Hierarchy Template
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+## The problem with KGP's default
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+KGP's auto-applied `applyDefaultHierarchyTemplate()` builds the *full* source-set hierarchy for whatever registers, so an iOS-only module still gets `nativeMain` **and** `appleMain` intermediates that are redundant with `iosMain`. Each redundant intermediate spawns ~8 wasteful Gradle tasks; across dozens of modules this dominates sync time ([the hidden cost of default hierarchy templates](https://dev.to/rsicarelli/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform-256a)).
+
+## The minimal template
+
+Because `kmp-targets` already knows each module's active target set, it applies a **minimal** custom hierarchy instead — collapsing every redundant single-child group:
+
+| Active targets | Intermediate source sets |
+|---|---|
+| one iOS leaf | none (target attaches to `commonMain`) |
+| iOS (≥2 leaves) | `iosMain` only — no `appleMain`, no `nativeMain` |
+| iOS + macOS | `appleMain` over `iosMain` + `macosMain` — no `nativeMain` |
+| iOS + Linux | `nativeMain` over `iosMain` + `linuxMain` — no `appleMain` |
+
+The collapse rule: a group materializes a source set only when it merges **≥2 present children**; a single-child group collapses away. If that rule breaks your codebase's load-bearing `src/iosMain` dirs, see [No-Collapse Mode](no-collapse-mode.md).
+
+It's **on by default** and applied automatically — no configuration needed.
+
+## Opting out
+
+Opt out when a module supplies its own `applyHierarchyTemplate { … }`, so the plugin stays out of the way (KGP's default applies again):
+
+```properties
+# kmp-targets.properties — global default (also accepted via -P, env, gradle.properties,
+# local.properties — same precedence chain as kmptargets.targets)
+kmptargets.hierarchyTemplate=false
+```
+
+```kotlin
+// any module's build.gradle.kts — per-project override
+kmpTargets { hierarchyTemplate.set(false) }
+```
+
+Precedence: **project DSL > global key > built-in default (`true`)**.
+
+## Renamed targets
+
+KGP's hierarchy matchers (`withJvm()`) key off the *platform type*, not the target name — so a [renamed jvm target](jvm-rename.md) (`targetName(jvm, "desktop")`) attaches to the minimal template exactly as a plain `jvm` would.
+
+## Related
+
+- [No-Collapse Mode](no-collapse-mode.md) — keep single-child intermediates alive
+- [Why kmp-targets?](../why-kmp-targets.md) — where the hierarchy tax fits in the bigger picture

--- a/docs/user-guide/jvm-rename.md
+++ b/docs/user-guide/jvm-rename.md
@@ -1,6 +1,23 @@
 # Renaming the JVM Target
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+Codebases that grew up before the default-hierarchy era often register their JVM target under a custom name — most commonly `kotlin.jvm("desktop")` — and carry years of accumulated `src/desktopMain` source dirs, `-desktop` published artifact suffixes, and CI task names (`compileKotlinDesktop`) keyed off it. For them, adopting kmp-targets must not be a breaking rename.
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+`targetName` lets the jvm leaf register under that custom Gradle name:
+
+```kotlin
+kmpTargets {
+    targetName(jvm, "desktop") // must come BEFORE supports { } — registration is eager and one-way
+    supports { mobile + jvm }
+}
+```
+
+## Semantics
+
+- **Selection token unchanged.** Builds still select it with `jvm` (or its `desktop` alias) — `kmptargets.targets=jvm,iosArm64` registers the renamed target. Only the registered Gradle target, its source sets (`desktopMain`), and the published artifact suffix follow the custom name.
+- **jvm leaf only.** `androidTarget`'s name is fixed by AGP, and native/web names are derived by KGP — renaming them would break konan/source-set conventions. `targetName` fails loud on any other leaf (or a preset), on a blank name, and when called after `supports { }` already registered the jvm leaf (a late rename could never apply).
+- **Hierarchy unaffected.** KGP's hierarchy matchers (`withJvm()`) key off the platform type, not the target name, so the [minimal template](hierarchy-template.md) attaches a renamed target exactly as it would a plain `jvm`.
+- **Introspection.** [`kmpTargetsInfo`](kmp-targets-info.md) surfaces the rename on the registered line: `jvm (registered as: desktop)`. Build-logic sees it through [`RegisteredTarget.gradleName`](build-logic.md#registeredtarget), so [`onRegistered`-driven wiring](build-logic.md) keeps working without knowing about the rename.
+
+## See it running
+
+The [`desktop-named` sample](../samples/index.md) supports `jvm + iosArm64` with the jvm leaf renamed to `desktop` — `src/desktopMain` and `compileKotlinDesktop` work as in a legacy codebase.

--- a/docs/user-guide/kmp-targets-info.md
+++ b/docs/user-guide/kmp-targets-info.md
@@ -1,6 +1,57 @@
 # Inspecting with kmpTargetsInfo
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+Every project the plugin is applied to gets a `kmpTargetsInfo` task (group `help`) that answers *"what did the plugin decide for this module, and why?"*
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+```bash
+./gradlew :shared-core:kmpTargetsInfo -q
+```
+
+```console
+kmp-targets — :shared-core
+
+Selection (what to build now)
+  targets:  iosArm64, iosSimulatorArm64, jvm
+  source:   kmp-targets.properties
+
+Supported (what this module can build)
+  declared: yes
+  targets:  androidNativeArm32, ..., watchosX64
+
+Registered (selection ∩ supported)
+  targets:  iosArm64, iosSimulatorArm64, jvm
+
+Vocabulary
+  presets:  all, native, appleMobile, appleDesktop, appleWatch, appleTv, apple, linux, mingw, windows, androidNative, web, jvmFamily, mobile
+  leaves:   androidNativeArm32, ..., macosX64 (deprecated), ..., watchosX64 (deprecated) (25)
+```
+
+## Reading the report
+
+**`Selection`** — the resolved global selection and, crucially, its **source**: the winning layer of the [precedence chain](selection-layers.md) by name — `command line (-Pkmptargets.targets)`, `kmp-targets.local.properties`, `local.properties`, or the `defaultSelection` / built-in fallbacks. One coarseness, stated in the label itself: values from `-Dorg.gradle.project.kmptargets.targets` and `~/.gradle/gradle.properties` are indistinguishable from root `gradle.properties`, so all three report as the fused `gradle.properties (...)` layer.
+
+**`Supported`** — whether the module declared [`supports { }`](selection-dsl.md) and what it expanded to.
+
+**`Registered`** — the intersection that actually registered. Every empty case gets its own explanation: a module that never declared `supports { … }`, a selection narrowed to nothing, or a genuinely disjoint `selection ∩ supported`.
+
+**`Vocabulary`** — the parser's full preset and leaf list, i.e. a copy-paste surface for valid tokens.
+
+## Per-leaf annotations
+
+The lists carry markers the plain names can't:
+
+| Annotation | Meaning |
+|---|---|
+| `iosArm64 (not compilable on this host: LINUX_X64)` | registered, but this host can't compile it — same decision source as the [host advisory](advisories.md#host-compatibility) |
+| `macosX64 (deprecated)` | Kotlin [marks the leaf deprecated](https://kotlinlang.org/docs/native-target-support.html) — same set as the [deprecated advisory](advisories.md#deprecated-targets) |
+| `androidTarget (skipped: no Android plugin applied)` | the [AGP guard](advisories.md#android-target-without-agp) skipped it |
+| `jvm (registered as: desktop)` | the leaf registered under a [custom name](jvm-rename.md) |
+| `inert:` line | the module registered zero targets — the [inert-module](advisories.md#inert-modules) condition |
+
+## Properties of the task
+
+- **Read-only** — it never registers targets; running it cannot change the build.
+- **Configuration-cache compatible** — the second run is a cache hit.
+- **Per-module** — run it on the module you're diagnosing (`:feature-mobile:kmpTargetsInfo`), not just the root.
+
+!!! tip
+    `kmpTargetsInfo` is the first move whenever a selection surprises you — it answers both "what won?" and "why is this module empty?" in one cached run.

--- a/docs/user-guide/no-collapse-mode.md
+++ b/docs/user-guide/no-collapse-mode.md
@@ -1,6 +1,40 @@
 # No-Collapse Mode
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+## The use case: load-bearing intermediates
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+The [minimal template's](hierarchy-template.md) collapse rule — a group materializes only when it merges **≥2 present children** — is right for new code. But established codebases have **load-bearing intermediate source dirs**: dozens of modules with `src/iosMain` holding `actual` implementations.
+
+For them, narrowing the selection to a single iOS leaf (`-Pkmptargets.targets=iosArm64`, the everyday "build for device only" move) silently drops `iosMain` from the model, and the build breaks with unresolved `expect` declarations.
+
+## The opt-out
+
+No-collapse mode materializes a group whenever it has **≥1 present child**, so `iosMain` survives a single-iOS-leaf selection:
+
+```properties
+# kmp-targets.properties — global default (same precedence chain as the other keys)
+kmptargets.hierarchyCollapse=false
+```
+
+```kotlin
+// any module's build.gradle.kts — per-project override; set BEFORE supports { }
+kmpTargets {
+    collapseHierarchy.set(false)
+    supports { appleMobile }
+}
+```
+
+Precedence mirrors `hierarchyTemplate`: **project DSL > global key > built-in default (`true`, collapse — the minimal tree)**.
+
+## Semantics, precisely
+
+- Single-child chains materialize fully (`nativeMain → appleMain → iosMain` for one iOS leaf). The inert empty intermediates are harmless — no code, no `expect`/`actual` to resolve.
+- Empty groups are still dropped, and ungrouped leaves (jvm/android/web) still never form groups.
+- The knob **never changes what registers** — only which intermediate source sets materialize.
+- It is a documented no-op when [`hierarchyTemplate`](hierarchy-template.md) resolves to `false` — KGP's default template owns the tree then.
+
+!!! note "Possible future extension"
+    Force-materializing *named* groups only (e.g. just `ios`, avoiding the inert parents) is a recognized refinement, currently out of scope.
+
+## See it running
+
+The [`pinned-intermediates` sample](../samples/index.md) is an `appleMobile` module with collapse off — narrow it to one leaf and `iosMain` stays in the model.

--- a/docs/user-guide/recipes.md
+++ b/docs/user-guide/recipes.md
@@ -1,6 +1,74 @@
 # Recipes
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+Build-logic patterns collected from real multi-module adoptions. Each is a few lines in a convention plugin; all of them key off [`registered()` / `onRegistered`](build-logic.md) rather than KGP internals.
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+## Gate compilation on inert modules
+
+A narrowed lane can leave a module with zero registered targets — and KGP's commonMain metadata compilation [fails on a platform-less module](advisories.md#inert-modules). Gate it right after `supports { }`:
+
+```kotlin
+if (kmpTargets.registered().isEmpty()) {
+    tasks.withType(KotlinCompilationTask::class.java).configureEach { enabled = false }
+}
+```
+
+This is the gate the inert-module advisory names. Variant: a metadata-only predicate for modules whose *native* fragment is the risky part — gate on `kmpTargets.registered(KmpTargetSet.native).isEmpty()` instead.
+
+## commonMain KSP needs a native target
+
+KSP processing of `commonMain` runs on a platform compilation. If your processor is wired to a native target, a selection without any native leaf silently skips generation — downstream code then fails with missing symbols. Gate and warn explicitly:
+
+```kotlin
+if (kmpTargets.registered(KmpTargetSet.native).isEmpty()) {
+    logger.warn(
+        "ksp: ':${project.name}' has no native target registered — " +
+        "commonMain symbol processing is skipped for this selection."
+    )
+}
+```
+
+## Per-target configuration wiring
+
+The canonical `onRegistered` use: per-target configurations (KSP, custom attributes), with the Gradle name pre-mangled — and rename-proof, because `gradleNameCapitalized` follows [`targetName`](jvm-rename.md):
+
+```kotlin
+kmpTargets.onRegistered { add("ksp${it.gradleNameCapitalized}", processorDep) }
+```
+
+!!! warning "Never snapshot `kotlin.targets` eagerly"
+    `kotlin.targets.forEach { … }` in a convention plugin sees only what registered *before that line ran* — ordering-sensitive and silently incomplete. `onRegistered` replays past registrations and fires for future ones.
+
+## Selection-gated eager AGP application
+
+`androidTarget` needs AGP applied **before** `supports { }` ([the ordering rule](advisories.md#android-target-without-agp)). A convention can apply AGP only when Android is actually selected, avoiding AGP's configuration cost in non-Android lanes:
+
+```kotlin
+// in the convention plugin, before configuring kmpTargets
+val selectsAndroid = /* read kmptargets.targets via providers and check for android/jvmFamily/mobile */
+if (selectsAndroid) {
+    pluginManager.apply("com.android.library")
+}
+// note: com.android.application modules apply AGP unconditionally — the app module IS Android
+```
+
+## Lane-agnostic CI invocations
+
+Aggregate tasks (`build`, `check`) only cover registered targets, so the **same Gradle invocation works in every lane** — the selection does the narrowing, not the task list:
+
+```bash
+./gradlew check "-Pkmptargets.targets=$LANE_TARGETS"
+```
+
+Avoid hardcoding per-target task names (`:m:iosArm64Test`) in CI scripts: they break under renames and lane changes. If you must derive test tasks, derive them from `registered()` in a small task-listing helper, not from string conventions.
+
+## Selection vs the dependency graph
+
+Selection is **per-module**, intersected per-module. If `:app` supports `jvm + iosArm64` and depends on `:lib` that only supports `jvm`, an `iosArm64` build of `:app` fails at *variant resolution* — `:lib` has no iOS variant to offer. The error is KGP's wall of text, but the cause is set arithmetic: **a module's supported set must cover every target its dependents build**. Check both sides with `kmpTargetsInfo` and widen `:lib`'s `supports { }` (or narrow `:app`'s).
+
+## Binary-compatibility validator + selection
+
+BCV writes one ABI dump per target. A narrowed lane that runs `apiCheck`/`apiDump` sees only the registered subset — committing dumps from a narrowed lane deletes the other targets' dumps. Rule: **run BCV tasks only from a full-selection lane** (`kmptargets.targets=all` or your repo's full set), and gate `apiDump` in CI to that lane.
+
+## Troubleshooting first
+
+Symptom → cause → fix pairs for all of the above live in [Troubleshooting](../help/troubleshooting.md).

--- a/docs/user-guide/selection-dsl.md
+++ b/docs/user-guide/selection-dsl.md
@@ -1,6 +1,53 @@
 # Selection DSL
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+## `supports { }` — the module's supported set
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+```kotlin
+plugins {
+    kotlin("multiplatform")
+    id("com.rsicarelli.kmptargets") version "0.1.0-SNAPSHOT"
+}
+
+kmpTargets {
+    supports { mobile + web - iosX64 }   // presets and leaves compose freely
+}
+```
+
+Every preset (`all`, `mobile`, `apple`, `web`, `jvmFamily`, …) and every leaf (`jvm`, `iosArm64`, `linuxX64`, …) is in scope inside the block as **set algebra** — `+` unions, `-` subtracts. No imports, no strings. The full vocabulary lives in the [Targets Reference](targets-reference.md).
+
+Build-logic and callers that need raw values use the overload:
+
+```kotlin
+supports(KmpTargetSet.mobile + KmpTargetSet.web)
+```
+
+## Explicit by default
+
+A module that never calls `supports` registers **nothing** — exactly like plain KGP, where every target is declared by hand. To build "whatever the developer currently selects", opt in explicitly:
+
+```kotlin
+kmpTargets { supports { all } }   // global selection alone decides
+```
+
+The selection itself is **global** (the `kmptargets.targets` property — see [Selection Layers](selection-layers.md)); there is no per-module selection block. The plugin registers `selection ∩ supported` per module.
+
+A project-wide default for when `kmptargets.targets` is unset can be set from build-logic via the `defaultSelection` property; any actual `kmptargets.targets` value overrides it.
+
+## Eagerness and ordering
+
+`supports` registers **eagerly** — the moment it runs. Two rules follow:
+
+1. **Apply everything first.** Plugins that influence registration (most importantly the Android Gradle plugin for `androidTarget` — see [Advisories](advisories.md#android-target-without-agp)) must be applied *before* `supports { }` runs.
+2. **Call it before anything reads `kotlin.targets`.** Code that snapshots the target container before `supports` runs sees a stale view. Build-logic should prefer [`onRegistered`](build-logic.md#onregistered-the-ordering-immune-hook), which is ordering-immune.
+
+Calling `supports` more than once **unions** — an already-registered target can't be retracted. A later call registers only its delta (and re-checks the AGP guard, so AGP applied between two calls lets the later pass register `androidTarget` normally).
+
+## Escape hatch: mixing with raw KGP
+
+`supports { }` and explicit `kotlin { }` target calls coexist — the plugin registers through plain KGP APIs. The [`escape-hatch-dsl` sample](../samples/index.md) keeps a raw `kotlin.jvm { }` block next to `supports { jvm + linuxX64 }` for target-level configuration the DSL doesn't model.
+
+## Related
+
+- [Selection Layers](selection-layers.md) — where the global selection comes from
+- [Build-Logic Conventions](build-logic.md) — wrapping the DSL in your own convention plugins
+- [Renaming the JVM Target](jvm-rename.md) — `targetName(jvm, "desktop")`

--- a/docs/user-guide/selection-layers.md
+++ b/docs/user-guide/selection-layers.md
@@ -1,6 +1,58 @@
 # Selection Layers
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+The selection is **global** — one switch narrows the whole build. Its sources form **three layers in increasing priority**, the same model as Bazel's `.bazelrc` + `try-import user.bazelrc`:
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+| Layer | Sources | Who sets it |
+|---|---|---|
+| **Committed default** | `kmp-targets.properties` (and legacy root `gradle.properties`) | the team, in git |
+| **Personal override** | `kmp-targets.local.properties` (and legacy `local.properties`) — git-ignored | each developer, per machine |
+| **Per-invocation** | `-Pkmptargets.targets=…` CLI flag, `ORG_GRADLE_PROJECT_kmptargets.targets` env | this one build — a terminal run, a CI job |
+
+`kmptargets.targets` is the **single canonical key** across every layer — the string you commit, the string you override locally, and the string a [CI matrix](ci-matrix.md) passes per job are the same vocabulary.
+
+## Exact precedence (highest first)
+
+1. `-Pkmptargets.targets=...` on the CLI
+2. `ORG_GRADLE_PROJECT_kmptargets.targets` environment variable
+3. `kmp-targets.local.properties` (per-developer, git-ignored)
+4. `kmp-targets.properties` (committed, team-shared)
+5. the **root** `gradle.properties` (a *subproject's* `gradle.properties` is **not** a source — Gradle only reads root-level project properties)
+6. `local.properties` (per-developer, git-ignored)
+
+When no source provides a value, two **fallbacks** (not overrides — anything above beats them) apply: a project-wide `defaultSelection` set from build-logic, then the plugin default — every target the plugin knows about.
+
+!!! note "Why the dedicated files beat `gradle.properties`"
+    Once a team adopts the consolidation point, a stale key left behind in `gradle.properties` can't silently override it. One nuance: the rarer `-Dorg.gradle.project.kmptargets.targets` and `~/.gradle/gradle.properties` forms resolve at the `gradle.properties` layer, i.e. *below* the dedicated files.
+
+## The config files
+
+```properties
+# kmp-targets.properties — committed, team-shared
+kmptargets.targets=jvm,iosArm64
+kmptargets.hierarchyTemplate=true
+# kmptargets.hierarchyCollapse=false   # see "No-Collapse Mode"
+# kmptargets.strict=true               # see "Advisories & Strict Mode"
+```
+
+`kmp-targets.local.properties` (git-ignored) mirrors `try-import`: absent it's ignored; present, its keys override the committed file's. Both files accept **only** known `kmptargets.*` keys — an unknown key fails the build with a "did you mean …?" suggestion, so a typo can't silently no-op. Both are tracked configuration-cache inputs: editing one invalidates the cache, leaving them untouched keeps cache hits.
+
+## Selection grammar
+
+```properties
+kmptargets.targets=android,iosArm64        # explicit list
+kmptargets.targets=appleMobile             # preset (iosArm64 + iosSimulatorArm64 + iosX64)
+kmptargets.targets=appleMobile,-iosArm64   # preset minus a leaf
+kmptargets.targets=apple,+android          # preset plus an addition
+kmptargets.targets=ANDROID, ios-arm64      # aliases + case-insensitive
+```
+
+Unknown tokens **fail the build at configuration time** with a "did you mean …?" suggestion — silently dropping a misspelled target in CI is the worst failure mode, so the parser is strict. Bare Apple sub-family names (`ios`, `macos`, `watchos`, `tvos`) are rejected with a hint pointing at the relevant leaf or `appleX` preset.
+
+The full preset and leaf vocabulary lives in the [Targets Reference](targets-reference.md).
+
+!!! warning "Breaking rename (pre-1.0)"
+    The selection key used to be `KMP_TARGETS` (env: `ORG_GRADLE_PROJECT_KMP_TARGETS` or bare `KMP_TARGETS`). It is now `kmptargets.targets` — the old key is **not read at all**; a build still setting only `KMP_TARGETS` falls through to `defaultSelection` / the plugin default.
+
+## Diagnosing a surprising selection
+
+[`kmpTargetsInfo`](kmp-targets-info.md) prints the resolved selection **and the winning source by name** — `command line (-Pkmptargets.targets)`, `kmp-targets.local.properties`, etc. One coarseness, stated in the label itself: values from `-Dorg.gradle.project.kmptargets.targets` and `~/.gradle/gradle.properties` are indistinguishable from root `gradle.properties`, so all three report as the fused `gradle.properties (...)` layer.

--- a/docs/user-guide/targets-reference.md
+++ b/docs/user-guide/targets-reference.md
@@ -1,6 +1,61 @@
 # Targets Reference
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+Every target Kotlin Multiplatform (KGP 2.3.21) supports, except the deprecated `linuxArm32Hfp`. The same vocabulary works in the [`supports { }` DSL](selection-dsl.md), the [`kmptargets.targets` property](selection-layers.md), and [CI matrix values](ci-matrix.md).
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+## Leaves
+
+| Family | Targets |
+|---|---|
+| JVM | `androidTarget` (alias `android`), `jvm` (alias `desktop`) |
+| iOS | `iosArm64`, `iosSimulatorArm64`, `iosX64` |
+| macOS | `macosArm64`, `macosX64` |
+| watchOS | `watchosArm64`, `watchosArm32`, `watchosX64`, `watchosSimulatorArm64`, `watchosDeviceArm64` |
+| tvOS | `tvosArm64`, `tvosX64`, `tvosSimulatorArm64` |
+| Linux | `linuxX64`, `linuxArm64` |
+| MinGW | `mingwX64` |
+| Android Native | `androidNativeArm32`, `androidNativeArm64`, `androidNativeX86`, `androidNativeX64` |
+| Web | `js`, `wasmJs`, `wasmWasi` |
+
+Every leaf also accepts a kebab-case alias (e.g. `watchos-sim-arm64`, `linux-x64`, `android-native-arm64`), and parsing is case-insensitive.
+
+## Presets
+
+| Preset | Expands to |
+|---|---|
+| `all` | every shipped target |
+| `native` | every Kotlin/Native target (Apple + Linux + MinGW + Android Native) |
+| `apple` | all Apple platforms: iOS + macOS + watchOS + tvOS |
+| `appleMobile` / `appleDesktop` | all iOS / all macOS |
+| `appleWatch` / `appleTv` | all watchOS / all tvOS |
+| `linux` | `linuxX64`, `linuxArm64` |
+| `mingw` (alias `windows`) | `mingwX64` |
+| `androidNative` | the four `androidNative*` targets |
+| `web` | `js`, `wasmJs`, `wasmWasi` |
+| `jvmFamily` | `androidTarget`, `jvm` |
+| `mobile` | `androidTarget` + all iOS |
+
+## Membership clarifications
+
+Preset membership is worth spelling out where it's non-obvious:
+
+- **`jvmFamily` *includes* Android** — it is `{androidTarget, jvm}`, the two JVM-bytecode leaves, not just `jvm`.
+- **`mobile` = `androidTarget` + the iOS leaves** (`iosArm64`, `iosSimulatorArm64`, `iosX64`) — no watchOS, no macOS.
+- **`androidNative` ≠ `androidTarget`** — the four `androidNative*` leaves are Kotlin/Native NDK targets; the Android *app* target is `androidTarget` (alias `android`).
+- **Aliases**: `android` → `androidTarget`, `desktop` → `jvm`, `windows` → `mingw`. The alias and the canonical name are interchangeable in every layer.
+- **Bare sub-family names are rejected**: `ios`, `macos`, `watchos`, `tvos` fail parsing with a hint pointing at the relevant leaf or `appleX` preset — they would be ambiguous between "all leaves" and "the device leaf".
+
+## Deprecated leaves
+
+Kotlin [marks](https://kotlinlang.org/docs/native-target-support.html) `macosX64`, `watchosX64`, and `tvosX64` **deprecated** (since Kotlin 2.3.20). They stay selectable and stay in every preset (`appleDesktop` still expands to both macOS leaves) — registering one logs a [deprecated-target advisory](advisories.md#deprecated-targets), and [`kmpTargetsInfo`](kmp-targets-info.md) annotates them `(deprecated)` in its vocabulary listing. (`iosX64` is low-tier but *not* deprecated.)
+
+## Composing
+
+Presets and leaves compose with `+` / `-` in the DSL and with `,` / `-` / `+` in the property grammar:
+
+```kotlin
+kmpTargets { supports { mobile + web - iosX64 } }
+```
+
+```properties
+kmptargets.targets=appleMobile,-iosArm64,+jvm
+```

--- a/docs/why-kmp-targets.md
+++ b/docs/why-kmp-targets.md
@@ -1,6 +1,42 @@
 # Why kmp-targets?
 
-!!! note "Under construction"
-    This page is part of the initial docs scaffold. Its content lands in [#70](https://github.com/rsicarelli/kmp-targets/issues/70).
+## The full-target-build problem
 
-Until then, the [README](https://github.com/rsicarelli/kmp-targets#readme) covers everything this page will.
+A plain KMP module registers every target its build script declares, every time, for everyone. A shared module with 20+ targets drags all of them through every Gradle sync and every aggregate invocation — compile, link, KSP, publish task graphs for watchOS variants you haven't touched in months, on a laptop that only needed `jvm` and one iOS leaf today.
+
+The waste compounds in two directions:
+
+- **Per-developer**: an Android engineer iterating on `jvm`+`androidTarget` pays configuration and task-graph cost for every Apple and native target in every module, on every sync.
+- **Per-CI-host**: a Linux runner *cannot* compile `iosArm64`, yet a full-target build still registers it, configures it, and either fails or wastes time skipping it. macOS runners — billed at roughly 10× the Ubuntu rate on private repos — end up building targets Ubuntu could have handled.
+
+KGP's default hierarchy template adds a second tax: it materializes the *full* intermediate source-set tree for whatever registers, so an iOS-only module still carries `nativeMain` and `appleMain` — each redundant intermediate spawning ~8 wasteful tasks ([the hidden cost of default hierarchy templates](https://dev.to/rsicarelli/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform-256a)).
+
+## The thesis: explicit selection
+
+`kmp-targets` separates two facts that full-target builds conflate:
+
+| Fact | Declared by | Mechanism |
+|---|---|---|
+| What a module **can** build | the module, in git | `kmpTargets { supports { … } }` |
+| What you **want** built now | the developer / CI job | the global `kmptargets.targets` property |
+
+The plugin registers `selection ∩ supported` per module. Unselected targets are not "disabled" — they are **never registered with KGP at all**, so their tasks don't exist. The build doesn't skip work; the work isn't there.
+
+Selection is **explicit and deterministic**, not host-magic: selecting `iosArm64` on a Linux box registers `iosArm64` (with an [advisory](user-guide/advisories.md), since the host can't compile it). Registration being host-blind keeps configuration-cache keys, task graphs, and published metadata identical across machines — what differs per host is what you *select*, via the [same vocabulary everywhere](user-guide/ci-matrix.md).
+
+And because the plugin knows the active target set, it applies a [**minimal** hierarchy template](user-guide/hierarchy-template.md) — only the intermediates your registered targets actually need.
+
+## The trade-off, stated plainly
+
+Changing the selection changes what the configuration phase produces. The price is exact: **one configuration-cache miss + one Gradle sync per new `kmptargets.targets` value**. Each distinct value is its own cache entry, and entries coexist — switching *back* to a previous selection is a cache **hit**. Alternating between two working sets re-configures nothing after the first time each was seen.
+
+There is deliberately no file-watch workaround: Gradle has no mechanism to re-run the *configuration* phase on a file change, and the plugin won't fake one. The bounded miss is the price of not registering unused targets — the same property that makes every subsequent sync and build smaller.
+
+!!! tip
+    If a selection ever surprises you, [`kmpTargetsInfo`](user-guide/kmp-targets-info.md) prints what resolved, which source won, and what registered — at configuration-cache-hit speed.
+
+## What it is not
+
+- **Not a convention plugin.** One extension, one DSL, no bundled per-shape plugin ids. Teams that want `apply by id, no body` ergonomics [build their own conventions](user-guide/build-logic.md) on top.
+- **Not a host auto-gater.** The plugin never decides "this host can't build that, so drop it" — you select, it registers, advisories tell you when a combination can't work [and strict mode makes that fatal in CI](user-guide/advisories.md).
+- **Not a fork of the target model.** Everything registers through plain KGP APIs; modules that don't apply the plugin are untouched (see the [`plain-kmp` sample](samples/index.md)).


### PR DESCRIPTION
## Summary

Completes the docs site: every nav page now carries substantive content restructured from the README, KDoc, and sample sources — recipe-driven, code-first, cross-linked. No stub or placeholder text remains anywhere.

## Changes

- `why-kmp-targets.md` — the full-target-build problem, the explicit-selection thesis, and the config-cache trade-off told straight
- `user-guide/` (11 pages) — selection DSL (eagerness, unions, escape hatch), selection layers (exact precedence + grammar), targets reference (presets/leaves/aliases + **membership clarifications** per the issue comment: `jvmFamily` includes Android, `mobile` composition, alias story), hierarchy template, no-collapse mode, build-logic (`registered()`/`onRegistered`/`RegisteredTarget`, eager-conventions as canonical), **recipes hub** (inert-module gating, commonMain-KSP native gate, per-target wiring, selection-gated AGP, lane-agnostic CI, selection-vs-dependency-graph, BCV — the seeds from the consumer-pain mapping), advisories & strict mode (all five, verbatim message texts), `kmpTargetsInfo` walkthrough with the full annotation table, CI matrix, jvm rename
- `samples/index.md` — catalog of all **11 hello-world subprojects** + the isolated-projects sample, each row linking to its GitHub source, with the regression gates (`verifyEagerTargets`, `verifyIsolatedConfiguration`) called out
- `compatibility.md` — floors table, how `verifyCompatFloors` enforces them, philosophy, version pairing
- `help/faq.md` + `help/troubleshooting.md` — FAQ by theme; troubleshooting as symptom → cause → fix tables (resolution, selection, registration, building)

## Test plan

- [x] `task ci` is green locally (`task dod`; docs only)
- [x] Added/updated tests where appropriate (n/a)
- [x] Updated docs/README if user-facing (this is the docs PR)
- [x] No new public API without explicit intent

Verification:
- `mkdocs build --strict` → **zero** warnings/link findings (anchor slugs fixed where em-dashes/`+` slugify lossily)
- Cross-links resolve (hierarchy ↔ no-collapse, advisories ↔ ci-matrix, recipes ↔ troubleshooting, …)
- Snippet spot-check against the live sample: `-Pkmptargets.targets=appleMobile,-iosArm64,+jvm` → `kmpTargetsInfo` reports exactly the documented expansion (`iosSimulatorArm64, iosX64, jvm`)
- `sync-docs-version.main.kts 9.9.9` rewrites the version strings in the new pages (then restored) — release automation keeps them current
- Sample catalog facts checked against the sources (legacy-default = template off; KmpModule.kt path; gate task names)

## Deferred verification (needs #58)

- Click-through review on the live site after the first docs deploy

## Related

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)