### PR TITLE
feat: per-target configuration-name helpers on RegisteredTarget (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ changes may land in any release.
 
 ### Added
 
+- **Per-target configuration-name helpers** ([#74]): `RegisteredTarget.configurationName(prefix)`
+  and `RegisteredTarget.testConfigurationName(prefix)` build the `prefix + gradleNameCapitalized`
+  (+ `"Test"`) Gradle configuration name a per-target tool publishes — `it.configurationName("ksp")`
+  / `it.testConfigurationName("ksp")` instead of hand-rolled `"ksp${it.gradleNameCapitalized}"` and
+  a hardcoded `kspJvmTest` that breaks with *Configuration 'kspJvmTest' not found* under
+  `targetName(jvm, "desktop")` (it becomes `kspDesktopTest`). Derived from `gradleName`, so the
+  names track the rename; tool-generic by design (`it.configurationName("kapt")` works too — the
+  plugin blesses no single processor); blank prefix fails loud. Built on the existing
+  `gradleNameCapitalized` primitive, so they stay config-cache trivial (pure functions on the
+  immutable carrier).
 - **Native-only-metadata advisory** ([#72]): when a module **supports** the JVM family
   (`androidTarget`/`jvm`) yet a registration pass ends with **no** JVM-family target registered
   while other targets did register, the plugin logs a one-line advisory. The module is alive — the
@@ -117,3 +127,4 @@ changes may land in any release.
 [#52]: https://github.com/rsicarelli/kmp-targets/issues/52
 [#71]: https://github.com/rsicarelli/kmp-targets/issues/71
 [#72]: https://github.com/rsicarelli/kmp-targets/issues/72
+[#74]: https://github.com/rsicarelli/kmp-targets/issues/74

--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ kmpTargets.registered()                          // everything registered so far
 kmpTargets.registered(KmpTargetSet.appleMobile)  // just the registered iOS leaves
 ```
 
+**Configuration-name helpers (issue #74).** Even the `"ksp${it.gradleNameCapitalized}"` form above
+is a string to get wrong — and the test compilation's `kspJvmTest` is the one that bites: hardcode
+it and it throws *Configuration 'kspJvmTest' not found* the moment a `targetName(jvm, "desktop")`
+rename turns it into `kspDesktopTest`. `RegisteredTarget` owns that grammar so you never hand-roll
+it:
+
+```kotlin
+kmpTargets.onRegistered {
+    add(it.configurationName("ksp"), processor)      // kspJvm / kspIosArm64 / kspDesktop (renamed)
+    add(it.testConfigurationName("ksp"), processor)  // kspJvmTest / … / kspDesktopTest (renamed)
+}
+```
+
+Both are tool-generic — the prefix is any tool's convention (`it.configurationName("kapt")`); the
+plugin blesses no single processor. Always wire through `onRegistered`, never an eager
+`kotlin.targets` snapshot taken in the build script: that snapshot is ordering-sensitive (empty if
+read before `supports { }`), whereas the callback's `configureEach` semantics are not.
+
 **Callback vs snapshot.** `onRegistered` has `configureEach` semantics: hooked *before* the
 module's `supports { }` it fires as each leaf registers; hooked *after*, it replays for the leaves
 already registered — and a later `supports { }` union fires only its delta. That makes it the

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/RegisteredTarget.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/model/RegisteredTarget.kt
@@ -30,4 +30,50 @@ public data class RegisteredTarget(val leaf: KmpTarget, val gradleName: String) 
      */
     public val gradleNameCapitalized: String
         get() = gradleName.replaceFirstChar(Char::titlecase)
+
+    /**
+     * The Gradle configuration name a per-target tool publishes for this registration's **main**
+     * compilation (issue #74): [prefix] + [gradleNameCapitalized] — the `ksp<Target>` grammar
+     * KGP-aware tools mangle into, owned here so build-logic stops re-rolling it by hand:
+     * ```kotlin
+     * // Before — string mangling repeated at every call site:
+     * kmpTargets.onRegistered { add("ksp${it.gradleNameCapitalized}", processor) }
+     *
+     * // After:
+     * kmpTargets.onRegistered { add(it.configurationName("ksp"), processor) }
+     * ```
+     *
+     * Tool-generic on purpose — [prefix] is any tool's convention (`"ksp"`, `"kapt"`); the plugin
+     * is mechanism, not a KSP integration. Built on [gradleNameCapitalized], so it stays truthful
+     * under a renamed jvm leaf (`targetName(jvm, "desktop")` → `configurationName("ksp") ==
+     * "kspDesktop"`). See [testConfigurationName] for the test compilation's configuration.
+     *
+     * @throws IllegalArgumentException if [prefix] is blank.
+     */
+    public fun configurationName(prefix: String): String {
+        require(prefix.isNotBlank()) {
+            "configurationName prefix must not be blank (got \"$prefix\"); pass a tool prefix like \"ksp\"."
+        }
+        return prefix + gradleNameCapitalized
+    }
+
+    /**
+     * The Gradle configuration name a per-target tool publishes for this registration's **test**
+     * compilation (issue #74): [configurationName] + `"Test"` — the `ksp<Target>Test` grammar. This
+     * is the variant that silently breaks when hardcoded: a literal `"kspJvmTest"` throws
+     * *Configuration 'kspJvmTest' not found* once the jvm leaf is renamed (it becomes
+     * `kspDesktopTest`), the very footgun `targetName` induces. Derived from [gradleName], so it
+     * never disagrees:
+     * ```kotlin
+     * kmpTargets.onRegistered {
+     *     add(it.configurationName("ksp"), processor)      // main compilation
+     *     add(it.testConfigurationName("ksp"), processor)  // test compilation
+     * }
+     * ```
+     *
+     * Delegates to [configurationName], so the prefix rule and validation live in one place.
+     *
+     * @throws IllegalArgumentException if [prefix] is blank.
+     */
+    public fun testConfigurationName(prefix: String): String = configurationName(prefix) + "Test"
 }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsRegisteredTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsRegisteredTest.kt
@@ -135,6 +135,44 @@ class KmpTargetsRegisteredTest {
     }
 
     @Test
+    fun `given onRegistered when wiring via configurationName then the names match KGP's`(
+        @TempDir dir: Path
+    ) {
+        // Same proof as the gradleNameCapitalized test above, but through the issue #74 helpers:
+        // configurationName / testConfigurationName must derive exactly the ksp<Target>[Test] names
+        // KGP would mangle, so consumers stop hand-rolling the string.
+        val project = projectWithSelection(dir, "iosArm64,iosSimulatorArm64")
+        val mainConfigs = mutableSetOf<String>()
+        val testConfigs = mutableSetOf<String>()
+        project.kmpTargets().onRegistered {
+            mainConfigs += it.configurationName("ksp")
+            testConfigs += it.testConfigurationName("ksp")
+        }
+        project.kmpTargets().supports(KmpTargetSet.appleMobile)
+        val expectedMain =
+            project.kotlinTargetNames().map { "ksp${it.replaceFirstChar(Char::titlecase)}" }.toSet()
+        assertEquals(expectedMain, mainConfigs)
+        assertEquals(expectedMain.map { it + "Test" }.toSet(), testConfigs)
+        assertTrue("kspIosArm64" in mainConfigs, mainConfigs.toString())
+        assertTrue("kspIosArm64Test" in testConfigs, testConfigs.toString())
+    }
+
+    @Test
+    fun `given a renamed jvm when configurationName helpers fire then they follow the custom name`(
+        @TempDir dir: Path
+    ) {
+        // The regression the issue reports: a hardcoded "kspJvmTest" breaks under targetName; the
+        // helpers track the renamed gradleName into "kspDesktop" / "kspDesktopTest".
+        val project = projectWithSelection(dir, "jvm")
+        project.kmpTargets().targetName(KmpTargetsDsl.jvm, "desktop")
+        val seen = mutableListOf<RegisteredTarget>()
+        project.kmpTargets().onRegistered { seen += it }
+        project.kmpTargets().supports(KmpTargetSet.of(KmpTarget.Jvm.Desktop))
+        assertEquals("kspDesktop", seen.single().configurationName("ksp"))
+        assertEquals("kspDesktopTest", seen.single().testConfigurationName("ksp"))
+    }
+
+    @Test
     fun `given a renamed jvm when onRegistered fires then gradleName is the custom name`(
         @TempDir dir: Path
     ) {

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/model/RegisteredTargetTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/model/RegisteredTargetTest.kt
@@ -1,0 +1,96 @@
+package com.rsicarelli.kmptargets.model
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+
+/**
+ * The per-target configuration-name helpers (issue #74): [RegisteredTarget.configurationName] /
+ * [RegisteredTarget.testConfigurationName] own the `prefix + gradleNameCapitalized [+ "Test"]`
+ * grammar so build-logic stops hand-rolling it — and stay truthful under a renamed jvm leaf, the
+ * footgun a hardcoded `"kspJvmTest"` falls into. Pure value tests on the immutable carrier.
+ */
+class RegisteredTargetTest {
+
+    @Test
+    fun `given a jvm registration when configurationName ksp then it is kspJvm`() {
+        assertEquals(
+            "kspJvm",
+            RegisteredTarget(KmpTarget.Jvm.Desktop, "jvm").configurationName("ksp"),
+        )
+    }
+
+    @Test
+    fun `given a jvm registration when testConfigurationName ksp then it is kspJvmTest`() {
+        assertEquals(
+            "kspJvmTest",
+            RegisteredTarget(KmpTarget.Jvm.Desktop, "jvm").testConfigurationName("ksp"),
+        )
+    }
+
+    @Test
+    fun `given a desktop-renamed jvm when configurationName ksp then it is kspDesktop`() {
+        // targetName(jvm, "desktop") makes gradleName == "desktop"; the helper must follow it.
+        assertEquals(
+            "kspDesktop",
+            RegisteredTarget(KmpTarget.Jvm.Desktop, "desktop").configurationName("ksp"),
+        )
+    }
+
+    @Test
+    fun `given a desktop-renamed jvm when testConfigurationName ksp then it is kspDesktopTest`() {
+        // The motivating regression: hardcoded "kspJvmTest" threw "Configuration not found" under
+        // the rename; derived from gradleName it correctly becomes "kspDesktopTest".
+        assertEquals(
+            "kspDesktopTest",
+            RegisteredTarget(KmpTarget.Jvm.Desktop, "desktop").testConfigurationName("ksp"),
+        )
+    }
+
+    @Test
+    fun `given an iosArm64 registration when configurationName ksp then it is kspIosArm64`() {
+        // Multi-segment name: only the first char is title-cased, the rest is preserved verbatim.
+        assertEquals(
+            "kspIosArm64",
+            RegisteredTarget(KmpTarget.Native.Apple.Ios.Arm64, "iosArm64").configurationName("ksp"),
+        )
+    }
+
+    @Test
+    fun `given an arbitrary tool prefix when configurationName kapt then it is kaptJvm`() {
+        // Tool-agnostic: the helper blesses no single tool's convention.
+        assertEquals(
+            "kaptJvm",
+            RegisteredTarget(KmpTarget.Jvm.Desktop, "jvm").configurationName("kapt"),
+        )
+    }
+
+    @Test
+    fun `given a blank prefix when configurationName then it throws IllegalArgumentException`() {
+        val target = RegisteredTarget(KmpTarget.Jvm.Desktop, "jvm")
+        assertFailsWith<IllegalArgumentException> { target.configurationName("") }
+        assertFailsWith<IllegalArgumentException> { target.configurationName("   ") }
+    }
+
+    @Test
+    fun `given a blank prefix when testConfigurationName then it throws IllegalArgumentException`() {
+        // Validation is delegated to configurationName, so it must hold on the test variant too.
+        val target = RegisteredTarget(KmpTarget.Jvm.Desktop, "jvm")
+        assertFailsWith<IllegalArgumentException> { target.testConfigurationName("") }
+        assertFailsWith<IllegalArgumentException> { target.testConfigurationName("   ") }
+    }
+
+    @Test
+    fun `given a single-char gradleName when configurationName then the char is title-cased`() {
+        assertEquals("kspX", RegisteredTarget(KmpTarget.Jvm.Desktop, "x").configurationName("ksp"))
+    }
+
+    @Test
+    fun `given an already-capitalized gradleName when configurationName then capitalization is unchanged`() {
+        // titlecase of an already-upper first char is a no-op; the rest of the string is untouched.
+        assertEquals(
+            "kspDesktop",
+            RegisteredTarget(KmpTarget.Jvm.Desktop, "Desktop").configurationName("ksp"),
+        )
+    }
+}


### PR DESCRIPTION
## Problem

`RegisteredTarget`/`onRegistered` (#52) give build-logic the truthful Gradle name per registered leaf, but the *string-derivation* half of per-target wiring stayed hand-rolled everywhere: `add("ksp${it.gradleNameCapitalized}", dep)`, and worse, hardcoded `add("kspJvmTest", …)` which broke with **Configuration 'kspJvmTest' not found** once the jvm leaf was renamed via `targetName(jvm, "desktop")` (KGP names the config `kspDesktopTest`). The plugin's own rename feature induces the footgun.

## What shipped — direction (a) + (c)

Two pure helpers on the immutable `RegisteredTarget` carrier:

```kotlin
public fun configurationName(prefix: String): String          // prefix + gradleNameCapitalized
public fun testConfigurationName(prefix: String): String       // configurationName(prefix) + "Test"
```

```kotlin
kmpTargets.onRegistered {
    add(it.configurationName("ksp"), processor)      // kspJvm / kspIosArm64 / kspDesktop (renamed)
    add(it.testConfigurationName("ksp"), processor)  // kspJvmTest / …      / kspDesktopTest (renamed)
}
```

Derived from `gradleName`, so they track the rename; tool-generic (`configurationName("kapt")`); blank prefix fails loud. Built on the existing `gradleNameCapitalized` primitive — config-cache trivial, no new dependency on the published artifact (no KSP anywhere, not even test scope). Plus README + CHANGELOG (direction (c) docs).

## Deferred — direction (b)

Slice-scoped `onRegistered(slice: KmpTargetSet) { }` is **not** in this PR (scope discipline). It carries its own replay-semantics design (slice-scoped replay of already-registered leaves, repeated-`supports{}`-union deltas, leaves outside the slice never firing) that deserves its own thread. Filed as a follow-up comment on #74. The helpers here are the load-bearing fix for the reported regression and ship independently.

## Open questions answered

- **Tool-generic vs blessed `ksp` sugar** → tool-generic only. `prefix` is a plain `String`; no `kspConfigurationName` symbol, no KSP dependency. Plugin = mechanism; KSP stays the canonical *example* in docs/KDoc, never a concept the API names.
- **Where the `Test`-suffix rule lives** → here, in the configuration namespace, via `testConfigurationName` delegating to `configurationName` (one place for the prefix rule + validation). See the #79 boundary below.
- **Blank-prefix behavior** → `require(prefix.isNotBlank())` fail-loud, matching the house key-validation posture. (Bare lowercase `gradleName` was rejected: it maps to no real configuration and needs an un-capitalized special case.)

## #79 boundary decision

#79 (registered-aware test-*task* names) shares conceptual machinery but a **different namespace**. Decision recorded on #79: the shared primitive is the existing `gradleNameCapitalized`. `configurationName` owns the *configuration* grammar (`prefix + Capitalized [+ "Test"]`). #79's future test-task surface derives `"${gradleName}Test"` directly — **lowercase first char, no capitalize step** — so the two surfaces share only the `Test` literal and `gradleName`, never the capitalize. No code unification; do not reuse `configurationName` for task names.

## Docs interplay

Only touched README + CHANGELOG + KDoc. `docs/user-guide/recipes.md`/`build-logic.md` are being rewritten by open PR #91 — left untouched to avoid conflict; the user-guide KSP recipe should adopt these helpers after both merge.

## Test evidence

- New `RegisteredTargetTest` (pure value tests): default jvm → `kspJvm`/`kspJvmTest`; rename → `kspDesktop`/`kspDesktopTest`; `iosArm64`; arbitrary prefix (`kapt`); blank-prefix throws on both functions; single-char + already-capitalized capitalization edges.
- Extended `KmpTargetsRegisteredTest`: helpers via `onRegistered` match KGP's real config names; renamed-jvm variant.
- `task dod` green (fmt + build + test); pre-commit DoD gate passed.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)