### PR TITLE
docs: commonMain-KSP native-target gate recipe + KGP invariant tripwire (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,22 @@ changes may land in any release.
   `kmpTargetsInfo` marks the leaf `androidTarget (skipped: no Android plugin applied)` while the
   condition holds.
 
+### Documentation
+
+- **commonMain-KSP-needs-a-native-target recipe, hardened** ([#73]). A processor that generates
+  into `commonMain` runs on the shared commonMain metadata route (`kspCommonMainKotlinMetadata`),
+  which KSP only wires when the selection registers a **native** target — so a native-less lane
+  silently skips generation (worst case: a green build shipping missing codegen). **No new API**:
+  the trap's distinguishing fact ("this module runs a commonMain metadata-route processor") is one
+  the plugin cannot observe, so per the mechanism-vs-conventions split it stays in build-logic,
+  which gates on the existing `registered(KmpTargetSet.native)` primitive ([#52]). The user-guide
+  recipe now warns **and** disables the doomed compilations, notes that K2's strict fragment
+  resolution rules out a per-platform workaround, and is backed by two tests: one pinning the gate
+  predicate, one pinning the actual KGP 2.3.21 rule for `compileCommonMainKotlinMetadata` — which
+  tracks a *shared* commonMain (≥2 platform targets), **not** native presence (`jvm + js` has it
+  with zero native targets; a lone `iosArm64` does not). That invariant test is a tripwire: a KGP
+  bump that shifts the rule fails it loudly.
+
 ### Fixed
 
 - **Plugin jar is now consumable from Gradle 8.x `kotlin-dsl` build-logic and JDK 17 daemons**
@@ -127,4 +143,5 @@ changes may land in any release.
 [#52]: https://github.com/rsicarelli/kmp-targets/issues/52
 [#71]: https://github.com/rsicarelli/kmp-targets/issues/71
 [#72]: https://github.com/rsicarelli/kmp-targets/issues/72
+[#73]: https://github.com/rsicarelli/kmp-targets/issues/73
 [#74]: https://github.com/rsicarelli/kmp-targets/issues/74

--- a/docs/user-guide/recipes.md
+++ b/docs/user-guide/recipes.md
@@ -12,20 +12,24 @@ if (kmpTargets.registered().isEmpty()) {
 }
 ```
 
-This is the gate the inert-module advisory names. Variant: a metadata-only predicate for modules whose *native* fragment is the risky part — gate on `kmpTargets.registered(KmpTargetSet.native).isEmpty()` instead.
+This is the gate the inert-module advisory names. Variant: when only a *native*-wired codegen processor is at risk rather than the whole module, gate on the narrower `kmpTargets.registered(KmpTargetSet.native).isEmpty()` — see [commonMain KSP needs a native target](#commonmain-ksp-needs-a-native-target).
 
 ## commonMain KSP needs a native target
 
-KSP processing of `commonMain` runs on a platform compilation. If your processor is wired to a native target, a selection without any native leaf silently skips generation — downstream code then fails with missing symbols. Gate and warn explicitly:
+A processor that generates into `commonMain` runs on the shared **commonMain metadata compilation** (`kspCommonMainKotlinMetadata`). KSP's multiplatform wiring only creates that task when the selection registers a **native** target — so a native-less lane (`jvm`, `android,jvm`) silently skips generation, and the failure ranges from unresolved-reference errors to a green build that ships missing codegen. There is **no per-platform workaround**: K2's strict fragment resolution forbids `commonMain` from referencing platform-generated symbols, so generating per-platform instead does not help. Gate the module — warn *and* disable the doomed compilations — right after `supports { }`:
 
 ```kotlin
 if (kmpTargets.registered(KmpTargetSet.native).isEmpty()) {
     logger.warn(
-        "ksp: ':${project.name}' has no native target registered — " +
-        "commonMain symbol processing is skipped for this selection."
+        "ksp: ':${project.name}' generates commonMain code but no native target is " +
+        "registered — symbol processing is skipped for this selection."
     )
+    tasks.withType(KotlinCompilationTask::class.java).configureEach { enabled = false }
 }
 ```
+
+!!! note "Why the gate is `native`, not the metadata compilation itself"
+    KGP's `compileCommonMainKotlinMetadata` tracks a *shared* commonMain (two or more platform targets), **not** native presence — `jvm + js` has it with zero native targets, a lone `iosArm64` does not. The **native** gate above is specific to the KSP commonMain-metadata *route*; it is the conservative predicate for a native-wired processor, not a claim about the compilation itself. [`kmpTargetsInfo`](kmp-targets-info.md) shows what registered, per lane.
 
 ## Per-target configuration wiring
 

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/CommonMainKspGateTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/CommonMainKspGateTest.kt
@@ -1,0 +1,106 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Proves the build-logic gate the user guide blesses for the commonMain-KSP-needs-a-native-target
+ * trap (#73): a module whose KSP processor generates into commonMain via the native metadata route
+ * skips generation under a native-less selection, so build-logic gates on
+ * `kmpTargets.registered(KmpTargetSet.native).isEmpty()`. There is intentionally **no plugin
+ * advisory** here — the trigger has a conjunct the plugin cannot observe ("does this module run a
+ * commonMain metadata-route processor?"), so the plugin owns only the selection-awareness primitive
+ * ([KmpTargetsExtension.registered]) and the gate stays in build-logic. These tests pin that the
+ * primitive answers the gate truthfully.
+ *
+ * Registration is host-blind, so `iosArm64` registers on Linux CI too; nothing here compiles, so
+ * the native leaf is cross-host safe.
+ */
+class CommonMainKspGateTest {
+
+    @Test
+    fun `given a jvm-only selection when supports is declared then the native gate is empty`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { jvm }
+        // The recipe's gate: registered(native).isEmpty() == true → build-logic warns and
+        // disables the doomed codegen compilations.
+        assertTrue(gate(project))
+    }
+
+    @Test
+    fun `given a native leaf in the selection when supports is declared then the native gate is non-empty`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { iosArm64 }
+        // A native leaf registered → the metadata-route codegen runs; the gate stays silent.
+        assertEquals(setOf("iosArm64"), registeredTargets(project))
+        assertFalse(gate(project))
+    }
+
+    @Test
+    fun `given a jvm and web selection when supports is declared then the native gate is still empty`(
+        @TempDir dir: Path
+    ) {
+        // The boundary that separates #73 from the bare metadata compilation: jvm+web shares a real
+        // commonMain (see CommonMainMetadataCompilationInvariantTest) yet registers no native leaf
+        // —
+        // so the native-route processor's codegen is still skipped and the gate must fire.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,js\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { jvm + js }
+        assertEquals(setOf("jvm", "js"), registeredTargets(project))
+        assertTrue(gate(project))
+    }
+
+    @Test
+    fun `given a jvm selection when a later union registers a native leaf then the native gate resolves`(
+        @TempDir dir: Path
+    ) {
+        // Registration is one-way: a later supports { } union that adds a native leaf flips the
+        // gate
+        // from empty to non-empty permanently — the doomed state resolves itself.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm,iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { jvm }
+        assertTrue(gate(project), "gate fires while only jvm is registered")
+        extension.supports { jvm + iosArm64 }
+        assertFalse(gate(project), "gate resolves once the native leaf registers")
+    }
+
+    /** The exact predicate the user-guide recipe gates on. */
+    private fun gate(project: Project): Boolean =
+        ext(project).registered(KmpTargetSet.native).isEmpty()
+
+    private fun newProjectWithKgp(dir: Path): Project {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        return project
+    }
+
+    private fun ext(project: Project): KmpTargetsExtension =
+        project.extensions.getByType(KmpTargetsExtension::class.java)
+
+    private fun registeredTargets(project: Project): Set<String> =
+        project.extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .names
+            .filter { it != "metadata" }
+            .toSet()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/CommonMainMetadataCompilationInvariantTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/CommonMainMetadataCompilationInvariantTest.kt
@@ -1,0 +1,106 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Tripwire pinning the **actual** KGP 2.3.21 rule for the commonMain Kotlin **metadata compilation
+ * task** (`compileCommonMainKotlinMetadata`) that the #73 recipe reasons about. Issue #73's open
+ * question asks whether "≥1 native target" is the precise, stable condition for that compilation
+ * existing. Measured here, it is **not**: the task tracks a genuinely **shared commonMain (≥2
+ * platform targets)**, not native presence —
+ *
+ * - a lone `jvm` → absent (single target, commonMain not shared)
+ * - a lone `iosArm64` → **absent** (a native target alone does *not* create it)
+ * - `jvm + js` → **present** (two non-native targets share commonMain)
+ * - `jvm + iosArm64` → present
+ *
+ * So the native-gating the issue describes belongs to KSP's `kspCommonMainKotlinMetadata` route
+ * (KSP's own multiplatform wiring), not to KGP's metadata compilation. The recipe therefore gates
+ * conservatively on `registered(KmpTargetSet.native).isEmpty()` for native-wired processors rather
+ * than claiming anything about the bare compilation. If a KGP bump changes the target-count rule
+ * pinned below, this test fails loudly and the recipe's premise must be revisited.
+ *
+ * In-process via `evaluate()` (no compile, so the native leaf is cross-host safe); a real build is
+ * unnecessary to observe task existence.
+ */
+class CommonMainMetadataCompilationInvariantTest {
+
+    @Test
+    fun `given a single jvm target when the project evaluates then the commonMain metadata compilation is absent`(
+        @TempDir dir: Path
+    ) {
+        val project = evaluated(dir, "jvm") { supports { jvm } }
+        assertNull(
+            project.tasks.findByName(COMMON_MAIN_METADATA),
+            "a single target shares no commonMain, so KGP creates no $COMMON_MAIN_METADATA",
+        )
+    }
+
+    @Test
+    fun `given a single native target when the project evaluates then the commonMain metadata compilation is still absent`(
+        @TempDir dir: Path
+    ) {
+        // The case that refutes "≥1 native target ⇒ metadata compilation exists": iosArm64 ALONE
+        // does not create it. Native presence is not the trigger; target count is.
+        val project = evaluated(dir, "iosArm64") { supports { iosArm64 } }
+        assertNull(
+            project.tasks.findByName(COMMON_MAIN_METADATA),
+            "a lone native target shares no commonMain either — native presence is not the trigger",
+        )
+    }
+
+    @Test
+    fun `given jvm and web targets when the project evaluates then the commonMain metadata compilation exists despite no native target`(
+        @TempDir dir: Path
+    ) {
+        // The pin that matters: two NON-native targets share commonMain, so the metadata
+        // compilation exists even though registered(native) is empty.
+        val project = evaluated(dir, "jvm,js") { supports { jvm + js } }
+        assertTrue(ext(project).registered(KmpTargetSet.native).isEmpty(), "no native registered")
+        assertNotNull(
+            project.tasks.findByName(COMMON_MAIN_METADATA),
+            "two shared targets create $COMMON_MAIN_METADATA with zero native targets",
+        )
+    }
+
+    @Test
+    fun `given jvm and a native target when the project evaluates then the commonMain metadata compilation exists`(
+        @TempDir dir: Path
+    ) {
+        val project = evaluated(dir, "jvm,iosArm64") { supports { jvm + iosArm64 } }
+        assertFalse(ext(project).registered(KmpTargetSet.native).isEmpty(), "native registered")
+        assertNotNull(project.tasks.findByName(COMMON_MAIN_METADATA))
+    }
+
+    private fun evaluated(
+        dir: Path,
+        selection: String,
+        block: KmpTargetsExtension.() -> Unit,
+    ): Project {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=$selection\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        ext(project).block()
+        (project as ProjectInternal).evaluate()
+        return project
+    }
+
+    private fun ext(project: Project): KmpTargetsExtension =
+        project.extensions.getByType(KmpTargetsExtension::class.java)
+
+    private companion object {
+        const val COMMON_MAIN_METADATA = "compileCommonMainKotlinMetadata"
+    }
+}


### PR DESCRIPTION
## Problem

Some modules generate code **into commonMain** via KSP (the `kspCommonMainKotlinMetadata` route — Ktorfit/Koin-codegen style). Under a native-less selection (`jvm`, `android,jvm`) KSP never wires that task, so commonMain references to generated symbols don't resolve — and the failure ranges from confusing unresolved-reference errors to **a green build that ships missing codegen**. There is **no per-platform workaround**: K2's strict fragment resolution forbids commonMain from referencing platform-generated symbols.

## Decision: direction (b) — KSP-agnostic query + recipe. **No new public API.**

The issue framed three directions and asked for a written, design-driven decision. I ran a 3-lens parallel design exploration (API-minimalism, consumer-ergonomics-at-scale, doctrine-consistency) over (a) opt-in declaration + advisory vs (b) query + recipe. It split **2-1 for (b)**.

The decisive argument: **#73's trigger has a conjunct the plugin cannot observe** — "does this module run a commonMain metadata-route processor?". Every existing advisory (#71 inert, #72 native-only-metadata, host, deprecation, empty-overlap) fires from facts the plugin *owns*. A #73 advisory would be the first that fires only because the consumer **declared** the very thing being warned about — tautological — and a consumer disciplined enough to declare a flag can equally write the one-line gate. Per the project's `plugin = mechanism, build-logic = team conventions` doctrine, the "is-a-codegen-module" fact stays in build-logic, which already owns the `registered(KmpTargetSet.native)` primitive (#52) the recipe keys on.

The consumer-ergonomics dissent argued (a) enables a central convention plugin to auto-gate all declaring modules via a queryable accessor — but build-logic can own that marker itself (its own convention extension), reading the plugin's already-public `registered(native)`. The plugin needn't host it.

**Key finding:** direction (b)'s recipe already shipped with the #69/#70 docs work — but it was warn-only and **untested**. So this PR *completes* it.

## Changes

- **`docs/user-guide/recipes.md`** — the "commonMain KSP needs a native target" recipe now warns **and disables** the doomed compilations (the real-world consumer's actual mitigation), explains the K2 no-per-platform-workaround constraint, and reconciles the inert recipe's dangling "Variant" line into a cross-reference.
- **`CommonMainKspGateTest`** — pins the gate predicate `registered(KmpTargetSet.native)` across jvm-only (fires), native-leaf (silent), jvm+web (still fires), and one-way-union-resolves.
- **`CommonMainMetadataCompilationInvariantTest`** — pins the **actual KGP 2.3.21 rule** for `compileCommonMainKotlinMetadata` as a tripwire.
- **`CHANGELOG.md`** — new `### Documentation` entry; no new API.

## Empirical finding (answers open-question #3)

The issue's premise — "the metadata compilation only exists with ≥1 native target" — is **empirically false** for the bare `compileCommonMainKotlinMetadata` in KGP 2.3.21. Measured:

| Selection | `compileCommonMainKotlinMetadata`? | native registered? |
|---|---|---|
| `jvm` (1 target) | ❌ | no |
| `iosArm64` (1 target) | ❌ | **yes** |
| `jvm,js` (2 non-native) | ✅ | **no** |
| `jvm,iosArm64` | ✅ | yes |

The rule is **shared commonMain (≥2 platform targets)**, *not* native presence: `jvm+js` has it with zero native targets, a lone `iosArm64` does not. The native-gating the issue describes is specific to **KSP's** `kspCommonMainKotlinMetadata` route, not KGP's metadata compilation. The recipe therefore gates conservatively on `native` for a native-wired processor, and the invariant test documents the distinction and fails loudly if a KGP bump shifts the rule.

## Open questions — explicit answers

1. **Declaration surface / scope?** None — **no API added**. The unobservable conjunct makes an opt-in declaration tautological; it stays a build-logic concern (and thus doesn't feed #82 doctor output either — there's no plugin-owned fact to render).
2. **Is "≥1 native ⇒ metadata compilation" stable across KGP?** No — it was never the rule for the bare compilation (see table); pinned by `CommonMainMetadataCompilationInvariantTest` as a tripwire.
3. **Relationship to #71/#72?** A distinct, plugin-**unobservable** axis: a jvm-only module that runs a metadata-route processor is **alive, registered, NOT inert (#71), NOT native-only-metadata (#72)** — yet broken. #72's predicate already carries a `registered ≠ ∅` conjunct, so there's no overlap; the boundary is *missing codegen*, not failing metadata.

## Test evidence

`task dod` green (fmt + build + test, including both new in-process tests). The invariant test uses in-process `evaluate()` (no compile → the native leaf is cross-host safe on Linux CI).

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)