### PR TITLE
docs: selection vs the dependency graph — android→jvm fallback rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,22 @@ changes may land in any release.
 
 ### Documentation
 
+- **Selection vs the dependency graph — the android→jvm fallback rule** ([#80]). Selection is
+  resolved per module, but its *validity* can depend on the cross-module dependency graph: an
+  android-leaning module that consumes a `jvm`+native-only library resolves against that library's
+  **jvm fallback** variant, so a pure-`android` selection — which strips `jvm` from every producer —
+  removes the variant the android modules were resolving against. The failure surfaces as Gradle's
+  raw attribute-resolution wall of text on a `compileDependencyFiles` configuration, with no hint
+  the selection is the cause; the fix is to keep `jvm` **co-selected** (`kmptargets.targets=android,jvm`).
+  **No new API, by feasibility, not omission**: an accurate in-code closure check would have to read
+  peer projects' registered sets at configuration time — forbidden by the plugin's
+  configuration-cache and Isolated-Projects guarantees — and the canonical trigger is *external*
+  published libraries the plugin cannot model one-module-at-a-time. So the deliverable is docs: the
+  [recipe](docs/user-guide/recipes.md) gains the asymmetric android→jvm case,
+  [troubleshooting](docs/help/troubleshooting.md) gains a `compileDependencyFiles` row, and the
+  closure analysis is deferred to a future doctor mode ([#82]). Adjacent hygiene: the
+  [advisories](docs/user-guide/advisories.md) page now documents the **native-only-metadata**
+  advisory ([#72]) and counts six advisories, not five.
 - **commonMain-KSP-needs-a-native-target recipe, hardened** ([#73]). A processor that generates
   into `commonMain` runs on the shared commonMain metadata route (`kspCommonMainKotlinMetadata`),
   which KSP only wires when the selection registers a **native** target — so a native-less lane
@@ -159,3 +175,5 @@ changes may land in any release.
 [#73]: https://github.com/rsicarelli/kmp-targets/issues/73
 [#74]: https://github.com/rsicarelli/kmp-targets/issues/74
 [#77]: https://github.com/rsicarelli/kmp-targets/issues/77
+[#80]: https://github.com/rsicarelli/kmp-targets/issues/80
+[#82]: https://github.com/rsicarelli/kmp-targets/issues/82

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -35,6 +35,7 @@ First move for anything selection-shaped: **[`kmpTargetsInfo`](../user-guide/kmp
 | Symptom | Cause | Fix |
 |---|---|---|
 | Variant-resolution wall of text on an inter-module dependency | dependency's supported set doesn't cover a target the dependent builds | check both modules with `kmpTargetsInfo`; widen the dependency's `supports { }` ([recipe](../user-guide/recipes.md#selection-vs-the-dependency-graph)) |
+| Variant-resolution wall of text on a `compileDependencyFiles` config after narrowing to `android`-only | android consumers were resolving against producers' **jvm fallback** variant; a pure-`android` selection dropped it | co-select `jvm` with `android` (`kmptargets.targets=android,jvm`) ([recipe](../user-guide/recipes.md#the-asymmetric-case-android-and-the-jvm-fallback)) |
 | Unresolved `expect` after narrowing to one iOS leaf | minimal template collapsed the single-child `iosMain` your sources live in | [no-collapse mode](../user-guide/no-collapse-mode.md) |
 | iOS compile/link fails on a Linux/Windows runner | host can't compile the registered Apple target — registration is host-blind | per-host selections ([CI matrix](../user-guide/ci-matrix.md)); the [host advisory](../user-guide/advisories.md#host-compatibility) names the mismatch |
 | CI job fails at configuration with an advisory's text | [strict mode](../user-guide/advisories.md#strict-mode) promotes advisories to failures | that's the point — fix the flagged configuration, or scope strict to lanes the host can fully compile |

--- a/docs/user-guide/advisories.md
+++ b/docs/user-guide/advisories.md
@@ -1,6 +1,6 @@
 # Advisories & Strict Mode
 
-The plugin emits five configuration-time advisories. Four are **signal only — never filtering**; one (android-without-AGP) genuinely skips a leaf because the alternative is a raw KGP crash. [Strict mode](#strict-mode) promotes all five to build failures with identical message text.
+The plugin emits six configuration-time advisories. Five are **signal only — never filtering**; one (android-without-AGP) genuinely skips a leaf because the alternative is a raw KGP crash. [Strict mode](#strict-mode) promotes all six to build failures with identical message text.
 
 ## Host compatibility
 
@@ -62,9 +62,23 @@ if (kmpTargets.registered().isEmpty()) {
 
 A module that **never calls** `supports { }` registers nothing *by definition* and is deliberately not flagged — that's the explicit-selection baseline, not the trap. A later `supports { }` union that registers a leaf un-inerts the module permanently.
 
+## Native-only metadata
+
+The consequence sibling of the inert trap, for a module that is *alive* but lopsided. A module that **supports** the JVM family yet, under this selection, registers no JVM-family leaf while registering at least one other target gets a JVM-less shared `commonMain`:
+
+```
+kmp-targets: ':shared' supports the JVM family but this selection registered no JVM-family
+target while other targets did — commonMain is now a JVM-less shared fragment. The platform
+klibs compile, but the *KotlinMetadata* compilations reject JVM-flavored constructs (e.g.
+@JvmInline): klibs build, metadata fails. Gate it in build-logic when
+kmpTargets.registered(jvmFamily).isEmpty(), disabling only the *KotlinMetadata* compilations.
+```
+
+The failure is paradoxical: every platform klib compiles, but the `*KotlinMetadata*` compilations reject JVM-flavored constructs (`@JvmInline` is the greppable token — named so a user arriving from the raw compiler error finds this advisory). Signal only, and **cause-agnostic**: a narrowed lane and an android-only [AGP skip](#android-target-without-agp) fire it alike, so it deliberately names neither the selection nor the supported set. It is **disjoint** from the inert advisory — inert means *registered empty*, this means *registered non-empty but no JVM-family leaf*; at most one fires per module. Any single JVM-family leaf (`jvm` **or** `androidTarget` — Android is a JVM platform) defeats it. The gate it points at is the *scoped* sibling of inert's: disable only the metadata compilations, keep the live platform ones. See [Gate compilation on inert modules](recipes.md#gate-compilation-on-inert-modules) for the build-logic shape.
+
 ## Strict mode
 
-By default all five advisories are warnings — right for local iteration, easy to miss in CI, where a module silently building nothing is usually a real configuration bug.
+By default all six advisories are warnings — right for local iteration, easy to miss in CI, where a module silently building nothing is usually a real configuration bug.
 
 `kmptargets.strict=true` promotes them to configuration-time **build failures** (`GradleException`) with the **identical message text** — severity changes, policy does not. It never changes *which* configurations are flagged and never changes *what registers* (the AGP skip happens with or without strict). Default **off**, deliberately. The flag resolves through the same [precedence chain](selection-layers.md) as every `kmptargets.*` key; anything other than `true`/`false` (case-insensitive) is treated as unset.
 

--- a/docs/user-guide/recipes.md
+++ b/docs/user-guide/recipes.md
@@ -69,6 +69,25 @@ Avoid hardcoding per-target task names (`:m:iosArm64Test`) in CI scripts: they b
 
 Selection is **per-module**, intersected per-module. If `:app` supports `jvm + iosArm64` and depends on `:lib` that only supports `jvm`, an `iosArm64` build of `:app` fails at *variant resolution* — `:lib` has no iOS variant to offer. The error is KGP's wall of text, but the cause is set arithmetic: **a module's supported set must cover every target its dependents build**. Check both sides with `kmpTargetsInfo` and widen `:lib`'s `supports { }` (or narrow `:app`'s).
 
+### The asymmetric case: android and the jvm fallback
+
+The same set arithmetic has a subtler form that bites at scale, and it is the single hardest selection failure to diagnose. An android-leaning module depends on a library that ships only `jvm` + native variants and **no `androidTarget`** — common for pure-Kotlin libraries that never opted into Android. That build still works, because Gradle resolves the android consumer against the library's **`jvm` variant** as a fallback. The android module was relying on the jvm variant all along, even though nobody wrote it down.
+
+Now narrow the selection to pure `android` (`kmptargets.targets=android`). Every producer that *supported* `jvm` now registers no jvm target — and the jvm variant the android consumers were falling back to is gone. The edge no longer resolves. The rule:
+
+> **An android consumer can be satisfied by a producer's `jvm` variant (the jvm fallback). A pure-`android` selection that strips `jvm` from those producers removes the variant the android modules were resolving against.**
+
+The symptom is unhelpful: Gradle's raw attribute-resolution wall of text on a **`compileDependencyFiles`** configuration (`*CompileDependencyFiles`), listing producer variants and consumer attributes, with **no hint that the selection is the cause**. If you arrived here from that error, the fix is one line — keep `jvm` **co-selected** with `android`:
+
+```properties
+kmptargets.targets=android,jvm
+```
+
+(or any preset that includes both). The jvm variant the android modules fall back to then still registers on every producer, and the edges resolve again. For a large android repo this is usually what you actually want: `android,jvm`, not bare `android`.
+
+!!! note "The plugin cannot detect this for you"
+    Selection is resolved one module at a time, so this conflict is **invisible to the plugin by construction** — and it usually originates in **external published libraries** (the `jvm`-only producers), which the plugin cannot model at all. `kmpTargetsInfo` on a producer confirms it lost its `jvm` leaf under the current selection, but you reason about the closure across the graph yourself. A future [doctor mode](https://github.com/rsicarelli/kmp-targets/issues/82) may surface project-edge closure gaps; it can never see external-dependency variants, so co-selecting `jvm` remains the rule.
+
 ## Binary-compatibility validator + selection
 
 BCV writes one ABI dump per target. A narrowed lane that runs `apiCheck`/`apiDump` sees only the registered subset — committing dumps from a narrowed lane deletes the other targets' dumps. Rule: **run BCV tasks only from a full-selection lane** (`kmptargets.targets=all` or your repo's full set), and gate `apiDump` in CI to that lane.


### PR DESCRIPTION
## Problem

Selection in `kmp-targets` is resolved **per module**, but its *validity* can depend on the **cross-module dependency graph**. The canonical case (a ~95-module consumer): android-leaning modules consume libraries that ship only `jvm`+native variants and rely on Gradle resolving the android consumer to the library's **jvm fallback variant**. Under a pure-`android` selection those producers register no `jvm` target → the jvm variant disappears and the edge no longer resolves. The symptom is Gradle's raw attribute-resolution wall of text on a `compileDependencyFiles` configuration, with **no hint that the selection is the cause** or that **co-selecting `jvm` is the fix**. The plugin sees one module at a time, so this is invisible to it by construction.

#80 seeded a design exploration of three directions: (a) root closure-report task, (b) per-module advisory, (c) docs / failure-time augmentation.

## Feasibility analysis (the heart of this PR)

Two of the plugin's own **shipped guarantees** are binding constraints, and they rule out the in-code directions:

1. **Configuration-cache safety** — never resolve configurations at config time, never capture `Project`.
2. **Isolated Projects** — `samples/isolated-projects/` is an *executable guard*: any cross-project reach fails configuration and reddens CI. The plugin touches only the project it's applied to today.

Verified construction-by-construction that **no accurate in-code closure check is buildable** without breaking these:

- **(a) root reader / (b) accurate per-module** need each producer's `registered()`/`resolvedSupported()`, which lives on the *peer* project's extension → reading it cross-project is exactly what IP forbids.
- **Settings plugin** sees the module graph but not per-project `supports { }`/selection (config-time facts) → insufficient.
- **Shared BuildService** fails on cross-project config *ordering* (a peer may not have registered yet) and on IP isolation of the service itself.
- **ValueSource** isolates external I/O, not peer in-memory models → wrong tool.
- The one **IP-legal construction** (per-project primitive emitters + an *execution-time* file aggregator) still **cannot see external published libraries** — the actual trigger — so it doesn't solve #80.
- The **android→jvm fallback rule** can't be captured by a naive static supported-set closure; it must be hardcoded and even then only approximates Gradle's attribute matching and only covers `project(...)` edges.

## Decision: ship docs, defer the in-code diagnostic

Scope A. We convert the opaque variant wall-of-text into a **named symptom with a one-line fix** (`kmptargets.targets=android,jvm`). Scope B (opt-in root report gated off under IP) was rejected: untestable in the flagship IP sample, blind to the external deps that cause the issue, and false-positive-prone on the hardcoded fallback rule.

### False-positive honesty / IP handling

Zero false positives, by design — there is no automated check. The docs are explicit that the plugin **cannot** detect this (invisible by construction; usually external deps it can't model), and the closure analysis is deferred to a future **doctor mode (#82)** with its permanent limits stated.

## Changes (docs-only — no plugin API, no code, no new tests)

- **`docs/user-guide/recipes.md`** — new "The asymmetric case: android and the jvm fallback" subsection: topology, the rule, the greppable `compileDependencyFiles` symptom, the `android,jvm` fix, and an honesty note.
- **`docs/help/troubleshooting.md`** — a matching Building row.
- **`docs/user-guide/advisories.md`** (adjacent hygiene) — documents the previously-undocumented **native-only-metadata** advisory (#72) and fixes the count five → six.
- **`CHANGELOG.md`** — Documentation entry + `[#80]`/`[#82]` reference links.

## Test evidence

`task dod` (fmt + build + test) green; pre-commit DoD hook also passed:

```
✓ DOD checks passed
```

Docs-only change ships no cross-module logic, so the samples (hello-world / isolated-projects) are behaviorally unaffected.

Closes #80