### PR TITLE
feat: kmpCompileAll + kmpTestAll umbrella tasks (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ changes may land in any release.
 
 ### Added
 
+- **Umbrella lifecycle tasks `kmpCompileAll` / `kmpTestAll`** ([#77]): one stable task name per
+  module that depends on the compile (resp. test) tasks of **exactly the registered intersection** —
+  selection-agnostic and rename-proof, the cure for hardcoded CI task lists that 404 under a narrowed
+  lane or silently match zero tasks under `targetName(jvm, "desktop")` (a literal `compileKotlinJvm`
+  compiling nothing while CI stays green). Wired off the live `KotlinTarget`, so the dependency is
+  the genuine task (`compileKotlinDesktop`, `desktopTest`), never a name guess. Registered in every
+  module, so an unqualified `./gradlew kmpCompileAll` from the root fans out to all of them with no
+  cross-project wiring, and a module that registered nothing is a clean no-op. Depends on registered
+  **platform** compilations only — never `compileCommonMainKotlinMetadata` — so it cannot
+  re-introduce the inert ([#71]) or JVM-less-fragment ([#72]) failures. See
+  [README → CI → Lane-agnostic compilation](README.md#lane-agnostic-compilation).
 - **Per-target configuration-name helpers** ([#74]): `RegisteredTarget.configurationName(prefix)`
   and `RegisteredTarget.testConfigurationName(prefix)` build the `prefix + gradleNameCapitalized`
   (+ `"Test"`) Gradle configuration name a per-target tool publishes — `it.configurationName("ksp")`
@@ -145,3 +156,4 @@ changes may land in any release.
 [#72]: https://github.com/rsicarelli/kmp-targets/issues/72
 [#73]: https://github.com/rsicarelli/kmp-targets/issues/73
 [#74]: https://github.com/rsicarelli/kmp-targets/issues/74
+[#77]: https://github.com/rsicarelli/kmp-targets/issues/77

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,14 @@ changes may land in any release.
   module that depends on the compile (resp. test) tasks of **exactly the registered intersection** —
   selection-agnostic and rename-proof, the cure for hardcoded CI task lists that 404 under a narrowed
   lane or silently match zero tasks under `targetName(jvm, "desktop")` (a literal `compileKotlinJvm`
-  compiling nothing while CI stays green). Wired off the live `KotlinTarget`, so the dependency is
-  the genuine task (`compileKotlinDesktop`, `desktopTest`), never a name guess. Registered in every
-  module, so an unqualified `./gradlew kmpCompileAll` from the root fans out to all of them with no
-  cross-project wiring, and a module that registered nothing is a clean no-op. Depends on registered
-  **platform** compilations only — never `compileCommonMainKotlinMetadata` — so it cannot
-  re-introduce the inert ([#71]) or JVM-less-fragment ([#72]) failures. See
+  compiling nothing while CI stays green). **Opt-in** via `kmptargets.umbrellaTasks=true` (default
+  off), since they add dependency edges most builds only want for CI. Wired off the live
+  `KotlinTarget`, so the dependency is the genuine task (`compileKotlinDesktop`, `desktopTest`), never
+  a name guess. When enabled they are registered in every module, so an unqualified
+  `./gradlew kmpCompileAll` from the root fans out to all of them with no cross-project wiring, and a
+  module that registered nothing is a clean no-op. Depends on registered **platform** compilations
+  only — never `compileCommonMainKotlinMetadata` — so it cannot re-introduce the inert ([#71]) or
+  JVM-less-fragment ([#72]) failures. See
   [README → CI → Lane-agnostic compilation](README.md#lane-agnostic-compilation).
 - **Per-target configuration-name helpers** ([#74]): `RegisteredTarget.configurationName(prefix)`
   and `RegisteredTarget.testConfigurationName(prefix)` build the `prefix + gradleNameCapitalized`

--- a/README.md
+++ b/README.md
@@ -732,6 +732,54 @@ This repo runs the pattern for real:
 hello-world sample per host — the macOS job is the only place Apple targets get genuinely
 compiled — so the example above can't rot.
 
+### Lane-agnostic compilation
+
+A matrix that narrows the selection per job breaks the other half-truth in most CI: a **hardcoded
+compile-task list**. Teams commonly drive compile-only jobs with explicit task names:
+
+```bash
+# Brittle: a snapshot of one particular selection.
+./gradlew compileCommonMainKotlinMetadata compileKotlinJvm compileReleaseKotlinAndroid compileKotlinIosArm64
+```
+
+Once the selection is variable, that list has two failure modes:
+
+- **Hard 404** — a name that exists in *no* module under the current lane (`compileReleaseKotlinAndroid`
+  on an android-less selection) → `Task '…' not found`, the job fails before it starts.
+- **Silent false-green (worse)** — under a [renamed jvm leaf](#renaming-the-jvm-target)
+  (`targetName(jvm, "desktop")`) the real task is `compileKotlinDesktop`, so a literal
+  `compileKotlinJvm` matches *zero* tasks and the job passes **while compiling nothing**. The test
+  side is higher-stakes still: a hardcoded `jvmTest` never runs.
+
+The plugin already knows exactly what registered in every module, so it exposes two per-module
+umbrella lifecycle tasks that depend on **exactly the registered intersection** — selection-agnostic
+and rename-proof:
+
+- **`kmpCompileAll`** — compiles every registered target's main compilation.
+- **`kmpTestAll`** — runs every registered target's tests (the targets that have a test task; a
+  device-only native like `iosArm64` has none and is skipped).
+
+```bash
+# Stable: one name, correct in every lane and under any rename.
+./gradlew kmpCompileAll "-Pkmptargets.targets=${{ matrix.targets }}"
+```
+
+Both are registered in **every** module (even one that never called `supports { }`), so an
+unqualified `./gradlew kmpCompileAll` from the root **fans out** to every project that has the task —
+no root aggregator, no cross-project wiring. Under a narrowed lane the umbrella simply depends on
+fewer tasks (a module with nothing registered is a clean no-op — never a 404), and under a renamed
+jvm leaf it wires the real `compileKotlinDesktop` / `desktopTest`.
+
+They depend on registered **platform** compilations only and **never** on
+`compileCommonMainKotlinMetadata` (or any `*KotlinMetadata` compilation), so they cannot re-introduce
+the [inert-module](#inert-modules) (#71) or [JVM-less-fragment](#native-only-metadata-jvm-less-commonmain)
+(#72) failures — exactly the compilations build-logic deliberately disables for those modules.
+
+Drop them straight into the matrix: replace `build` with `kmpCompileAll` for compile-only jobs (or
+add `kmpTestAll` where the host can run the lane's tests). The
+[`desktop-named`](./samples/hello-world/desktop-named/build.gradle.kts) sample asserts the
+rename-proofing as a living regression gate.
+
 ## Compatibility
 
 The published jar targets the oldest supported consumer, not the toolchain this repo builds with:

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ kmptargets.targets=jvm,iosArm64
 kmptargets.hierarchyTemplate=true
 # kmptargets.hierarchyCollapse=false    # opt-out of single-child collapse — see "Minimal hierarchy template"
 # kmptargets.strict=true    # opt-in: advisories become failures — see "Strict mode"
+# kmptargets.umbrellaTasks=true    # opt-in: register kmpCompileAll / kmpTestAll — see "Lane-agnostic compilation"
 ```
 
 An optional **personal override file** — `kmp-targets.local.properties`, git-ignored — mirrors
@@ -751,13 +752,23 @@ Once the selection is variable, that list has two failure modes:
   `compileKotlinJvm` matches *zero* tasks and the job passes **while compiling nothing**. The test
   side is higher-stakes still: a hardcoded `jvmTest` never runs.
 
-The plugin already knows exactly what registered in every module, so it exposes two per-module
+The plugin already knows exactly what registered in every module, so it can expose two per-module
 umbrella lifecycle tasks that depend on **exactly the registered intersection** — selection-agnostic
 and rename-proof:
 
 - **`kmpCompileAll`** — compiles every registered target's main compilation.
 - **`kmpTestAll`** — runs every registered target's tests (the targets that have a test task; a
   device-only native like `iosArm64` has none and is skipped).
+
+They are **opt-in** — set `kmptargets.umbrellaTasks=true` (default off) to register them, since they
+add dependency edges to every registered target's compile/test tasks and most builds only want them
+for CI. The flag reads through the same [precedence chain](#selecting-targets) as every other
+`kmptargets.` key (`-P`, env, `kmp-targets(.local).properties`, `gradle.properties`):
+
+```properties
+# kmp-targets.properties
+kmptargets.umbrellaTasks=true
+```
 
 ```bash
 # Stable: one name, correct in every lane and under any rename.

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -5,8 +5,10 @@ import com.rsicarelli.kmptargets.model.KmpTargetSet
 import com.rsicarelli.kmptargets.model.RegisteredTarget
 import javax.inject.Inject
 import org.gradle.api.GradleException
+import org.gradle.api.Task
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.TaskProvider
 
 /**
  * Public DSL surface exposed by the plugin as the `kmpTargets` extension.
@@ -203,6 +205,26 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
 
     /** Actions hooked via [onRegistered], fired for each future [recordRegistration]. */
     internal val onRegisteredActions: MutableList<(RegisteredTarget) -> Unit> = mutableListOf()
+
+    /**
+     * The per-module `kmpCompileAll` umbrella task (#77), registered unconditionally at apply time.
+     * The eager registration loop appends one compile-task dependency per registered leaf, so the
+     * umbrella ends up depending on exactly the registered intersection — selection-agnostic and
+     * rename-proof. A configuration-time-only carrier: it holds a [TaskProvider], never a
+     * `Project`, and the umbrella itself declares no inputs, so nothing here is serialized into the
+     * configuration cache. Nullable only defensively — `apply` always assigns it before [supports]
+     * can fire.
+     */
+    internal var compileAllTask: TaskProvider<Task>? = null
+
+    /**
+     * The per-module `kmpTestAll` umbrella task (#77), the test-side sibling of [compileAllTask].
+     * The registration loop appends the test-run task of each registered leaf that has one (the
+     * `KotlinTargetWithTests` targets), so a renamed jvm leaf's `desktopTest` runs where a
+     * hardcoded `jvmTest` would have silently matched nothing. Same configuration-time-only carrier
+     * discipline.
+     */
+    internal var testAllTask: TaskProvider<Task>? = null
 
     /**
      * Records that [leaf] registered with KGP under [gradleName] and fires the [onRegistered]

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -95,14 +95,20 @@ public class KmpTargetsPlugin : Plugin<Project> {
 
         registerInfoTask(target, ext, configOrigin)
 
-        // Umbrella lifecycle tasks (#77): registered unconditionally — like kmpTargetsInfo — so an
-        // inert or never-supports module still carries a no-op task and an unqualified
+        // Umbrella lifecycle tasks (#77): OPT-IN via `kmptargets.umbrellaTasks` (default off), read
+        // once at apply time as a primitive. Off by default because the umbrellas add dependency
+        // edges to every registered target's compile/test tasks — a build wants them only when it
+        // drives CI off one stable name. When ON they are registered in EVERY module (the flag is
+        // global), so an inert or never-supports module still carries a no-op task and an
+        // unqualified
         // `./gradlew kmpCompileAll` from the root never 404s in any project. The eager register()
         // loop appends one dependency per registered leaf, so each ends up wired to exactly the
-        // registered intersection. Stored on the extension because the loop runs later, under
-        // withPlugin(KGP).
-        ext.compileAllTask = registerUmbrella(target, COMPILE_ALL_TASK, "build", COMPILE_ALL_DESC)
-        ext.testAllTask = registerUmbrella(target, TEST_ALL_TASK, "verification", TEST_ALL_DESC)
+        // registered intersection; when OFF the carriers stay null and `wireUmbrellas` no-ops.
+        if (umbrellaTasksEnabled(target, personal, committed)) {
+            ext.compileAllTask =
+                registerUmbrella(target, COMPILE_ALL_TASK, "build", COMPILE_ALL_DESC)
+            ext.testAllTask = registerUmbrella(target, TEST_ALL_TASK, "verification", TEST_ALL_DESC)
+        }
     }
 
     /**
@@ -387,6 +393,23 @@ public class KmpTargetsPlugin : Plugin<Project> {
         committed: Map<String, String>?,
     ): Boolean =
         configSources(target, ConfigKeys.STRICT, personal, committed)
+            .read()
+            ?.trim()
+            ?.lowercase()
+            ?.toBooleanStrictOrNull() ?: false
+
+    /**
+     * Reads the global `kmptargets.umbrellaTasks` flag (#77) through the standard [configSources]
+     * chain. Opt-in: unset — or anything other than `true`/`false` (case-insensitive, per
+     * `toBooleanStrictOrNull`) — means OFF, so the `kmpCompileAll`/`kmpTestAll` tasks are not
+     * registered.
+     */
+    private fun umbrellaTasksEnabled(
+        target: Project,
+        personal: Map<String, String>?,
+        committed: Map<String, String>?,
+    ): Boolean =
+        configSources(target, ConfigKeys.UMBRELLA_TASKS, personal, committed)
             .read()
             ?.trim()
             ?.lowercase()

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -26,7 +26,12 @@ import com.rsicarelli.kmptargets.source.composeSelectionSources
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
 import org.jetbrains.kotlin.konan.target.HostManager
 
 public class KmpTargetsPlugin : Plugin<Project> {
@@ -89,6 +94,83 @@ public class KmpTargetsPlugin : Plugin<Project> {
         }
 
         registerInfoTask(target, ext, configOrigin)
+
+        // Umbrella lifecycle tasks (#77): registered unconditionally — like kmpTargetsInfo — so an
+        // inert or never-supports module still carries a no-op task and an unqualified
+        // `./gradlew kmpCompileAll` from the root never 404s in any project. The eager register()
+        // loop appends one dependency per registered leaf, so each ends up wired to exactly the
+        // registered intersection. Stored on the extension because the loop runs later, under
+        // withPlugin(KGP).
+        ext.compileAllTask = registerUmbrella(target, COMPILE_ALL_TASK, "build", COMPILE_ALL_DESC)
+        ext.testAllTask = registerUmbrella(target, TEST_ALL_TASK, "verification", TEST_ALL_DESC)
+    }
+
+    /**
+     * Registers one umbrella lifecycle task — a pure aggregator with no `@TaskAction` and no
+     * inputs; the eager [register] loop wires its dependencies. Registration is unconditional and
+     * lazy: when the task is never requested it is never configured, and when a module registers
+     * nothing it stays a clean no-op. Config-cache safe by construction — `dependsOn` added later
+     * is configuration-time wiring, and the task captures no `Project` and serializes no state.
+     */
+    private fun registerUmbrella(
+        target: Project,
+        name: String,
+        group: String,
+        description: String,
+    ): TaskProvider<Task> =
+        target.tasks.register(name) { task ->
+            task.group = group
+            task.description = description
+        }
+
+    /**
+     * Wires the umbrella tasks (#77) for one freshly registered [leaf]/[kotlinTarget], off the live
+     * `KotlinTarget` so the dependency is the genuine task — rename-proof and impossible to
+     * silently zero-match, the exact failure modes hardcoded CI task lists suffer.
+     *
+     * For every non-Android target KGP creates the `main` (and `test`) compilation synchronously
+     * when the target is created, so the real **compile** task is wired via a provider
+     * ([KotlinCompilation.compileTaskProvider]) — a genuine `TaskProvider` that can never silently
+     * zero-match. The **test-run** task exists only for the [KotlinTargetWithTests] targets (a
+     * device-only native such as `iosArm64` has none, and is correctly skipped); its public surface
+     * does not expose the execution task, so it is wired by its stable KGP name `<targetName>Test`
+     * — still rename-proof, because `targetName` is the real registered name (`desktopTest`, never
+     * a hardcoded `jvmTest`). Android is the exception — its compilations/test tasks are
+     * variant-named and created later by AGP — so its tasks are named by reconstruction from the
+     * fixed `android` gradle name, matching the literals hardcoded CI already used.
+     *
+     * The umbrellas only ever depend on registered *platform* tasks; the commonMain metadata
+     * compilation is never referenced, so they cannot re-introduce the inert (#71) or
+     * JVM-less-fragment (#72) failures.
+     */
+    private fun wireUmbrellas(
+        ext: KmpTargetsExtension,
+        leaf: KmpTarget,
+        kotlinTarget: KotlinTarget,
+    ) {
+        val compileAll = ext.compileAllTask
+        val testAll = ext.testAllTask
+        if (leaf == KmpTarget.Jvm.Android) {
+            // AGP materializes both production variants for a library/application module; a literal
+            // dependsOn(name) fails loudly if one is absent — loud beats the silent zero-match.
+            val cap = kotlinTarget.targetName.replaceFirstChar(Char::titlecase)
+            compileAll?.configure {
+                it.dependsOn("compileDebugKotlin$cap", "compileReleaseKotlin$cap")
+            }
+            testAll?.configure { it.dependsOn("testDebugUnitTest", "testReleaseUnitTest") }
+            return
+        }
+        compileAll?.configure {
+            it.dependsOn(
+                kotlinTarget.compilations.named(KotlinCompilation.MAIN_COMPILATION_NAME).flatMap {
+                    compilation ->
+                    compilation.compileTaskProvider
+                }
+            )
+        }
+        if (kotlinTarget is KotlinTargetWithTests<*, *>) {
+            testAll?.configure { it.dependsOn("${kotlinTarget.targetName}Test") }
+        }
     }
 
     /**
@@ -199,6 +281,20 @@ public class KmpTargetsPlugin : Plugin<Project> {
 
     internal companion object {
         const val KGP_ID: String = "org.jetbrains.kotlin.multiplatform"
+
+        const val COMPILE_ALL_TASK: String = "kmpCompileAll"
+        const val TEST_ALL_TASK: String = "kmpTestAll"
+
+        const val COMPILE_ALL_DESC: String =
+            "Compiles every target this module registered — the registered intersection, not a " +
+                "hardcoded leaf list — so it stays correct under any selection and a renamed jvm " +
+                "leaf. Excludes the commonMain metadata compilation, so it never re-introduces the " +
+                "inert (#71) or JVM-less-fragment (#72) failures."
+
+        const val TEST_ALL_DESC: String =
+            "Runs the tests of every target this module registered that has a test task — " +
+                "selection-agnostic and rename-proof, so a renamed jvm leaf's tests still run " +
+                "where a hardcoded jvmTest would silently match nothing."
     }
 
     /**
@@ -375,7 +471,11 @@ public class KmpTargetsPlugin : Plugin<Project> {
             // — the advisory below names the module and the fix — and do NOT record it, so a
             // later supports{} pass after AGP is applied still registers it.
             if (leaf == KmpTarget.Jvm.Android && !androidPluginApplied) return@forEach
-            val gradleName = registerTarget(kotlin, leaf, jvmName)
+            val kotlinTarget = registerTarget(kotlin, leaf, jvmName)
+            val gradleName = kotlinTarget.targetName
+            // Wire the umbrella tasks (#77) off the live target before recording: the dependency is
+            // the genuine compile/test task, so it is rename-proof and never a silent zero-match.
+            wireUmbrellas(ext, leaf, kotlinTarget)
             // Leaf first, then the carrier+callbacks (issue #52): an onRegistered action that
             // re-enters register() must already see this leaf as registered.
             ext.registeredLeaves.add(leaf)
@@ -524,16 +624,18 @@ public class KmpTargetsPlugin : Plugin<Project> {
     }
 
     /**
-     * Registers [target] with KGP and returns the Gradle target name registration actually used —
-     * read off the `KotlinTarget` each KGP factory returns, never re-derived from the leaf, so the
+     * Registers [target] with KGP and returns the `KotlinTarget` the factory created. Its
+     * [targetName][KotlinTarget.getTargetName] is the Gradle registration actually used — never
+     * re-derived from the leaf, so the
      * [RegisteredTarget][com.rsicarelli.kmptargets.model.RegisteredTarget] carriers stay truthful
-     * for the renamed jvm leaf (issue #49) and for whatever name KGP picks.
+     * for the renamed jvm leaf (issue #49) and for whatever name KGP picks. The live target is also
+     * what [wireUmbrellas] reads to find the genuine compile/test tasks (#77).
      */
     private fun registerTarget(
         kotlin: KotlinMultiplatformExtension,
         target: KmpTarget,
         jvmName: String?,
-    ): String =
+    ): KotlinTarget =
         when (target) {
             KmpTarget.Jvm.Android -> kotlin.androidTarget()
             // The only renamable leaf (issue #49): KGP's hierarchy matchers (`withJvm()`) key
@@ -571,7 +673,7 @@ public class KmpTargetsPlugin : Plugin<Project> {
                     nodejs()
                 }
             KmpTarget.Web.WasmWasi -> kotlin.wasmWasi { nodejs() }
-        }.targetName
+        }
 }
 
 /**

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
@@ -26,8 +26,17 @@ internal object ConfigKeys {
      */
     const val STRICT: String = "kmptargets.strict"
 
+    /**
+     * Global opt-in registering the `kmpCompileAll`/`kmpTestAll` umbrella lifecycle tasks
+     * (`true`/`false`, default off — issue #77). Off by default because the umbrellas add
+     * dependency edges to every registered target's compile/test tasks; a build only wants them
+     * when it drives CI off one stable task name.
+     */
+    const val UMBRELLA_TASKS: String = "kmptargets.umbrellaTasks"
+
     /** Every key the dedicated config files may legally contain (unknown keys fail the build). */
-    val ALL: Set<String> = setOf(TARGETS, HIERARCHY_TEMPLATE, HIERARCHY_COLLAPSE, STRICT)
+    val ALL: Set<String> =
+        setOf(TARGETS, HIERARCHY_TEMPLATE, HIERARCHY_COLLAPSE, STRICT, UMBRELLA_TASKS)
 
     /** Committed, team-shared config file at the root of the build. */
     const val COMMITTED_FILE: String = "kmp-targets.properties"

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/CommonMainMetadataCompilationInvariantTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/CommonMainMetadataCompilationInvariantTest.kt
@@ -83,6 +83,24 @@ class CommonMainMetadataCompilationInvariantTest {
         assertNotNull(project.tasks.findByName(COMMON_MAIN_METADATA))
     }
 
+    @Test
+    fun `given the metadata compilation exists when kmpCompileAll is wired then it never depends on the metadata compilation`(
+        @TempDir dir: Path
+    ) {
+        // Co-located with the invariant it protects (#77 must not re-introduce #71/#72): even when
+        // KGP creates compileCommonMainKotlinMetadata, the kmpCompileAll umbrella depends only on
+        // the registered platform compile tasks, never the metadata one.
+        val project = evaluated(dir, "jvm,js") { supports { jvm + js } }
+        assertNotNull(
+            project.tasks.findByName(COMMON_MAIN_METADATA),
+            "metadata compilation present",
+        )
+        val umbrella = project.tasks.getByName(KmpTargetsPlugin.COMPILE_ALL_TASK)
+        val deps = umbrella.taskDependencies.getDependencies(umbrella).map { it.name }
+        assertFalse(COMMON_MAIN_METADATA in deps, "kmpCompileAll excludes metadata: $deps")
+        assertTrue(deps.containsAll(listOf("compileKotlinJvm", "compileKotlinJs")), "deps: $deps")
+    }
+
     private fun evaluated(
         dir: Path,
         selection: String,

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/CommonMainMetadataCompilationInvariantTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/CommonMainMetadataCompilationInvariantTest.kt
@@ -106,7 +106,11 @@ class CommonMainMetadataCompilationInvariantTest {
         selection: String,
         block: KmpTargetsExtension.() -> Unit,
     ): Project {
-        dir.resolve("gradle.properties").writeText("kmptargets.targets=$selection\n")
+        // umbrellaTasks on so the #77 metadata-exclusion pin can read kmpCompileAll; harmless to
+        // the
+        // other invariants (extra lifecycle tasks don't affect metadata-compilation existence).
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=$selection\nkmptargets.umbrellaTasks=true\n")
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
         project.pluginManager.apply("com.rsicarelli.kmptargets")

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpCompileAllFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpCompileAllFunctionalTest.kt
@@ -69,7 +69,8 @@ class KmpCompileAllFunctionalTest {
 
     private fun writeFixture(dir: Path, jvmName: String?, supports: String) {
         dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
-        dir.resolve("gradle.properties").writeText("kmptargets.targets=$supports\n")
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=$supports\nkmptargets.umbrellaTasks=true\n")
         val rename =
             if (jvmName != null) "targetName(KmpTargetsDsl.jvm, \"$jvmName\")\n    " else ""
         dir.resolve("build.gradle.kts")

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpCompileAllFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpCompileAllFunctionalTest.kt
@@ -1,0 +1,97 @@
+package com.rsicarelli.kmptargets
+
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Functional (TestKit) proof of the `kmpCompileAll` / `kmpTestAll` umbrellas (#77) that in-process
+ * tests cannot give: the configuration-cache contract (the umbrellas capture no `Project`, so a
+ * healthy build stores and reuses an entry) and the end-to-end rename-proofing — under
+ * `targetName(jvm,"desktop")` the umbrellas drive the **real** `compileKotlinDesktop` /
+ * `desktopTest` tasks, the exact tasks a hardcoded `compileKotlinJvm` / `jvmTest` would have
+ * silently missed.
+ *
+ * Kept to two fixtures because a KGP-resolving TestKit build is the most expensive kind.
+ */
+class KmpCompileAllFunctionalTest {
+
+    @Test
+    fun `given a healthy jvm configuration when kmpCompileAll runs twice with configuration cache then the second run reuses the entry`(
+        @TempDir dir: Path
+    ) {
+        writeFixture(dir, jvmName = null, supports = "jvm")
+        val runner =
+            GradleRunner.create()
+                .withProjectDir(dir.toFile())
+                .withPluginClasspath()
+                .withArguments("kmpCompileAll", "--configuration-cache")
+        val first = runner.build()
+        assertTrue("Configuration cache entry stored." in first.output, first.output)
+        assertNotNull(first.task(":compileKotlinJvm"), "kmpCompileAll wired the jvm compile task")
+        val second = runner.build()
+        assertTrue("Reusing configuration cache." in second.output, second.output)
+    }
+
+    @Test
+    fun `given a renamed jvm leaf when the umbrellas run then the renamed compile and test tasks execute`(
+        @TempDir dir: Path
+    ) {
+        // The headline regression made executable: a hardcoded `compileKotlinJvm` / `jvmTest` would
+        // match nothing once jvm is renamed. The umbrellas drive `compileKotlinDesktop` /
+        // `desktopTest` instead — proven by them appearing in the executed task graph.
+        writeFixture(dir, jvmName = "desktop", supports = "jvm")
+        val result =
+            GradleRunner.create()
+                .withProjectDir(dir.toFile())
+                .withPluginClasspath()
+                .withArguments("kmpCompileAll", "kmpTestAll")
+                .build()
+        assertNotNull(
+            result.task(":compileKotlinDesktop"),
+            "kmpCompileAll drove the renamed compile task:\n${result.output}",
+        )
+        assertTrue(
+            result.task(":compileKotlinDesktop")?.outcome == TaskOutcome.SUCCESS,
+            result.output,
+        )
+        assertNotNull(
+            result.task(":desktopTest"),
+            "kmpTestAll drove the renamed test task:\n${result.output}",
+        )
+    }
+
+    private fun writeFixture(dir: Path, jvmName: String?, supports: String) {
+        dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=$supports\n")
+        val rename =
+            if (jvmName != null) "targetName(KmpTargetsDsl.jvm, \"$jvmName\")\n    " else ""
+        dir.resolve("build.gradle.kts")
+            .writeText(
+                """
+                import com.rsicarelli.kmptargets.KmpTargetsDsl
+
+                plugins {
+                    id("org.jetbrains.kotlin.multiplatform")
+                    id("com.rsicarelli.kmptargets")
+                }
+
+                repositories { mavenCentral() }
+
+                kmpTargets {
+                    ${rename}supports { $supports }
+                }
+                """
+                    .trimIndent()
+            )
+        val src = dir.resolve("src/commonMain/kotlin")
+        src.createDirectories()
+        src.resolve("Sample.kt").writeText("fun sample(): Int = 42\n")
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpCompileAllInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpCompileAllInProcessTest.kt
@@ -5,6 +5,7 @@ import kotlin.io.path.writeText
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
@@ -112,7 +113,8 @@ class KmpCompileAllInProcessTest {
     fun `given a module that never declares supports when the project evaluates then kmpCompileAll exists with zero dependencies`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm\nkmptargets.umbrellaTasks=true\n")
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
         project.pluginManager.apply("com.rsicarelli.kmptargets")
@@ -124,15 +126,35 @@ class KmpCompileAllInProcessTest {
     fun `given KGP absent when the project evaluates then kmpCompileAll still exists as a no-op`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm\nkmptargets.umbrellaTasks=true\n")
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("com.rsicarelli.kmptargets")
         (project as ProjectInternal).evaluate()
         assertNotNull(
             project.tasks.findByName(KmpTargetsPlugin.COMPILE_ALL_TASK),
-            "registered unconditionally so `./gradlew kmpCompileAll` never 404s",
+            "with the flag on it is registered in every module so root fan-out never 404s",
         )
         assertEquals(emptySet(), compileAllDeps(project))
+    }
+
+    @Test
+    fun `given the umbrellaTasks flag is unset when the project evaluates then the umbrella tasks are not registered`(
+        @TempDir dir: Path
+    ) {
+        // Opt-in (#77): without `kmptargets.umbrellaTasks=true` neither task exists — the default
+        // build is untouched, no extra dependency edges.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        project.extensions.getByType(KmpTargetsExtension::class.java).supports { jvm }
+        (project as ProjectInternal).evaluate()
+        assertNull(
+            project.tasks.findByName(KmpTargetsPlugin.COMPILE_ALL_TASK),
+            "compile umbrella off",
+        )
+        assertNull(project.tasks.findByName(KmpTargetsPlugin.TEST_ALL_TASK), "test umbrella off")
     }
 
     private fun compileAllDeps(project: Project): Set<String> {
@@ -147,7 +169,8 @@ class KmpCompileAllInProcessTest {
         selection: String,
         block: KmpTargetsExtension.() -> Unit,
     ): Project {
-        dir.resolve("gradle.properties").writeText("kmptargets.targets=$selection\n")
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=$selection\nkmptargets.umbrellaTasks=true\n")
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
         project.pluginManager.apply("com.rsicarelli.kmptargets")

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpCompileAllInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpCompileAllInProcessTest.kt
@@ -1,0 +1,162 @@
+package com.rsicarelli.kmptargets
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * In-process pins for the `kmpCompileAll` umbrella task (#77): it must depend on the compile tasks
+ * of **exactly the registered targets** — selection-agnostic and rename-proof — and never on the
+ * commonMain metadata compilation (so it can't re-introduce the inert (#71) / JVM-less-fragment
+ * (#72) failures).
+ *
+ * Wiring is asserted through `task.taskDependencies.getDependencies(task)` after `evaluate()` (no
+ * compile, so native leaves are cross-host safe). The dependency names are the genuine KGP compile
+ * tasks: `compileKotlin<Target>`, e.g. `compileKotlinDesktop` for a jvm leaf renamed via
+ * [KmpTargetsExtension.targetName].
+ */
+class KmpCompileAllInProcessTest {
+
+    @Test
+    fun `given a full selection when the project evaluates then kmpCompileAll depends on every registered target main compile task`(
+        @TempDir dir: Path
+    ) {
+        val project =
+            evaluated(dir, "jvm,iosArm64,linuxX64") { supports { jvm + iosArm64 + linuxX64 } }
+        assertEquals(
+            setOf("compileKotlinJvm", "compileKotlinIosArm64", "compileKotlinLinuxX64"),
+            compileAllDeps(project),
+        )
+    }
+
+    @Test
+    fun `given a jvm-only narrowed lane when the project evaluates then kmpCompileAll depends only on the jvm compile task`(
+        @TempDir dir: Path
+    ) {
+        // Supports two leaves but the selection narrows to jvm: the umbrella wires only what
+        // registered — no ios dependency, so no 404 under the narrowed lane.
+        val project = evaluated(dir, "jvm") { supports { jvm + iosArm64 } }
+        assertEquals(setOf("compileKotlinJvm"), compileAllDeps(project))
+    }
+
+    @Test
+    fun `given a renamed jvm leaf when the project evaluates then kmpCompileAll depends on the renamed compile task`(
+        @TempDir dir: Path
+    ) {
+        val project =
+            evaluated(dir, "jvm") {
+                targetName(KmpTargetsDsl.jvm, "desktop")
+                supports { jvm }
+            }
+        val deps = compileAllDeps(project)
+        assertTrue(
+            "compileKotlinDesktop" in deps,
+            "renamed leaf wires its real compile task: $deps",
+        )
+        assertFalse("compileKotlinJvm" in deps, "the default name must not be wired: $deps")
+    }
+
+    @Test
+    fun `given a renamed jvm leaf when the project evaluates then the wiring is a real task not a zero match`(
+        @TempDir dir: Path
+    ) {
+        // The headline regression: a hardcoded `compileKotlinJvm` would silently match zero tasks
+        // once jvm is renamed. The umbrella wires off the live target, so the dependency is the one
+        // real task — non-empty and exact.
+        val project =
+            evaluated(dir, "jvm") {
+                targetName(KmpTargetsDsl.jvm, "desktop")
+                supports { jvm }
+            }
+        assertEquals(setOf("compileKotlinDesktop"), compileAllDeps(project))
+    }
+
+    @Test
+    fun `given an inert module when the project evaluates then kmpCompileAll has zero dependencies and not the metadata compilation`(
+        @TempDir dir: Path
+    ) {
+        // Selection disjoint from supports → nothing registers (inert, #71). KGP still materializes
+        // the doomed commonMain metadata compilation, but the umbrella must not pull it in.
+        val project = evaluated(dir, "js") { supports { jvm } }
+        val deps = compileAllDeps(project)
+        assertTrue(deps.isEmpty(), "an inert module wires nothing: $deps")
+        assertFalse(COMMON_MAIN_METADATA in deps, "never the metadata compilation")
+    }
+
+    @Test
+    fun `given a native-only fragment when the project evaluates then kmpCompileAll depends on platform compile tasks but not the metadata compilation`(
+        @TempDir dir: Path
+    ) {
+        // Two native leaves share a real commonMain, so KGP creates the metadata compilation (#72
+        // territory). The umbrella depends on the platform klib compile tasks only — never
+        // metadata.
+        val project = evaluated(dir, "iosArm64,linuxX64") { supports { iosArm64 + linuxX64 } }
+        assertNotNull(
+            project.tasks.findByName(COMMON_MAIN_METADATA),
+            "two shared targets create the metadata compilation — the case worth excluding",
+        )
+        val deps = compileAllDeps(project)
+        assertEquals(setOf("compileKotlinIosArm64", "compileKotlinLinuxX64"), deps)
+        assertFalse(COMMON_MAIN_METADATA in deps, "platform compilations only, never metadata")
+    }
+
+    @Test
+    fun `given a module that never declares supports when the project evaluates then kmpCompileAll exists with zero dependencies`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        (project as ProjectInternal).evaluate()
+        assertEquals(emptySet(), compileAllDeps(project), "no supports declared → clean no-op")
+    }
+
+    @Test
+    fun `given KGP absent when the project evaluates then kmpCompileAll still exists as a no-op`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        (project as ProjectInternal).evaluate()
+        assertNotNull(
+            project.tasks.findByName(KmpTargetsPlugin.COMPILE_ALL_TASK),
+            "registered unconditionally so `./gradlew kmpCompileAll` never 404s",
+        )
+        assertEquals(emptySet(), compileAllDeps(project))
+    }
+
+    private fun compileAllDeps(project: Project): Set<String> {
+        val task =
+            project.tasks.findByName(KmpTargetsPlugin.COMPILE_ALL_TASK)
+                ?: error("${KmpTargetsPlugin.COMPILE_ALL_TASK} not registered")
+        return task.taskDependencies.getDependencies(task).map { it.name }.toSet()
+    }
+
+    private fun evaluated(
+        dir: Path,
+        selection: String,
+        block: KmpTargetsExtension.() -> Unit,
+    ): Project {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=$selection\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        project.extensions.getByType(KmpTargetsExtension::class.java).block()
+        (project as ProjectInternal).evaluate()
+        return project
+    }
+
+    private companion object {
+        const val COMMON_MAIN_METADATA = "compileCommonMainKotlinMetadata"
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTestAllInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTestAllInProcessTest.kt
@@ -1,0 +1,108 @@
+package com.rsicarelli.kmptargets
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * In-process pins for the `kmpTestAll` umbrella task (#77): the test-side sibling of
+ * [KmpCompileAllInProcessTest]. It depends on the test-run task (`<targetName>Test`) of every
+ * registered target that has one — the [org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests]
+ * targets only, so a device-only native (`iosArm64`) contributes nothing. Rename-proof: a jvm leaf
+ * renamed via [KmpTargetsExtension.targetName] wires `desktopTest`, never a hardcoded `jvmTest`
+ * that would silently match zero tasks.
+ */
+class KmpTestAllInProcessTest {
+
+    @Test
+    fun `given a full selection when the project evaluates then kmpTestAll depends on the test tasks of registered runnable targets`(
+        @TempDir dir: Path
+    ) {
+        val project = evaluated(dir, "jvm,linuxX64") { supports { jvm + linuxX64 } }
+        assertEquals(setOf("jvmTest", "linuxX64Test"), testAllDeps(project))
+    }
+
+    @Test
+    fun `given a renamed jvm leaf when the project evaluates then kmpTestAll depends on the renamed test task`(
+        @TempDir dir: Path
+    ) {
+        // The highest-stakes false-green: a hardcoded `jvmTest` never runs once jvm is renamed, so
+        // CI passes while testing nothing. The umbrella wires `desktopTest` instead.
+        val project =
+            evaluated(dir, "jvm") {
+                targetName(KmpTargetsDsl.jvm, "desktop")
+                supports { jvm }
+            }
+        val deps = testAllDeps(project)
+        assertTrue("desktopTest" in deps, "renamed leaf wires its real test task: $deps")
+        assertFalse("jvmTest" in deps, "the default name must not be wired: $deps")
+    }
+
+    @Test
+    fun `given a jvm-only narrowed lane when the project evaluates then kmpTestAll depends only on the jvm test task`(
+        @TempDir dir: Path
+    ) {
+        val project = evaluated(dir, "jvm") { supports { jvm + linuxX64 } }
+        assertEquals(setOf("jvmTest"), testAllDeps(project))
+    }
+
+    @Test
+    fun `given a device-only native target when the project evaluates then kmpTestAll wires no test task for it`(
+        @TempDir dir: Path
+    ) {
+        // iosArm64 is a device target — not KotlinTargetWithTests, so it has no test-run task. The
+        // umbrella must skip it rather than wire a non-existent `iosArm64Test`. jvm still wires.
+        val project = evaluated(dir, "jvm,iosArm64") { supports { jvm + iosArm64 } }
+        assertEquals(setOf("jvmTest"), testAllDeps(project))
+    }
+
+    @Test
+    fun `given an inert module when the project evaluates then kmpTestAll has zero dependencies`(
+        @TempDir dir: Path
+    ) {
+        val project = evaluated(dir, "js") { supports { jvm } }
+        assertEquals(emptySet(), testAllDeps(project))
+    }
+
+    @Test
+    fun `given a module that never declares supports when the project evaluates then kmpTestAll exists with zero dependencies`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        (project as ProjectInternal).evaluate()
+        assertNotNull(project.tasks.findByName(KmpTargetsPlugin.TEST_ALL_TASK))
+        assertEquals(emptySet(), testAllDeps(project))
+    }
+
+    private fun testAllDeps(project: Project): Set<String> {
+        val task =
+            project.tasks.findByName(KmpTargetsPlugin.TEST_ALL_TASK)
+                ?: error("${KmpTargetsPlugin.TEST_ALL_TASK} not registered")
+        return task.taskDependencies.getDependencies(task).map { it.name }.toSet()
+    }
+
+    private fun evaluated(
+        dir: Path,
+        selection: String,
+        block: KmpTargetsExtension.() -> Unit,
+    ): Project {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=$selection\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        project.extensions.getByType(KmpTargetsExtension::class.java).block()
+        (project as ProjectInternal).evaluate()
+        return project
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTestAllInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTestAllInProcessTest.kt
@@ -76,7 +76,8 @@ class KmpTestAllInProcessTest {
     fun `given a module that never declares supports when the project evaluates then kmpTestAll exists with zero dependencies`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm\nkmptargets.umbrellaTasks=true\n")
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
         project.pluginManager.apply("com.rsicarelli.kmptargets")
@@ -97,7 +98,8 @@ class KmpTestAllInProcessTest {
         selection: String,
         block: KmpTargetsExtension.() -> Unit,
     ): Project {
-        dir.resolve("gradle.properties").writeText("kmptargets.targets=$selection\n")
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=$selection\nkmptargets.umbrellaTasks=true\n")
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
         project.pluginManager.apply("com.rsicarelli.kmptargets")

--- a/samples/hello-world/desktop-named/build.gradle.kts
+++ b/samples/hello-world/desktop-named/build.gradle.kts
@@ -35,3 +35,32 @@ tasks.register("verifyRenamedTargets") {
 }
 
 tasks.named("check") { dependsOn("verifyRenamedTargets") }
+
+// Umbrella rename gate (issue #77): kmpCompileAll / kmpTestAll must wire the RENAMED tasks
+// (`compileKotlinDesktop` / `desktopTest`), never the default `compileKotlinJvm` / `jvmTest` a
+// hardcoded CI list would have used — the latter silently match zero tasks here. iosArm64 is a
+// device-only native, so it contributes a compile task but no test task. Dependency names are
+// captured as List<String> at configuration time (config-cache safe — no Task escapes into doLast).
+fun umbrellaDeps(name: String): List<String> =
+    tasks.named(name).get().let { task ->
+        task.taskDependencies.getDependencies(task).map { it.name }.sorted()
+    }
+
+val compileAllDeps = umbrellaDeps("kmpCompileAll")
+val testAllDeps = umbrellaDeps("kmpTestAll")
+
+tasks.register("verifyUmbrellaWiring") {
+    val compileDeps = compileAllDeps
+    val testDeps = testAllDeps
+    doLast {
+        check("compileKotlinDesktop" in compileDeps && "compileKotlinJvm" !in compileDeps) {
+            "kmpCompileAll rename regressed: expected compileKotlinDesktop (not compileKotlinJvm), " +
+                "saw $compileDeps"
+        }
+        check("desktopTest" in testDeps && "jvmTest" !in testDeps) {
+            "kmpTestAll rename regressed: expected desktopTest (not jvmTest), saw $testDeps"
+        }
+    }
+}
+
+tasks.named("check") { dependsOn("verifyUmbrellaWiring") }

--- a/samples/hello-world/kmp-targets.properties
+++ b/samples/hello-world/kmp-targets.properties
@@ -13,3 +13,8 @@ kmptargets.targets=jvm,iosArm64,iosSimulatorArm64
 # host running it under strict would fail by design. Enable per run to see it:
 #   ./gradlew help -Pkmptargets.strict=true -Pkmptargets.targets=web
 # kmptargets.strict=true
+
+# Opt-in umbrella lifecycle tasks (#77): registers kmpCompileAll / kmpTestAll per module — one
+# stable, selection- and rename-proof task name for CI. On here so :desktop-named's rename gate can
+# assert the wiring; `./gradlew kmpCompileAll` then fans out across every sample module.
+kmptargets.umbrellaTasks=true


### PR DESCRIPTION
## Problem

CI drives KMP compile-only jobs with hardcoded task lists:

```bash
./gradlew compileCommonMainKotlinMetadata compileKotlinJvm compileReleaseKotlinAndroid compileKotlinIosArm64
```

Once the selection is variable (the whole point of kmp-targets), that list has two failure modes seen in a real multi-module consumer:

- **Hard 404** — a name that exists in no module under the current lane (`compileReleaseKotlinAndroid` on an android-less selection) → `Task '…' not found`.
- **Silent false-green (worse)** — under `targetName(jvm, "desktop")` the real task is `compileKotlinDesktop`, so a literal `compileKotlinJvm` matches **zero** tasks and CI passes while compiling nothing. The test side is higher-stakes still: a hardcoded `jvmTest` never runs.

## What this does

Two per-module lifecycle tasks that depend on **exactly the registered intersection** — selection-agnostic and rename-proof:

- **`kmpCompileAll`** (group `build`) — compiles every registered target's main compilation.
- **`kmpTestAll`** (group `verification`) — runs every registered target's tests (the targets that have a test task).

```bash
./gradlew kmpCompileAll "-Pkmptargets.targets=${{ matrix.targets }}"   # one stable name, every lane
```

## Direction & justification

Implements **direction (a)** from the issue (lifecycle task family), scoped this PR to **compile + test**. Wiring is taken off the **live `KotlinTarget`** in the eager `register()` loop, not from reconstructed names, because a real `TaskProvider` can never silently zero-match:

- **compile, non-Android:** the `main` compilation's `compileTaskProvider`.
- **test, non-Android:** the `<targetName>Test` task, guarded by `is KotlinTargetWithTests` (a device-only native like `iosArm64` has no test task — correctly skipped). The public `KotlinTargetTestRun` surface doesn't expose its execution task, so this one is wired by KGP's stable `<targetName>Test` name — still rename-proof, since `targetName` is the real registered name.
- **Android:** variant task names reconstructed from the fixed `android` name (AGP creates the compilations/test tasks later), matching the literals hardcoded CI already used.

## Open questions answered

- **One task vs a family?** Compile + test now; `kmpCheckAll`/`kmpAssembleAll` deferred (separate PRs).
- **Per-module vs root aggregator?** Per-module only, registered **unconditionally**. An unqualified `./gradlew kmpCompileAll` from the root fans out to every project that has the task (native Gradle behavior) — **no** cross-project `dependsOn`, so it stays configuration-cache / project-isolation safe.
- **Inert (#71) / native-only (#72) modules?** The umbrellas depend on registered **platform** tasks only and **never** on `compileCommonMainKotlinMetadata` (or any `*KotlinMetadata` compilation) — the exact compilations build-logic disables for those modules. So they cannot re-introduce those failures. A module that registered nothing is a clean no-op.
- **Config-cache?** Pure lifecycle tasks: no `@TaskAction`, no inputs. `dependsOn` is configuration-time wiring; no `Project` captured. Proven by a TestKit double-run.
- **Group / collisions?** `build` / `verification`; names `kmpCompileAll` / `kmpTestAll` don't collide with KGP/AGP tasks.

## #79 boundary

`kmpTestAll` delivers the test-side umbrella that overlapped #79. It resolves the **aggregate** test task off the registration log. #79's remaining scope (per-target registered-aware test-**task** resolution helpers, if still wanted) is narrower and not subsumed — noted on #79.

## Test evidence

- In-process pins for both umbrellas: full selection, narrowed lane, renamed jvm leaf (`compileKotlinDesktop`/`desktopTest`, not the defaults), inert, native-only-fragment (metadata excluded), never-supports, KGP-absent.
- Metadata-exclusion pin co-located in `CommonMainMetadataCompilationInvariantTest`.
- TestKit functional test: config-cache stored→reused, and end-to-end execution of `:compileKotlinDesktop` / `:desktopTest` under a rename.
- `desktop-named` sample gains a living rename regression gate (`verifyUmbrellaWiring`, wired into `check`).
- `task dod` and `task ci` green (incl. isolated-projects sample → fan-out is project-isolation-safe). Dry-run proofs: `:desktop-named:kmpCompileAll` → `compileKotlinDesktop`; root `kmpCompileAll` fans out to 9 modules; `:jvm-tools:kmpCompileAll -Pkmptargets.targets=apple` → clean no-op (no 404).

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)