### PR TITLE
docs: selection-gated AGP application recipe + enriched android-without-AGP advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,23 @@ changes may land in any release.
 
 ### Documentation
 
+- **Selection-gated eager AGP application — recipe concretized, advisory turned into a discovery
+  vehicle** ([#76]). `androidTarget` registers only when an Android Gradle plugin is applied *before*
+  `supports { }`; applying AGP to every module is expensive, so the canonical pattern gates it on the
+  selection. **No new API, by mechanism-vs-conventions, not omission**: a `whenSelected { }`
+  pre-registration hook would have to fire eagerly at call-site to keep AGP ahead of the eager
+  `register()` — making it behaviorally identical to
+  `if (KmpTarget.Jvm.Android in kmpTargets.resolvedSelection()) { … }` over the existing
+  [`resolvedSelection()`](#52) primitive, with zero added mechanism and a footgun (apply-late) it
+  cannot remove by construction, and the `com.android.application` exemption is a build-logic decision
+  the plugin cannot make one-module-at-a-time. So the deliverable is docs + signal: the
+  [recipe](docs/user-guide/recipes.md#selection-gated-eager-agp-application) now spells out the real
+  `resolvedSelection()` gate, the application-module exemption (an app is always Android — never
+  double-apply or gate it), the apply-before-`supports { }` ordering rule, the **downstream-read
+  gating** (a `namespace`/manifest read crashes under non-Android selections unless guarded by the
+  same predicate), and companion-plugin reactions via `pluginManager.withPlugin(...)`; the
+  android-without-AGP advisory message now appends a one-line selection-gate hint and links that
+  recipe; and [advisories](docs/user-guide/advisories.md#android-target-without-agp) cross-links it.
 - **Selection vs the dependency graph — the android→jvm fallback rule** ([#80]). Selection is
   resolved per module, but its *validity* can depend on the cross-module dependency graph: an
   android-leaning module that consumes a `jvm`+native-only library resolves against that library's
@@ -174,6 +191,7 @@ changes may land in any release.
 [#72]: https://github.com/rsicarelli/kmp-targets/issues/72
 [#73]: https://github.com/rsicarelli/kmp-targets/issues/73
 [#74]: https://github.com/rsicarelli/kmp-targets/issues/74
+[#76]: https://github.com/rsicarelli/kmp-targets/issues/76
 [#77]: https://github.com/rsicarelli/kmp-targets/issues/77
 [#80]: https://github.com/rsicarelli/kmp-targets/issues/80
 [#82]: https://github.com/rsicarelli/kmp-targets/issues/82

--- a/README.md
+++ b/README.md
@@ -496,7 +496,8 @@ plugin **skips registering that leaf** and logs a one-line advisory naming the m
 ```
 kmp-targets: ':feature' selects and supports [androidTarget] but no Android Gradle plugin is
 applied — the target was not registered. Apply com.android.library or com.android.application
-before supports { }.
+before supports { } — gate it on the selection (see
+https://rsicarelli.github.io/kmp-targets/user-guide/recipes/#selection-gated-eager-agp-application).
 ```
 
 This is the one advisory that **does filter**: unlike its siblings, the flagged leaf genuinely does
@@ -511,6 +512,12 @@ plugin that applies AGP after `supports { }` has already missed registration —
 leaf normally. [`kmpTargetsInfo`](#debugging-the-selection) marks the leaf
 `androidTarget (skipped: no Android plugin applied)` in its registered section while the condition
 holds.
+
+To apply AGP only when Android is selected — without paying its configuration cost in every lane —
+gate it on `KmpTarget.Jvm.Android in kmpTargets.resolvedSelection()`, apply **before** `supports { }`,
+exempt `com.android.application` modules (an app is always Android), and guard any downstream
+`android { namespace = … }` read with the same predicate. Full pattern:
+[Selection-gated eager AGP application](https://rsicarelli.github.io/kmp-targets/user-guide/recipes/#selection-gated-eager-agp-application).
 
 ### Inert modules
 

--- a/docs/user-guide/advisories.md
+++ b/docs/user-guide/advisories.md
@@ -33,10 +33,13 @@ Signal only: deprecated leaves stay selectable, stay in every preset, and regist
 ```
 kmp-targets: ':feature' selects and supports [androidTarget] but no Android Gradle plugin is
 applied — the target was not registered. Apply com.android.library or com.android.application
-before supports { }.
+before supports { } — gate it on the selection (see
+https://rsicarelli.github.io/kmp-targets/user-guide/recipes/#selection-gated-eager-agp-application).
 ```
 
 This is the one advisory that **does filter** — the alternative is KGP's raw crash with no module-level guidance, which during build-logic migrations reads as "kmp-targets dropped my target". The fix is an **ordering rule**: apply the Android plugin *before* `supports { }`. A later `supports { }` union re-checks, so AGP applied between two calls lets the later pass register the leaf normally. Everything else registers exactly as selected.
+
+To apply AGP only on Android lanes — without paying its configuration cost in every lane — gate it on the resolved selection: see [Selection-gated eager AGP application](recipes.md#selection-gated-eager-agp-application), which spells out the `KmpTarget.Jvm.Android in resolvedSelection()` gate, the `com.android.application` exemption, and the downstream-read gating the same predicate must guard.
 
 ## Empty overlap
 

--- a/docs/user-guide/recipes.md
+++ b/docs/user-guide/recipes.md
@@ -44,16 +44,45 @@ kmpTargets.onRegistered { add("ksp${it.gradleNameCapitalized}", processorDep) }
 
 ## Selection-gated eager AGP application
 
-`androidTarget` needs AGP applied **before** `supports { }` ([the ordering rule](advisories.md#android-target-without-agp)). A convention can apply AGP only when Android is actually selected, avoiding AGP's configuration cost in non-Android lanes:
+`androidTarget` needs an Android Gradle plugin applied **before** `supports { }` ([the ordering rule](advisories.md#android-target-without-agp)) — `kotlin.androidTarget()` is a hard KGP FATAL without one. Applying AGP to *every* module is expensive (config-time cost plus a swarm of Android tasks/configurations that are meaningless under android-less lanes), so a **library** convention applies it only when Android is actually selected, read straight off [`resolvedSelection()`](build-logic.md):
 
 ```kotlin
-// in the convention plugin, before configuring kmpTargets
-val selectsAndroid = /* read kmptargets.targets via providers and check for android/jvmFamily/mobile */
-if (selectsAndroid) {
+// in the LIBRARY convention plugin, BEFORE the supports { } block
+val androidSelected = KmpTarget.Jvm.Android in kmpTargets.resolvedSelection()
+if (androidSelected) {
     pluginManager.apply("com.android.library")
+    // configure AGP here, between apply and supports { } — also gated (see below)
+    extensions.configure<com.android.build.api.dsl.LibraryExtension> {
+        namespace = "com.example.${project.name}"
+    }
 }
-// note: com.android.application modules apply AGP unconditionally — the app module IS Android
+
+kmpTargets.supports {
+    androidTarget + jvm    // androidTarget registers iff AGP was applied above
+}
 ```
+
+The gate is `KmpTarget.Jvm.Android in resolvedSelection()`, not a preset membership test: `resolvedSelection()` is the same value registration intersects against, so the gate and the eventual registration never disagree.
+
+!!! warning "Apply AGP before `supports { }`, never after"
+    Registration is eager: `supports { }` checks for AGP *at that instant* and [skips `androidTarget`](advisories.md#android-target-without-agp) if it is absent. AGP applied **after** `supports { }` — or in a separate `afterEvaluate` — silently misses registration, and android never appears with no error outside [strict mode](advisories.md#strict-mode). Keep the `apply` above the block. (A later `supports { }` union re-checks, so AGP applied *between* two calls lets the later pass register the leaf — but the one-block form above is the rule.)
+
+!!! warning "Gate downstream AGP reads with the SAME predicate"
+    Any code that reads AGP-owned configuration — `android { namespace = … }`, `compileSdk`/manifest wiring, a `LibraryExtension` lookup — **crashes under a non-Android selection** if it runs unconditionally, because AGP was never applied in that lane. It must sit inside the same `if (androidSelected)` (as above) or be keyed off the same `resolvedSelection()` check. The half-gated state — AGP application gated, but a downstream `android { }` read left ungated — is where real-world partial-selection crashes come from. The gate is not just for the `apply` call; it is for everything that assumes AGP is present.
+
+!!! note "`com.android.application` modules are exempt — do not gate them"
+    An app module **is** Android by definition: AGP arrives from the app's own plugin block (or a `*.application` convention), not from this library gate. Do not apply `com.android.library` to it (double-applying AGP / half-configuring an app module breaks it), and do not put its AGP application behind the selection gate — the app always wants Android. This recipe is for **library** modules whose Android-ness is conditional on the lane.
+
+!!! note "Companion plugins react via `pluginManager.withPlugin`"
+    A plugin that must run only when AGP is present (the Gradle cache-fix plugin is the canonical case) should **react** to AGP rather than re-test the selection — it then stays correct whether AGP came from this gate or from an app's own block:
+
+    ```kotlin
+    pluginManager.withPlugin("com.android.library") {
+        pluginManager.apply("org.gradle.android.cache-fix")
+    }
+    ```
+
+Confirm per lane with [`kmpTargetsInfo`](kmp-targets-info.md): under a non-Android selection it shows no `androidTarget` and AGP is never applied; under an Android lane it shows `androidTarget` registered. There is deliberately **no plugin hook** for this — eager-gating AGP is a one-line `if` over `resolvedSelection()` (the primitive already exists), and the application-vs-library exemption is a build-logic decision the plugin cannot make for you ([#76](https://github.com/rsicarelli/kmp-targets/issues/76)).
 
 ## Lane-agnostic CI invocations
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -761,12 +761,15 @@ internal fun shouldWarnAndroidWithoutAgp(
  * The android-without-AGP advisory (#51). Mirrors its siblings in shape; serves as both the warning
  * and the strict-mode failure text through [warnOrFail]. Unlike them it reports a leaf that was
  * genuinely NOT registered, and names the fix — the ordering rule that the Android plugin must be
- * applied before `supports { }` runs.
+ * applied before `supports { }` runs. The closing clause (#76) makes it the discovery vehicle for
+ * the selection-gated idiom: apply AGP only when android is selected, and link the recipe that
+ * covers the `com.android.application` exemption and the downstream-read traps the gate must guard.
  */
 internal fun androidWithoutAgpWarning(path: String): String =
     "kmp-targets: '$path' selects and supports [androidTarget] but no Android Gradle plugin is " +
         "applied — the target was not registered. Apply com.android.library or " +
-        "com.android.application before supports { }."
+        "com.android.application before supports { } — gate it on the selection " +
+        "(see https://rsicarelli.github.io/kmp-targets/user-guide/recipes/#selection-gated-eager-agp-application)."
 
 /**
  * The deprecated leaves of [active] not yet flagged for this module — the dedup math of the

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AndroidAgpAdvisoryTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AndroidAgpAdvisoryTest.kt
@@ -55,7 +55,7 @@ class AndroidAgpAdvisoryTest {
     }
 
     @Test
-    fun `given a module path when the warning is built then it names the leaf the skip and the fix`() {
+    fun `given a module path when the warning is built then it names the leaf the skip the fix and the recipe`() {
         val message = androidWithoutAgpWarning(":feature")
         assertContains(message, ":feature")
         assertContains(message, "[androidTarget]")
@@ -63,6 +63,13 @@ class AndroidAgpAdvisoryTest {
         assertContains(message, "com.android.library")
         assertContains(message, "com.android.application")
         assertContains(message, "before supports { }")
+        // #76: the message doubles as the discovery vehicle for the selection-gated idiom — it
+        // names the gate and links the recipe that covers the exemption and downstream-read traps.
+        assertContains(message, "gate it on the selection")
+        assertContains(
+            message,
+            "https://rsicarelli.github.io/kmp-targets/user-guide/recipes/#selection-gated-eager-agp-application",
+        )
     }
 
     @Test


### PR DESCRIPTION
## Problem

`androidTarget` registers only when an Android Gradle plugin (AGP) is applied **before** `supports { }` runs — `kotlin.androidTarget()` is a FATAL `AndroidGradlePluginIsMissing` diagnostic otherwise (the #51 advisory). Applying AGP unconditionally to every module is expensive (config-time cost + a swarm of meaningless Android tasks/configs under android-less lanes), so a real ~95-module consumer hand-rolled a gate: apply AGP only when the selection contains android. Issue #76 seeds three directions: (a) a new `whenSelected(leaf){}` pre-registration hook, (b) enrich the #51 advisory, (c) a docs recipe.

## Decision: decline the hook (a), ship (b)+(c) — **zero new API**

A `whenSelected` block that applies AGP **must fire eagerly at call-site**: AGP must precede the eager `register()`, and it cannot defer because the block must also run before the consumer's own `supports { }` and any downstream `android { }` configuration. Eager-at-call-site is behaviorally identical to:

```kotlin
if (KmpTarget.Jvm.Android in kmpTargets.resolvedSelection()) { plugins.apply("com.android.library") }
```

over the `resolvedSelection()` primitive that **already exists**. So the hook would add public surface for **zero new mechanism**, over-fits AGP (its only concrete consumer), and its one differentiating feature — defer the block to remove the apply-late footgun — is structurally impossible here (deferral lands at the same instant `register()` runs, too late for the downstream config it's meant to enable). This matches the repo's #73/#80 *"no new API, by feasibility, not omission"* doctrine: plugin = mechanism, conventions = build-logic.

## Open-question answers

- **Does a dedicated hook over-fit AGP?** Yes. AGP is its only concrete consumer; any shippable `whenSelected` reduces to call-site-eager `if (leaf in resolvedSelection()) { }` with zero added mechanism; the one differentiator (defer to kill apply-late) is structurally impossible.
- **Ordering contract vs a later `defaultSelection`?** `resolvedSelection()` (= `globalSelection ?: defaultSelection.get()`) is authoritative the instant it's read. The contract: set `defaultSelection` (if at all) before you read it to gate AGP, and read it before `supports { }`. This window is **identical** for a hook and the raw `if` — both funnel through the same getter — so it's a property of the primitive, not something a hook fixes or worsens.
- **Should anything know the `com.android.application` exemption?** No — firmly convention territory. The plugin can't distinguish a library that should gate AGP from an app that must not; that lives in *which convention a module applies*. The plugin's only (correct) AGP awareness is the reactive `isAndroidPluginApplied` check, which already treats app and library AGP ids identically.

## Changes

- **Advisory message** (`KmpTargetsPlugin.kt`): append a terse selection-gate clause + recipe URL, turning the advisory into the discovery vehicle. Kept short — the string doubles as the strict-mode failure text. (+2 exact-string asserts, red→green.)
- **Recipe** (`docs/user-guide/recipes.md`): replace the hand-wave placeholder with the real pattern — the `KmpTarget.Jvm.Android in resolvedSelection()` gate, apply-before-`supports { }` ordering rule, **downstream-read gating** warning (a `namespace`/manifest read crashes under non-Android selections unless guarded by the same predicate), the `com.android.application` exemption (an app is always Android — never double-apply/gate), and companion-plugin `pluginManager.withPlugin(...)` reactions.
- **Cross-links**: bidirectional `advisories.md` ↔ recipe; README pointer + message sync; CHANGELOG `Documentation` entry.

## Test evidence

`task dod` (ktfmt + build + test) green; the pre-commit hook re-ran it on commit and passed.

The advisory message is covered by the enriched exact-string test (`AndroidAgpAdvisoryTest`). **Limitation, stated deliberately**: the *with-AGP* recipe path ("androidTarget actually registers when real AGP precedes `supports { }`") is not automatable — AGP is not on the test classpath and the hello-world sample has no Android module; proving it would require adding AGP + an Android SDK to CI, out of scope. The enriched exact-string assertion is the only new automated coverage.

Closes #76