### PR TITLE
feat: kmpTargetsDoctor — explain why a module is inert and what was disabled (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ changes may land in any release.
 
 ### Added
 
+- **Doctor mode — `kmpTargetsDoctor`** ([#82], closes [#80]): a per-module *triage* report (group
+  `help`) that complements the neutral `kmpTargetsInfo` state dump. It renders one `[!]` block per
+  active advisory — cause → effect → fix — for inert ([#71]), JVM-less metadata ([#72]),
+  android-without-AGP ([#51]), host-impossible ([#32]), deprecated ([#43]) and empty-overlap
+  ([#10]); a clean bill when healthy; and an intentional-silence note for a module that never called
+  `supports { }`. **Doctor renders, it does not own predicates**: every finding is wired from the
+  same decision function the advisory uses, so it can never re-detect or drift. It also flags
+  **project-edge closure gaps** ([#80]) — a `project(...)` dependency that registers none of the
+  leaves this module needs — via a companion `kmpTargetsDoctorData` emitter whose file dependents
+  consume through a lenient artifact view (file-only, never a peer `Project` read, so it is
+  configuration-cache- and **Isolated Projects**-safe). Two honest, permanent limits, printed
+  inline: no external-dependency coverage, and an approximate android→jvm fallback — best-effort
+  project-edge diagnostics, not a correctness guarantee. See
+  [Doctor mode](https://rsicarelli.github.io/kmp-targets/user-guide/doctor-mode/).
 - **Umbrella lifecycle tasks `kmpCompileAll` / `kmpTestAll`** ([#77]): one stable task name per
   module that depends on the compile (resp. test) tasks of **exactly the registered intersection** —
   selection-agnostic and rename-proof, the cure for hardcoded CI task lists that 404 under a narrowed
@@ -180,8 +194,11 @@ changes may land in any release.
   the POM stops declaring a toolchain-version stdlib. A new `verifyCompatFloors` task guards the
   floors on every `check`.
 
+[#10]: https://github.com/rsicarelli/kmp-targets/issues/10
 [#30]: https://github.com/rsicarelli/kmp-targets/issues/30
 [#31]: https://github.com/rsicarelli/kmp-targets/issues/31
+[#32]: https://github.com/rsicarelli/kmp-targets/issues/32
+[#43]: https://github.com/rsicarelli/kmp-targets/issues/43
 [#48]: https://github.com/rsicarelli/kmp-targets/issues/48
 [#49]: https://github.com/rsicarelli/kmp-targets/issues/49
 [#50]: https://github.com/rsicarelli/kmp-targets/issues/50

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Docs](https://img.shields.io/badge/docs-rsicarelli.github.io%2Fkmp--targets-blue)](https://rsicarelli.github.io/kmp-targets/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-**Status:** alpha (pre-1.0). Shipped and exercised by the multi-module sample plus a real 3-OS CI matrix: the global selector with [try-import-style layering](#selecting-targets) (dedicated config files, unified `kmptargets.*` keys), the automatic [minimal hierarchy template](#minimal-hierarchy-template), the [`kmpTargetsInfo`](#debugging-the-selection) introspection task, [host-compatibility](#host-compatibility), [deprecated-target](#deprecated-targets), [android-without-AGP](#android-target-without-the-android-gradle-plugin), [inert-module](#inert-modules), and [native-only-metadata](#native-only-metadata-jvm-less-commonmain) advisories, and opt-in [strict mode](#strict-mode). Roadmap: user-defined hierarchy groups, XCFramework helpers.
+**Status:** alpha (pre-1.0). Shipped and exercised by the multi-module sample plus a real 3-OS CI matrix: the global selector with [try-import-style layering](#selecting-targets) (dedicated config files, unified `kmptargets.*` keys), the automatic [minimal hierarchy template](#minimal-hierarchy-template), the [`kmpTargetsInfo`](#debugging-the-selection) introspection task, [`kmpTargetsDoctor`](#doctor-mode) diagnostics, [host-compatibility](#host-compatibility), [deprecated-target](#deprecated-targets), [android-without-AGP](#android-target-without-the-android-gradle-plugin), [inert-module](#inert-modules), and [native-only-metadata](#native-only-metadata-jvm-less-commonmain) advisories, and opt-in [strict mode](#strict-mode). Roadmap: user-defined hierarchy groups, XCFramework helpers.
 
 `kmp-targets` is a Gradle plugin for Kotlin Multiplatform projects that lets each developer (and each CI runner) choose which KMP targets to build, via a single Gradle property:
 
@@ -325,6 +325,37 @@ host cannot compile** are marked `iosArm64 (not compilable on this host: LINUX_X
 source as the [host compatibility](#host-compatibility) advisory), and vocabulary leaves Kotlin
 [marks deprecated](https://kotlinlang.org/docs/native-target-support.html) carry `(deprecated)` —
 so the copy-paste surface itself tells you what to avoid adopting.
+
+### Doctor mode
+
+Where `kmpTargetsInfo` is the neutral state dump, `kmpTargetsDoctor` (group `help`) is the **triage**
+surface — "what's wrong, why, and how do I fix it?". It renders one `[!]` block per active advisory
+(cause → effect → fix), a clean bill when healthy, and a **project-edge closure** check across
+`project(...)` dependencies:
+
+```console
+$ ./gradlew :feature-mobile:kmpTargetsDoctor -q
+
+kmp-targets doctor — :feature-mobile
+
+[!] inert module
+    why:    declared supports { } but registered zero targets
+    effect: KGP still materializes the commonMain metadata compilation, which fails with no platform targets
+    fix:    gate on registered().isEmpty() in build-logic
+
+Project-edge closure (project dependencies only)
+[!] :feature-mobile → :core-jvm
+    missing: iosArm64 — the dependency registers none of these leaves this module needs
+    fix:     widen :core-jvm's supports { } (or the selection) to register them
+  limits: external (non-project) dependencies are invisible; the android→jvm fallback is approximate
+```
+
+Doctor **renders, it does not own predicates** — every finding is keyed off the same decision the
+advisory uses, so it can never drift. The closure check crosses the project boundary by **file,
+never a peer `Project` read** (a per-module `kmpTargetsDoctorData` emitter the dependents consume),
+so it stays configuration-cache- and **Isolated Projects**-safe. Two honest, permanent limits,
+printed inline: no external-dependency coverage, and an approximate android→jvm fallback — see the
+[Doctor mode guide](https://rsicarelli.github.io/kmp-targets/user-guide/doctor-mode/).
 
 ### Supported targets
 

--- a/docs/user-guide/advisories.md
+++ b/docs/user-guide/advisories.md
@@ -2,6 +2,9 @@
 
 The plugin emits six configuration-time advisories. Five are **signal only — never filtering**; one (android-without-AGP) genuinely skips a leaf because the alternative is a raw KGP crash. [Strict mode](#strict-mode) promotes all six to build failures with identical message text.
 
+!!! tip "See the same findings explained, with fixes"
+    [`kmpTargetsDoctor`](doctor-mode.md) renders each advisory below as a `[!]` finding (cause → effect → fix) plus a project-edge closure check — the triage surface for when a build broke and you want *why*.
+
 ## Host compatibility
 
 The registered set is **host-blind by design**: selecting `iosArm64` registers it on macOS, Linux, and Windows alike, so configuration-cache keys, task graphs, and published metadata stay identical across CI agents. But not every host can *compile* every native target. When the selection includes a native target the current host can't compile, the plugin warns — and **still registers it**:

--- a/docs/user-guide/doctor-mode.md
+++ b/docs/user-guide/doctor-mode.md
@@ -1,0 +1,79 @@
+# Doctor mode
+
+`kmpTargetsInfo` is a neutral *state dump* — "what did the plugin decide?". `kmpTargetsDoctor` is the *triage* surface — **"what's wrong, why, and how do I fix it?"**. Every project the plugin is applied to gets a `kmpTargetsDoctor` task (group `help`):
+
+```bash
+./gradlew :feature-mobile:kmpTargetsDoctor -q
+```
+
+A healthy module reports a clean bill:
+
+```console
+kmp-targets doctor — :jvm-tools
+
+✓ clean bill of health — registered: jvm
+```
+
+A module that hit a trap gets one `[!]` block per finding — the cause, the effect, and the remedy:
+
+```console
+kmp-targets doctor — :jvm-tools
+
+[!] selection matches nothing supported
+    why:    the selection iosArm64 matches none of the supported set jvm
+    effect: this module registers no targets
+    fix:    widen the selection or this module's supports { } so they overlap
+
+[!] inert module
+    why:    declared supports { } but registered zero targets
+    effect: KGP still materializes the commonMain metadata compilation, which fails with no platform targets
+    fix:    gate on registered().isEmpty() in build-logic
+```
+
+## What it explains
+
+Doctor **renders, it does not own predicates**: every finding is keyed off the *same* decision the matching [advisory](advisories.md) uses, so the report can never disagree with what actually happened. It just explains it where you start debugging, with the fix attached.
+
+| Finding | The trap it explains |
+|---|---|
+| `selection matches nothing supported` | [empty overlap](advisories.md#empty-overlap) — a typo'd or over-narrow lane |
+| `inert module` | [inert module (#71)](advisories.md#inert-modules) — zero registrations, doomed commonMain metadata compilation |
+| `JVM-less commonMain` | [native-only metadata (#72)](advisories.md#native-only-metadata) — `@JvmInline` rejected while klibs compile |
+| `androidTarget skipped` | [android without AGP (#51)](advisories.md#android-target-without-agp) — the leaf that didn't register |
+| `not compilable on this host` | [host compatibility (#32)](advisories.md#host-compatibility) — registered, but this host can't build it |
+| `deprecated targets registered` | [deprecated targets (#43)](advisories.md#deprecated-targets) |
+| `note: jvm (registered as: …)` | the leaf registered under a [custom name](jvm-rename.md) — context, not a problem |
+
+For the commonMain-KSP-needs-a-native-target trap there is intentionally **no finding**: its trigger ("does this module run a commonMain metadata-route processor?") has a conjunct the plugin cannot observe, so it stays a build-logic [recipe](recipes.md#commonmain-ksp-needs-a-native-target) gating on `registered(KmpTargetSet.native).isEmpty()` — not something doctor can detect.
+
+## Project-edge closure
+
+Beyond the single module, doctor flags **project-edge closure gaps** (the failure described in [Selection vs the dependency graph](recipes.md#selection-vs-the-dependency-graph)): a `project(...)` dependency that registers none of the leaves this module needs, so this module's compilations for those leaves can't resolve the dependency's artifacts.
+
+```console
+kmp-targets doctor — :app-mobile
+
+✓ clean bill of health — registered: iosArm64, jvm
+
+Project-edge closure (project dependencies only)
+[!] :app-mobile → :lib-jvm
+    missing: iosArm64 — the dependency registers none of these leaves this module needs
+    fix:     widen :lib-jvm's supports { } (or the selection) to register them
+  limits: external (non-project) dependencies are invisible; the android→jvm fallback is approximate
+```
+
+This crosses the project boundary by **file, never by reading a peer project's model** — each module emits its own primitives via `kmpTargetsDoctorData`, and the dependent resolves those files through a lenient artifact view. That keeps it [configuration-cache](../user-guide/selection-layers.md) and **Isolated Projects** safe; it runs unchanged under `org.gradle.unsafe.isolated-projects=true`.
+
+!!! warning "Two permanent limits — best-effort, not a correctness guarantee"
+    1. **No external-dependency coverage.** Doctor sees only `project(...)` edges. The canonical android→jvm-fallback pain comes from **external** `jvm`-only libraries, which it cannot model at all — so co-selecting `jvm` with `android` ([the rule](recipes.md#the-asymmetric-case-android-and-the-jvm-fallback)) remains the real fix.
+    2. **The android→jvm fallback is approximate.** Doctor hardcodes "an `androidTarget` consumer is satisfied by a `jvm`-only producer" — it only approximates Gradle's real attribute matching, not reproduces it.
+
+## Properties of the task
+
+- **Read-only** — like `kmpTargetsInfo`, it never registers targets; running it cannot change the build.
+- **Configuration-cache compatible** — the second run is a cache hit.
+- **Per-module** — run it on the module you're diagnosing (`:feature-mobile:kmpTargetsDoctor`).
+- **Runs even when the module is inert** — KGP logs its own "No Kotlin Targets Declared" error, but doctor still prints the explanation of *why*.
+
+!!! tip
+    Reach for `kmpTargetsInfo` to see *what* the plugin decided; reach for `kmpTargetsDoctor` when a build broke and you want *why*, the consequence, and the fix in one cached run.

--- a/docs/user-guide/kmp-targets-info.md
+++ b/docs/user-guide/kmp-targets-info.md
@@ -55,3 +55,7 @@ The lists carry markers the plain names can't:
 
 !!! tip
     `kmpTargetsInfo` is the first move whenever a selection surprises you — it answers both "what won?" and "why is this module empty?" in one cached run.
+
+## See also: doctor mode
+
+`kmpTargetsInfo` is the neutral state dump. When a build actually *broke* and you want the cause, consequence, and fix in one place — plus a project-edge closure check across `project(...)` dependencies — reach for [`kmpTargetsDoctor`](doctor-mode.md).

--- a/docs/user-guide/recipes.md
+++ b/docs/user-guide/recipes.md
@@ -114,8 +114,8 @@ kmptargets.targets=android,jvm
 
 (or any preset that includes both). The jvm variant the android modules fall back to then still registers on every producer, and the edges resolve again. For a large android repo this is usually what you actually want: `android,jvm`, not bare `android`.
 
-!!! note "The plugin cannot detect this for you"
-    Selection is resolved one module at a time, so this conflict is **invisible to the plugin by construction** — and it usually originates in **external published libraries** (the `jvm`-only producers), which the plugin cannot model at all. `kmpTargetsInfo` on a producer confirms it lost its `jvm` leaf under the current selection, but you reason about the closure across the graph yourself. A future [doctor mode](https://github.com/rsicarelli/kmp-targets/issues/82) may surface project-edge closure gaps; it can never see external-dependency variants, so co-selecting `jvm` remains the rule.
+!!! note "What the plugin can and cannot detect for you"
+    Selection is resolved one module at a time, and this conflict usually originates in **external published libraries** (the `jvm`-only producers), which the plugin cannot model at all. [Doctor mode](doctor-mode.md#project-edge-closure) surfaces the **`project(...)`-edge** form of this gap — a sibling module that stopped registering a leaf its dependents need — but by construction it can never see external-dependency variants, so co-selecting `jvm` remains the rule. `kmpTargetsInfo` on a producer confirms it lost its `jvm` leaf under the current selection.
 
 ## Binary-compatibility validator + selection
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -1,5 +1,7 @@
 package com.rsicarelli.kmptargets
 
+import com.rsicarelli.kmptargets.doctor.KmpTargetsDoctorDataTask
+import com.rsicarelli.kmptargets.doctor.KmpTargetsDoctorTask
 import com.rsicarelli.kmptargets.hierarchy.computeHierarchySpec
 import com.rsicarelli.kmptargets.hierarchy.resolveHierarchyCollapseEnabled
 import com.rsicarelli.kmptargets.hierarchy.resolveHierarchyTemplateEnabled
@@ -27,6 +29,9 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
@@ -94,6 +99,7 @@ public class KmpTargetsPlugin : Plugin<Project> {
         }
 
         registerInfoTask(target, ext, configOrigin)
+        registerDoctorTask(target, ext)
 
         // Umbrella lifecycle tasks (#77): OPT-IN via `kmptargets.umbrellaTasks` (default off), read
         // once at apply time as a primitive. Off by default because the umbrellas add dependency
@@ -207,69 +213,22 @@ public class KmpTargetsPlugin : Plugin<Project> {
             task.presetNames.set(presetNames)
             task.leafIds.set(KmpTarget.all.map { it.id }.sorted())
             task.deprecatedIds.set(KmpTarget.deprecated.map { it.id }.sorted())
-            task.selectionIds.set(target.provider { ids(ext.resolvedSelection()) })
-            task.supportedIds.set(target.provider { ids(ext.resolvedSupported()) })
-            task.supportsDeclared.set(target.provider { ext.supportsProperty.isPresent })
-            task.registeredIds.set(
-                target.provider { ids(ext.resolvedSelection() intersect ext.resolvedSupported()) }
-            )
-            // Host annotations (#44): same decision source as the host advisory, but guarded by a
-            // runtime KGP check INSIDE the provider — one wiring path that degrades to empty
-            // without KGP, and `HostManager` (touched only in host/HostCompatibility.kt bodies)
-            // never classloads on that branch. `hasPlugin` is read at provider realization
-            // (task-graph calc, post-body), so KGP applied after this plugin still counts.
-            task.hostImpossibleIds.set(
-                target.provider {
-                    if (!target.pluginManager.hasPlugin(KGP_ID)) emptyList()
-                    else
-                        hostImpossibleIds(
-                            ext.resolvedSelection() intersect ext.resolvedSupported(),
-                            currentHostEnabled(),
-                        )
-                }
-            )
-            task.hostLabel.set(
-                target.provider {
-                    if (!target.pluginManager.hasPlugin(KGP_ID)) "" else currentHostLabel()
-                }
-            )
-            // The rename annotation (issue #49) reads lazily for the same post-body reason as the
-            // selection providers: the body sets `targetName(...)` before `supports { }`.
-            task.jvmRegisteredAs.set(target.provider { ext.jvmTargetName.orNull })
-            // Android-skip annotation (#51): same decision source as the advisory
-            // (`shouldWarnAndroidWithoutAgp`), realized lazily post-body and guarded by the same
-            // runtime KGP check as the host data — without KGP nothing registers, so there is no
-            // skip to report. AGP presence is read at provider realization, so AGP applied
-            // anywhere in the body still counts.
-            task.androidWithoutAgp.set(
-                target.provider {
-                    target.pluginManager.hasPlugin(KGP_ID) &&
-                        shouldWarnAndroidWithoutAgp(
-                            ext.resolvedSelection() intersect ext.resolvedSupported(),
-                            isAndroidPluginApplied(target),
-                        )
-                }
-            )
-            // Inert annotation (#71): same decision source as the advisory
-            // (`shouldWarnInertModule` over `registered()`), realized lazily post-body and guarded
-            // by the same runtime KGP check as the host data — without KGP no metadata compilation
-            // exists, so there is no trap to report.
-            task.inertModule.set(
-                target.provider {
-                    target.pluginManager.hasPlugin(KGP_ID) &&
-                        shouldWarnInertModule(ext.supportsProperty.isPresent, ext.registered())
-                }
-            )
-            // Native-only-metadata annotation (#72): same decision source as the advisory
-            // (`shouldWarnNativeOnlyMetadata` over `resolvedSupported()`/`registered()`), realized
-            // lazily post-body and guarded by the same runtime KGP check — without KGP nothing
-            // registers, so no JVM-less fragment exists and there is no trap to report.
-            task.nativeOnlyMetadata.set(
-                target.provider {
-                    target.pluginManager.hasPlugin(KGP_ID) &&
-                        shouldWarnNativeOnlyMetadata(ext.resolvedSupported(), ext.registered())
-                }
-            )
+            // Every diagnostic primitive comes from the shared builders below `registerDoctorTask`,
+            // wired IDENTICALLY into this neutral state dump and the doctor triage report — same
+            // decision functions (`shouldWarnInertModule` etc.), same KGP guards realized at
+            // provider time (post-body). One source means the two surfaces can never drift, and
+            // neither re-detects. The registered line here is the abstract `selection ∩ supported`;
+            // doctor renders the concrete `registered()`.
+            task.selectionIds.set(selectionIdsProvider(target, ext))
+            task.supportedIds.set(supportedIdsProvider(target, ext))
+            task.supportsDeclared.set(supportsDeclaredProvider(target, ext))
+            task.registeredIds.set(intersectionIdsProvider(target, ext))
+            task.hostImpossibleIds.set(hostImpossibleIdsProvider(target, ext))
+            task.hostLabel.set(hostLabelProvider(target))
+            task.jvmRegisteredAs.set(jvmRegisteredAsProvider(target, ext))
+            task.androidWithoutAgp.set(androidWithoutAgpProvider(target, ext))
+            task.inertModule.set(inertModuleProvider(target, ext))
+            task.nativeOnlyMetadata.set(nativeOnlyMetadataProvider(target, ext))
             // The config-layer origin is fixed at apply time, but the fallback labels must read
             // `defaultSelection` lazily — the body may override it after apply.
             task.originLabel.set(
@@ -285,8 +244,199 @@ public class KmpTargetsPlugin : Plugin<Project> {
         }
     }
 
+    /**
+     * Registers the doctor surfaces (#82): `kmpTargetsDoctor` — the per-project triage report that
+     * *explains* why a module is inert or had targets disabled and flags project-edge closure gaps
+     * — plus `kmpTargetsDoctorData`, the per-project emitter whose file dependent modules consume
+     * for that closure check.
+     *
+     * Doctor renders, it does not own predicates: every single-module property is wired from the
+     * same shared `…Provider` builders `kmpTargetsInfo` uses, so it can never re-detect or drift.
+     *
+     * The closure half (#80) is the only cross-module piece, and it crosses the boundary by FILE,
+     * never by peer `Project` model — the IP-legal construction #80 specified. The producer emits
+     * its own primitives and exposes them as an outgoing artifact on a dedicated consumable
+     * configuration (a unique custom attribute keeps it clear of KGP's variants); the consumer
+     * resolves the doctor-data of its own declared `project(...)` dependencies through a lenient
+     * ArtifactView. Both permanent limits are honest and documented: external (non-`project(...)`)
+     * dependencies are invisible, and the android→jvm fallback only approximates Gradle's attribute
+     * matching.
+     */
+    private fun registerDoctorTask(target: Project, ext: KmpTargetsExtension) {
+        val projectPath = target.path
+        val dataFile = target.layout.buildDirectory.file("kmp-targets/doctor-data.properties")
+
+        // Producer: emit this project's own (path, registered) primitives to a file and expose it
+        // as
+        // an outgoing artifact. The artifact's builtBy gives a dependent's doctor automatic
+        // ordering
+        // on this emit task — no cross-project task wiring at configuration time.
+        val dataTask =
+            target.tasks.register(DOCTOR_DATA_TASK, KmpTargetsDoctorDataTask::class.java) { task ->
+                task.group = "help"
+                task.description =
+                    "Emits this project's kmp-targets doctor-data (path + registered leaves), " +
+                        "consumed by dependent modules' kmpTargetsDoctor closure check."
+                task.projectPath.set(projectPath)
+                task.registeredIds.set(registeredIdsProvider(target, ext))
+                task.outputFile.set(dataFile)
+            }
+        val elements =
+            target.configurations.consumable(DOCTOR_DATA_ELEMENTS) {
+                it.attributes.attribute(DOCTOR_DATA_ATTRIBUTE, DOCTOR_DATA_ATTRIBUTE_VALUE)
+            }
+        target.artifacts.add(elements.name, dataFile) { it.builtBy(dataTask) }
+
+        // Consumer: a resolvable configuration extending a bucket we live-mirror this project's own
+        // declared project(...) dependencies into (config-time, own-project coordinates only — no
+        // afterEvaluate, no peer Project read). The lenient ArtifactView then resolves only the
+        // deps
+        // that expose the doctor-data variant; external and plugin-less deps vanish (limit #1).
+        val closureDeps = target.configurations.dependencyScope(DOCTOR_CLOSURE_DEPS).get()
+        val closure =
+            target.configurations
+                .resolvable(DOCTOR_CLOSURE) {
+                    it.extendsFrom(closureDeps)
+                    it.attributes.attribute(DOCTOR_DATA_ATTRIBUTE, DOCTOR_DATA_ATTRIBUTE_VALUE)
+                }
+                .get()
+        mirrorProjectDependencies(target, closureDeps)
+        val dependencyDataFiles = closure.incoming.artifactView { it.lenient(true) }.files
+
+        target.tasks.register(DOCTOR_TASK, KmpTargetsDoctorTask::class.java) { task ->
+            task.group = "help"
+            task.description =
+                "Explains why this module is inert or had targets disabled, and flags project-edge " +
+                    "closure gaps — the kmp-targets diagnostic report."
+            task.projectPath.set(projectPath)
+            task.supportsDeclared.set(supportsDeclaredProvider(target, ext))
+            task.selectionIds.set(selectionIdsProvider(target, ext))
+            task.supportedIds.set(supportedIdsProvider(target, ext))
+            task.registeredIds.set(registeredIdsProvider(target, ext))
+            task.emptyOverlap.set(emptyOverlapProvider(target, ext))
+            task.inertModule.set(inertModuleProvider(target, ext))
+            task.nativeOnlyMetadata.set(nativeOnlyMetadataProvider(target, ext))
+            task.androidWithoutAgp.set(androidWithoutAgpProvider(target, ext))
+            task.hostImpossibleIds.set(hostImpossibleIdsProvider(target, ext))
+            task.hostLabel.set(hostLabelProvider(target))
+            task.registeredDeprecatedIds.set(registeredDeprecatedIdsProvider(target, ext))
+            task.jvmRegisteredAs.set(jvmRegisteredAsProvider(target, ext))
+            task.dependencyData.from(dependencyDataFiles)
+        }
+    }
+
+    /**
+     * Live-mirrors every `project(...)` dependency this project declares (now or later in the body)
+     * into [closureDeps] as a plain coordinate, so the closure configuration resolves those
+     * dependencies' doctor-data without an `afterEvaluate` and without reading any peer `Project`
+     * model. Deduped by path; our own configurations are skipped so the mirror never feeds itself.
+     */
+    private fun mirrorProjectDependencies(target: Project, closureDeps: Configuration) {
+        val seen = mutableSetOf<String>()
+        target.configurations.all { configuration ->
+            if (configuration.name.startsWith("kmpTargetsDoctor")) return@all
+            configuration.dependencies.all { dependency ->
+                if (dependency is ProjectDependency && seen.add(dependency.path)) {
+                    closureDeps.dependencies.add(
+                        target.dependencies.project(mapOf("path" to dependency.path))
+                    )
+                }
+            }
+        }
+    }
+
+    // ---- Shared diagnostic provider builders (renders, not owns) --------------------------------
+    // One source for each diagnostic primitive, wired identically into kmpTargetsInfo and
+    // kmpTargetsDoctor. Each KGP-guarded provider calls the SAME decision function as its advisory,
+    // realized at provider time (task-graph calc, post-body) so it observes the final state.
+
+    private fun hasKgp(target: Project): Boolean = target.pluginManager.hasPlugin(KGP_ID)
+
+    private fun selectionIdsProvider(target: Project, ext: KmpTargetsExtension) = target.provider {
+        ids(ext.resolvedSelection())
+    }
+
+    private fun supportedIdsProvider(target: Project, ext: KmpTargetsExtension) = target.provider {
+        ids(ext.resolvedSupported())
+    }
+
+    private fun supportsDeclaredProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            ext.supportsProperty.isPresent
+        }
+
+    /** The abstract `selection ∩ supported` (what `kmpTargetsInfo` reports). */
+    private fun intersectionIdsProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            ids(ext.resolvedSelection() intersect ext.resolvedSupported())
+        }
+
+    /** The concrete `registered()` (what doctor reports and the closure check needs). */
+    private fun registeredIdsProvider(target: Project, ext: KmpTargetsExtension) = target.provider {
+        ids(ext.registered())
+    }
+
+    private fun hostImpossibleIdsProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            if (!hasKgp(target)) emptyList()
+            else
+                hostImpossibleIds(
+                    ext.resolvedSelection() intersect ext.resolvedSupported(),
+                    currentHostEnabled(),
+                )
+        }
+
+    private fun hostLabelProvider(target: Project) = target.provider {
+        if (!hasKgp(target)) "" else currentHostLabel()
+    }
+
+    private fun jvmRegisteredAsProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            ext.jvmTargetName.orNull
+        }
+
+    private fun androidWithoutAgpProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            hasKgp(target) &&
+                shouldWarnAndroidWithoutAgp(
+                    ext.resolvedSelection() intersect ext.resolvedSupported(),
+                    isAndroidPluginApplied(target),
+                )
+        }
+
+    private fun inertModuleProvider(target: Project, ext: KmpTargetsExtension) = target.provider {
+        hasKgp(target) && shouldWarnInertModule(ext.supportsProperty.isPresent, ext.registered())
+    }
+
+    private fun nativeOnlyMetadataProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            hasKgp(target) &&
+                shouldWarnNativeOnlyMetadata(ext.resolvedSupported(), ext.registered())
+        }
+
+    private fun emptyOverlapProvider(target: Project, ext: KmpTargetsExtension) = target.provider {
+        hasKgp(target) && shouldWarnEmptyOverlap(ext.resolvedSelection(), ext.resolvedSupported())
+    }
+
+    private fun registeredDeprecatedIdsProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            ids(ext.registered() intersect deprecatedSet)
+        }
+
     internal companion object {
         const val KGP_ID: String = "org.jetbrains.kotlin.multiplatform"
+
+        const val DOCTOR_TASK: String = "kmpTargetsDoctor"
+        const val DOCTOR_DATA_TASK: String = "kmpTargetsDoctorData"
+        const val DOCTOR_DATA_ELEMENTS: String = "kmpTargetsDoctorDataElements"
+        const val DOCTOR_CLOSURE_DEPS: String = "kmpTargetsDoctorClosureDeps"
+        const val DOCTOR_CLOSURE: String = "kmpTargetsDoctorClosure"
+
+        /** Unique attribute the doctor-data variant carries, so it never collides with KGP's. */
+        val DOCTOR_DATA_ATTRIBUTE: Attribute<String> =
+            Attribute.of("com.rsicarelli.kmptargets.doctordata", String::class.java)
+
+        const val DOCTOR_DATA_ATTRIBUTE_VALUE: String = "doctor-data"
 
         const val COMPILE_ALL_TASK: String = "kmpCompileAll"
         const val TEST_ALL_TASK: String = "kmpTestAll"
@@ -861,3 +1011,6 @@ internal fun nativeOnlyMetadataWarning(path: String): String =
         "compilations."
 
 private fun ids(set: KmpTargetSet): List<String> = set.members.map { it.id }.sorted()
+
+/** The deprecated leaves as a set, for doctor's `registered() ∩ deprecated` finding (#43). */
+private val deprecatedSet: KmpTargetSet = KmpTargetSet.of(*KmpTarget.deprecated.toTypedArray())

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/DoctorClosure.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/DoctorClosure.kt
@@ -1,0 +1,69 @@
+package com.rsicarelli.kmptargets.doctor
+
+/**
+ * One project-edge closure gap (#80): a `project(...)` dependency [dependencyPath] of the module
+ * under inspection that registers **none** of the [missingLeafIds] this module needs — so this
+ * module's compilations for those leaves cannot resolve the dependency's artifacts.
+ *
+ * A pure primitive carrier (path + sorted ids), so it threads through the configuration-cache-safe
+ * task boundary and the Gradle-free [formatKmpTargetsDoctor] formatter unchanged.
+ */
+internal data class ClosureGap(val dependencyPath: String, val missingLeafIds: List<String>)
+
+/**
+ * One `project(...)` dependency's emitted doctor-data: its [path] and the leaf ids it actually
+ * registered. Written by `kmpTargetsDoctorData` and read back by the dependent module's doctor —
+ * the only thing that ever crosses the project boundary, as a file (never a peer `Project` model),
+ * which is what keeps the whole closure feature configuration-cache- and Isolated-Projects-safe
+ * (#80).
+ */
+internal data class DoctorData(val path: String, val registeredLeafIds: List<String>)
+
+/** The leaf id of `androidTarget` — the only consumer leaf with a producer fallback (limit #2). */
+private const val ANDROID_ID = "androidTarget"
+
+/** The leaf id of the jvm leaf — `androidTarget`'s fallback producer. */
+private const val JVM_ID = "jvm"
+
+/**
+ * The project-edge closure gaps for a module that needs [neededLeafIds] (the leaves it registered)
+ * and declares the [dependencies] below: every dependency that registers none of a needed leaf,
+ * with that leaf listed as missing.
+ *
+ * The single approximation (limit #2): an `androidTarget` need is satisfied by a producer that
+ * registered either `androidTarget` *or* `jvm`, because Gradle's android variant resolves a
+ * jvm-only library. No other fallback exists (a jvm need is *not* satisfied by an android-only
+ * producer), and this only approximates Gradle's real attribute matching.
+ */
+internal fun computeClosureGaps(
+    neededLeafIds: List<String>,
+    dependencies: List<DoctorData>,
+): List<ClosureGap> = dependencies.mapNotNull { dep ->
+    val registered = dep.registeredLeafIds.toSet()
+    val missing = neededLeafIds.filterNot { leaf -> satisfies(leaf, registered) }.sorted()
+    if (missing.isEmpty()) null else ClosureGap(dep.path, missing)
+}
+
+private fun satisfies(neededLeaf: String, registered: Set<String>): Boolean =
+    neededLeaf in registered || (neededLeaf == ANDROID_ID && JVM_ID in registered)
+
+/** Serializes [data] to the flat `key=value` file `kmpTargetsDoctorData` writes. */
+internal fun renderDoctorData(data: DoctorData): String = buildString {
+    appendLine("path=${data.path}")
+    appendLine("registered=${data.registeredLeafIds.joinToString(",")}")
+}
+
+/** Parses the file [renderDoctorData] produced; tolerant of a trailing newline and blank values. */
+internal fun parseDoctorData(text: String): DoctorData {
+    val entries =
+        text
+            .lineSequence()
+            .mapNotNull { line ->
+                val idx = line.indexOf('=')
+                if (idx < 0) null else line.substring(0, idx) to line.substring(idx + 1)
+            }
+            .toMap()
+    val registered =
+        entries["registered"].orEmpty().split(",").map { it.trim() }.filter { it.isNotEmpty() }
+    return DoctorData(path = entries["path"].orEmpty(), registeredLeafIds = registered)
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorDataTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorDataTask.kt
@@ -1,0 +1,41 @@
+package com.rsicarelli.kmptargets.doctor
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Emits this project's *own* doctor-data — its path and the leaf ids it actually registered — to a
+ * single flat `key=value` file (#80). It is the one thing that crosses a project boundary for the
+ * cross-module closure check: a dependent module's `kmpTargetsDoctor` consumes this **file**
+ * through a resolvable configuration, never a peer `Project` model, which is what keeps the whole
+ * feature configuration-cache- and Isolated-Projects-safe.
+ *
+ * Both inputs are plain primitives wired by the plugin from the same providers `kmpTargetsInfo`
+ * uses, so the file always reflects the final post-`supports { }` state and serializes cleanly into
+ * the configuration cache; no `Project`, extension, or model type is ever captured.
+ */
+@DisableCachingByDefault(because = "emits a tiny primitive data file from already-cached inputs")
+public abstract class KmpTargetsDoctorDataTask : DefaultTask() {
+
+    /** The path of the project this data describes, e.g. `:core`. */
+    @get:Input public abstract val projectPath: Property<String>
+
+    /** Sorted leaf ids this project actually registered (`registered()`). */
+    @get:Input public abstract val registeredIds: ListProperty<String>
+
+    /** The file the dependent modules' doctor reads back. */
+    @get:OutputFile public abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    public fun emit() {
+        val file = outputFile.get().asFile
+        file.parentFile.mkdirs()
+        file.writeText(renderDoctorData(DoctorData(projectPath.get(), registeredIds.get())))
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormat.kt
@@ -1,0 +1,193 @@
+package com.rsicarelli.kmptargets.doctor
+
+/**
+ * Renders the `kmpTargetsDoctor` report from primitives only — no `Project`, extension, or
+ * `KmpTargetSet` ever reaches this function, which keeps the task action trivially
+ * configuration-cache safe and this formatter unit-testable without Gradle (mirrors
+ * [com.rsicarelli.kmptargets.info.formatKmpTargetsInfo]).
+ *
+ * Doctor is the *triage* surface to `kmpTargetsInfo`'s neutral *state dump*: every `[!]` finding is
+ * keyed off a boolean the plugin computes with the **same** decision function the matching advisory
+ * uses ([com.rsicarelli.kmptargets.shouldWarnInertModule],
+ * [com.rsicarelli.kmptargets.shouldWarnNativeOnlyMetadata],
+ * [com.rsicarelli.kmptargets.shouldWarnAndroidWithoutAgp], the host/deprecation predicates), so the
+ * report can never re-detect or drift from what actually happened. The findings are emitted in the
+ * same order [com.rsicarelli.kmptargets.KmpTargetsPlugin] emits the advisories — causes
+ * (empty-overlap, android-without-AGP) before consequences (inert, JVM-less) — so cause reads above
+ * effect.
+ *
+ * The project-edge closure section (#80) is best-effort, project-edges only, and prints its two
+ * permanent limits inline: it sees no external (non-`project(...)`) dependencies, and its
+ * android→jvm fallback only approximates Gradle's attribute matching.
+ */
+internal fun formatKmpTargetsDoctor(
+    projectPath: String,
+    supportsDeclared: Boolean,
+    selectionIds: List<String>,
+    supportedIds: List<String>,
+    registeredIds: List<String>,
+    emptyOverlap: Boolean,
+    inertModule: Boolean,
+    nativeOnlyMetadata: Boolean,
+    androidWithoutAgp: Boolean,
+    hostImpossibleIds: List<String>,
+    hostLabel: String,
+    registeredDeprecatedIds: List<String>,
+    jvmRegisteredAs: String?,
+    closureDepCount: Int,
+    closureGaps: List<ClosureGap>,
+): String = buildString {
+    appendLine("kmp-targets doctor — $projectPath")
+    appendLine()
+
+    // A module that never declared supports { } registers nothing *intentionally* (explicit-
+    // selection doctrine) — never a problem, and there is nothing downstream to check.
+    if (!supportsDeclared) {
+        append(
+            "✓ no kmp-targets selection — this module never called supports { }; registering " +
+                "nothing is intentional (explicit-selection doctrine)"
+        )
+        return@buildString
+    }
+
+    val findings = buildList {
+        if (emptyOverlap) {
+            add(
+                finding(
+                    "selection matches nothing supported",
+                    "why:    the selection ${render(selectionIds)} matches none of the supported " +
+                        "set ${render(supportedIds)}",
+                    "effect: this module registers no targets",
+                    "fix:    widen the selection or this module's supports { } so they overlap",
+                )
+            )
+        }
+        if (androidWithoutAgp) {
+            add(
+                finding(
+                    "androidTarget skipped",
+                    "why:    androidTarget is selected and supported but no Android Gradle plugin " +
+                        "is applied",
+                    "effect: the target was not registered — KGP's androidTarget() is fatal " +
+                        "without AGP",
+                    "fix:    apply com.android.library/application before supports { }, gated on " +
+                        "the selection",
+                )
+            )
+        }
+        if (hostImpossibleIds.isNotEmpty()) {
+            add(
+                finding(
+                    "not compilable on this host",
+                    "why:    ${render(hostImpossibleIds)} cannot be compiled on this host " +
+                        "($hostLabel)",
+                    "effect: still registered (selection is host-independent), but their " +
+                        "compile/link tasks fail or are skipped here",
+                    "fix:    run these targets' tasks on a capable host — the selection is " +
+                        "unchanged",
+                )
+            )
+        }
+        if (registeredDeprecatedIds.isNotEmpty()) {
+            add(
+                finding(
+                    "deprecated targets registered",
+                    "why:    ${render(registeredDeprecatedIds)} are marked deprecated by Kotlin",
+                    "effect: still registered (selection is unchanged), but consider migrating " +
+                        "off them",
+                    "fix:    drop them from this module's supports { } once migrated",
+                )
+            )
+        }
+        if (inertModule) {
+            add(
+                finding(
+                    "inert module",
+                    "why:    declared supports { } but registered zero targets",
+                    "effect: KGP still materializes the commonMain metadata compilation, which " +
+                        "fails with no platform targets",
+                    "fix:    gate on registered().isEmpty() in build-logic",
+                )
+            )
+        }
+        if (nativeOnlyMetadata) {
+            add(
+                finding(
+                    "JVM-less commonMain",
+                    "why:    supports the JVM family but registered no JVM-family target while " +
+                        "other targets did",
+                    "effect: the platform klibs compile, but the *KotlinMetadata* compilations " +
+                        "reject JVM-flavored constructs (e.g. @JvmInline)",
+                    "fix:    gate on registered(jvmFamily).isEmpty() in build-logic, disabling " +
+                        "only the *KotlinMetadata* compilations",
+                )
+            )
+        }
+    }
+
+    if (findings.isEmpty()) {
+        appendLine(cleanBill(registeredIds))
+    } else {
+        findings.forEach {
+            appendLine(it)
+            appendLine()
+        }
+    }
+
+    // The rename (#49) is context, not a problem: it explains why the build has e.g.
+    // compileKotlinDesktop tasks but no `jvm`-named target.
+    if (jvmRegisteredAs != null) {
+        appendLine()
+        appendLine("note: jvm (registered as: $jvmRegisteredAs)")
+    }
+
+    appendClosure(projectPath, closureDepCount, closureGaps)
+}
+
+private fun StringBuilder.appendClosure(
+    projectPath: String,
+    depCount: Int,
+    gaps: List<ClosureGap>,
+) {
+    if (depCount == 0 && gaps.isEmpty()) return
+    appendLine()
+    appendLine("Project-edge closure (project dependencies only)")
+    if (gaps.isEmpty()) {
+        appendLine(
+            "✓ $depCount project ${if (depCount == 1) "dependency" else "dependencies"}, no gaps"
+        )
+    } else {
+        gaps.forEach { gap ->
+            appendLine("[!] $projectPath → ${gap.dependencyPath}")
+            appendLine(
+                "    missing: ${render(gap.missingLeafIds)} — the dependency registers none of " +
+                    "these leaves this module needs"
+            )
+            appendLine(
+                "    fix:     widen ${gap.dependencyPath}'s supports { } (or the selection) to " +
+                    "register them"
+            )
+        }
+    }
+    append(
+        "  limits: external (non-project) dependencies are invisible; the android→jvm fallback is " +
+            "approximate"
+    )
+}
+
+private fun finding(title: String, vararg lines: String): String = buildString {
+    appendLine("[!] $title")
+    lines.forEachIndexed { i, line ->
+        if (i == lines.lastIndex) append("    $line") else appendLine("    $line")
+    }
+}
+
+private fun cleanBill(registeredIds: List<String>): String =
+    if (registeredIds.isEmpty()) {
+        "✓ no kmp-targets issues — no targets registered for this module"
+    } else {
+        "✓ clean bill of health — registered: ${registeredIds.joinToString(", ")}"
+    }
+
+private fun render(ids: List<String>): String =
+    if (ids.isEmpty()) "(none)" else ids.joinToString(", ")

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorTask.kt
@@ -1,0 +1,103 @@
+package com.rsicarelli.kmptargets.doctor
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Triages what the plugin decided for this project and why — the *explanation* surface to
+ * `kmpTargetsInfo`'s neutral *state dump*. It renders one `[!]` finding per active advisory
+ * (inert #71, JVM-less #72, android-without-AGP #51, host-impossible #32, deprecated #43,
+ * empty-overlap #10), a clean bill when healthy, and a project-edge **closure** section (#80).
+ *
+ * Doctor *renders*, it does not *own* predicates: every single-module property below is wired from
+ * the **same** provider/decision function the advisory and `kmpTargetsInfo` use, so it can never
+ * re-detect or drift. All are plain primitives wired post-`supports { }`; the action captures no
+ * `Project`, extension, or model type. [dependencyData] is the only cross-project input — the
+ * doctor-data **files** of this module's `project(...)` dependencies, resolved through a lenient
+ * ArtifactView (so external and plugin-less deps simply vanish — closure limit #1).
+ */
+@DisableCachingByDefault(because = "console report with no outputs; it must always run")
+public abstract class KmpTargetsDoctorTask : DefaultTask() {
+
+    /** The path of the project being diagnosed, e.g. `:feature-mobile`. */
+    @get:Internal public abstract val projectPath: Property<String>
+
+    /** Whether this module ever called `supports { … }`. */
+    @get:Internal public abstract val supportsDeclared: Property<Boolean>
+
+    /** Sorted leaf ids of the resolved selection. */
+    @get:Internal public abstract val selectionIds: ListProperty<String>
+
+    /** Sorted leaf ids of the resolved supported set. */
+    @get:Internal public abstract val supportedIds: ListProperty<String>
+
+    /** Sorted leaf ids this module actually registered — also its closure "needs". */
+    @get:Internal public abstract val registeredIds: ListProperty<String>
+
+    /** Same decision as the empty-overlap advisory (#10). */
+    @get:Internal public abstract val emptyOverlap: Property<Boolean>
+
+    /** Same decision as the inert-module advisory (#71). */
+    @get:Internal public abstract val inertModule: Property<Boolean>
+
+    /** Same decision as the native-only-metadata advisory (#72). */
+    @get:Internal public abstract val nativeOnlyMetadata: Property<Boolean>
+
+    /** Same decision as the android-without-AGP advisory (#51). */
+    @get:Internal public abstract val androidWithoutAgp: Property<Boolean>
+
+    /** Sorted ids of registered leaves the current host cannot compile (#32); empty without KGP. */
+    @get:Internal public abstract val hostImpossibleIds: ListProperty<String>
+
+    /** The current host's display name; empty without KGP. */
+    @get:Internal public abstract val hostLabel: Property<String>
+
+    /** Sorted ids of registered leaves Kotlin marks deprecated (#43). */
+    @get:Internal public abstract val registeredDeprecatedIds: ListProperty<String>
+
+    /** Custom Gradle name the jvm leaf registered under (#49), or blank/unset for the default. */
+    @get:Internal public abstract val jvmRegisteredAs: Property<String>
+
+    /**
+     * The doctor-data files of this module's `project(...)` dependencies, resolved at execution
+     * time through the lenient ArtifactView. Declaring them as inputs wires the dependency emit
+     * tasks, so a `kmpTargetsDoctor` run materializes its dependencies' data first.
+     */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NONE)
+    public abstract val dependencyData: ConfigurableFileCollection
+
+    @TaskAction
+    public fun report() {
+        val dependencies =
+            dependencyData.files.map { parseDoctorData(it.readText()) }.sortedBy { it.path }
+        val gaps = computeClosureGaps(registeredIds.get(), dependencies)
+        println(
+            formatKmpTargetsDoctor(
+                projectPath = projectPath.get(),
+                supportsDeclared = supportsDeclared.get(),
+                selectionIds = selectionIds.get(),
+                supportedIds = supportedIds.get(),
+                registeredIds = registeredIds.get(),
+                emptyOverlap = emptyOverlap.get(),
+                inertModule = inertModule.get(),
+                nativeOnlyMetadata = nativeOnlyMetadata.get(),
+                androidWithoutAgp = androidWithoutAgp.get(),
+                hostImpossibleIds = hostImpossibleIds.get(),
+                hostLabel = hostLabel.get(),
+                registeredDeprecatedIds = registeredDeprecatedIds.get(),
+                jvmRegisteredAs = jvmRegisteredAs.orNull?.takeIf { it.isNotBlank() },
+                closureDepCount = dependencies.size,
+                closureGaps = gaps,
+            )
+        )
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDoctorFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDoctorFunctionalTest.kt
@@ -1,0 +1,146 @@
+package com.rsicarelli.kmptargets
+
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Functional (TestKit) proof of `kmpTargetsDoctor` (#82) that in-process tests cannot give: the
+ * report running through Gradle's real launcher, the configuration-cache contract (captures no
+ * `Project`, so a healthy build stores then reuses an entry), and — the headline of the closure
+ * half (#80) — a real cross-project, file-only closure check resolving clean under **Isolated
+ * Projects**, where any peer-`Project` read would fail to configure.
+ *
+ * Kept to three KGP-resolving fixtures because that build is the most expensive kind.
+ */
+class KmpTargetsDoctorFunctionalTest {
+
+    @Test
+    fun `given a healthy jvm module when kmpTargetsDoctor runs twice with configuration cache then it reports a clean bill and reuses the entry`(
+        @TempDir dir: Path
+    ) {
+        writeSingleModule(dir, supports = "jvm", selection = "jvm")
+        val runner =
+            GradleRunner.create()
+                .withProjectDir(dir.toFile())
+                .withPluginClasspath()
+                .withArguments("kmpTargetsDoctor", "--configuration-cache")
+        val first = runner.build()
+        assertTrue("Configuration cache entry stored." in first.output, first.output)
+        assertTrue("clean bill of health — registered: jvm" in first.output, first.output)
+        assertTrue("[!]" !in first.output, first.output)
+        val second = runner.build()
+        assertTrue("Reusing configuration cache." in second.output, second.output)
+    }
+
+    @Test
+    fun `given a disjoint selection when kmpTargetsDoctor runs then it explains the inert module`(
+        @TempDir dir: Path
+    ) {
+        writeSingleModule(dir, supports = "jvm", selection = "wasmJs")
+        val result =
+            GradleRunner.create()
+                .withProjectDir(dir.toFile())
+                .withPluginClasspath()
+                .withArguments("kmpTargetsDoctor", "-q")
+                .build()
+        assertTrue("[!] inert module" in result.output, result.output)
+        assertTrue("commonMain metadata compilation" in result.output, result.output)
+        assertTrue("gate on registered().isEmpty()" in result.output, result.output)
+    }
+
+    @Test
+    fun `given a project-edge gap under isolated projects when kmpTargetsDoctor runs then it flags the gap names the clean edge and prints the limits`(
+        @TempDir dir: Path
+    ) {
+        writeClosureFixture(dir)
+        val runner =
+            GradleRunner.create()
+                .withProjectDir(dir.toFile())
+                .withPluginClasspath()
+                .withArguments(
+                    ":app-mobile:kmpTargetsDoctor",
+                    ":app-jvm:kmpTargetsDoctor",
+                    "--configuration-cache",
+                )
+        val first = runner.build()
+        // The gap: :app-mobile needs iosArm64 + jvm; :lib-jvm registers jvm only.
+        assertTrue("[!] :app-mobile → :lib-jvm" in first.output, first.output)
+        assertTrue("missing: iosArm64" in first.output, first.output)
+        // The false-positive guard: :app-jvm needs jvm; :lib-jvm registers jvm — a clean edge.
+        assertTrue("no gaps" in first.output, first.output)
+        // The two permanent, honest limits.
+        assertTrue("external" in first.output, first.output)
+        assertTrue("approximate" in first.output, first.output)
+        // Isolated Projects implies the configuration cache: the cross-project, file-only closure
+        // resolves and stores cleanly, then reuses — the proof no peer Project is ever read.
+        assertTrue("Configuration cache entry stored." in first.output, first.output)
+        val second = runner.build()
+        assertTrue("Reusing configuration cache." in second.output, second.output)
+    }
+
+    private fun writeSingleModule(dir: Path, supports: String, selection: String) {
+        dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=$selection\n")
+        dir.resolve("build.gradle.kts").writeText(moduleScript(supports))
+        commonSource(dir)
+    }
+
+    private fun writeClosureFixture(dir: Path) {
+        dir.resolve("settings.gradle.kts")
+            .writeText(
+                """
+                rootProject.name = "fixture"
+                include(":lib-jvm", ":app-mobile", ":app-jvm")
+                """
+                    .trimIndent()
+            )
+        dir.resolve("gradle.properties")
+            .writeText(
+                "kmptargets.targets=iosArm64,jvm\n" +
+                    "org.gradle.unsafe.isolated-projects=true\n" +
+                    "org.gradle.caching=true\n"
+            )
+        dir.resolve("build.gradle.kts").writeText("// root: no cross-project configuration\n")
+        module(dir, "lib-jvm", supports = "jvm", dependsOn = null)
+        module(dir, "app-mobile", supports = "iosArm64 + jvm", dependsOn = ":lib-jvm")
+        module(dir, "app-jvm", supports = "jvm", dependsOn = ":lib-jvm")
+    }
+
+    private fun module(dir: Path, name: String, supports: String, dependsOn: String?) {
+        val moduleDir = dir.resolve(name)
+        moduleDir.createDirectories()
+        moduleDir.resolve("build.gradle.kts").writeText(moduleScript(supports, dependsOn))
+        commonSource(moduleDir)
+    }
+
+    private fun moduleScript(supports: String, dependsOn: String? = null): String {
+        val dep =
+            if (dependsOn == null) ""
+            else
+                "\nkotlin { sourceSets { commonMain.dependencies " +
+                    "{ implementation(project(\"$dependsOn\")) } } }\n"
+        return """
+            plugins {
+                id("org.jetbrains.kotlin.multiplatform")
+                id("com.rsicarelli.kmptargets")
+            }
+
+            repositories { mavenCentral() }
+
+            kmpTargets { supports { $supports } }
+            $dep
+            """
+            .trimIndent()
+    }
+
+    private fun commonSource(moduleDir: Path) {
+        val src = moduleDir.resolve("src/commonMain/kotlin")
+        src.createDirectories()
+        src.resolve("Sample.kt").writeText("fun sample(): Int = 42\n")
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDoctorInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDoctorInProcessTest.kt
@@ -1,0 +1,118 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.doctor.DoctorData
+import com.rsicarelli.kmptargets.doctor.KmpTargetsDoctorDataTask
+import com.rsicarelli.kmptargets.doctor.KmpTargetsDoctorTask
+import com.rsicarelli.kmptargets.doctor.parseDoctorData
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Doctor (#82) renders, it does not own predicates: these in-process tests pin that every
+ * single-module property the report reads comes from the SAME extension state the advisories key
+ * off — `kmpTargetsDoctor`'s `inertModule`/`emptyOverlap`/… are the very providers behind
+ * `shouldWarnInertModule` and friends, never a re-implemented check. They also pin that the
+ * `kmpTargetsDoctorData` emitter writes only this project's own primitives (the IP-safe carrier for
+ * the closure check, #80).
+ */
+class KmpTargetsDoctorInProcessTest {
+
+    @Test
+    fun `given a disjoint module when the doctor inert and empty-overlap inputs are read then both are true`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=wasmJs\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { jvm }
+        val doctor = doctor(project)
+        assertTrue(doctor.inertModule.get(), "inert sourced from the advisory's decision")
+        assertTrue(doctor.emptyOverlap.get(), "empty-overlap sourced from the advisory's decision")
+        assertEquals(emptyList(), doctor.registeredIds.get())
+    }
+
+    @Test
+    fun `given an overlapping module when the doctor inert input is read then it is false`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { jvm }
+        assertFalse(doctor(project).inertModule.get())
+        assertEquals(listOf("jvm"), doctor(project).registeredIds.get())
+    }
+
+    @Test
+    fun `given a JVM-less selection when the doctor native-only input is read then it is true`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { iosArm64 + jvm }
+        assertTrue(doctor(project).nativeOnlyMetadata.get())
+    }
+
+    @Test
+    fun `given supports never declared when the doctor supportsDeclared input is read then it is false`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        assertFalse(doctor(project).supportsDeclared.get())
+    }
+
+    @Test
+    fun `given a registered deprecated leaf when the doctor deprecated input is read then it names it`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=watchosX64\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports(KmpTargetSet.of(KmpTarget.Native.Apple.Watchos.X64))
+        assertEquals(listOf("watchosX64"), doctor(project).registeredDeprecatedIds.get())
+    }
+
+    @Test
+    fun `given a registered module when the data emitter runs then it writes only its own primitives`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64,jvm\n")
+        val project = newProjectWithKgp(dir)
+        ext(project).supports { iosArm64 + jvm }
+        val data = project.tasks.getByName("kmpTargetsDoctorData") as KmpTargetsDoctorDataTask
+        data.emit()
+        val written = parseDoctorData(data.outputFile.get().asFile.readText())
+        assertEquals(DoctorData(project.path, listOf("iosArm64", "jvm")), written)
+    }
+
+    @Test
+    fun `given no KGP applied when the doctor inert input is read then it is false`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=wasmJs\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        ext(project).supports { jvm }
+        assertFalse(doctor(project).inertModule.get())
+    }
+
+    private fun newProjectWithKgp(dir: Path): Project {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        return project
+    }
+
+    private fun ext(project: Project): KmpTargetsExtension =
+        project.extensions.getByType(KmpTargetsExtension::class.java)
+
+    private fun doctor(project: Project): KmpTargetsDoctorTask =
+        project.tasks.getByName("kmpTargetsDoctor") as KmpTargetsDoctorTask
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/doctor/DoctorClosureTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/doctor/DoctorClosureTest.kt
@@ -1,0 +1,87 @@
+package com.rsicarelli.kmptargets.doctor
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The pure closure join (#80): given this module's needed leaves and the parsed doctor-data of its
+ * `project(...)` dependencies, flag the edges where a dependency registers none of a needed leaf.
+ * Best-effort and project-edges only — the Gradle layer (lenient ArtifactView) already drops
+ * external and plugin-less dependencies, so this logic never sees them (limit #1). The single
+ * hardcoded approximation lives here: an android consumer is satisfied by a jvm-only producer
+ * (limit #2).
+ */
+class DoctorClosureTest {
+
+    @Test
+    fun `given a dependency missing a needed leaf when gaps are computed then the edge is flagged`() {
+        val gaps =
+            computeClosureGaps(
+                neededLeafIds = listOf("iosArm64", "jvm"),
+                dependencies =
+                    listOf(DoctorData(path = ":core-jvm", registeredLeafIds = listOf("jvm"))),
+            )
+        assertEquals(listOf(ClosureGap(":core-jvm", listOf("iosArm64"))), gaps)
+    }
+
+    @Test
+    fun `given a dependency registering every needed leaf when gaps are computed then there is no gap`() {
+        val gaps =
+            computeClosureGaps(
+                neededLeafIds = listOf("iosArm64", "jvm"),
+                dependencies =
+                    listOf(
+                        DoctorData(
+                            ":core",
+                            registeredLeafIds = listOf("iosArm64", "jvm", "linuxX64"),
+                        )
+                    ),
+            )
+        assertTrue(gaps.isEmpty(), gaps.toString())
+    }
+
+    @Test
+    fun `given an android consumer and a jvm-only dependency when gaps are computed then the fallback satisfies it`() {
+        // The one hardcoded approximation: Gradle's android variant resolves a jvm-only library, so
+        // an androidTarget consumer is satisfied by a jvm-only producer.
+        val gaps =
+            computeClosureGaps(
+                neededLeafIds = listOf("androidTarget"),
+                dependencies = listOf(DoctorData(":core-jvm", registeredLeafIds = listOf("jvm"))),
+            )
+        assertTrue(gaps.isEmpty(), gaps.toString())
+    }
+
+    @Test
+    fun `given a jvm consumer and an android-only dependency when gaps are computed then there is no reverse fallback`() {
+        val gaps =
+            computeClosureGaps(
+                neededLeafIds = listOf("jvm"),
+                dependencies =
+                    listOf(DoctorData(":ui-android", registeredLeafIds = listOf("androidTarget"))),
+            )
+        assertEquals(listOf(ClosureGap(":ui-android", listOf("jvm"))), gaps)
+    }
+
+    @Test
+    fun `given no dependencies when gaps are computed then the result is empty`() {
+        assertTrue(computeClosureGaps(listOf("jvm"), emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `given doctor data when rendered then parsed then it round-trips`() {
+        val data =
+            DoctorData(
+                path = ":feature-mobile",
+                registeredLeafIds = listOf("androidTarget", "iosArm64"),
+            )
+        assertEquals(data, parseDoctorData(renderDoctorData(data)))
+    }
+
+    @Test
+    fun `given an inert dependency rendering no targets when parsed then its registered set is empty`() {
+        val parsed = parseDoctorData(renderDoctorData(DoctorData(":inert", emptyList())))
+        assertEquals(emptyList(), parsed.registeredLeafIds)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormatTest.kt
@@ -1,0 +1,221 @@
+package com.rsicarelli.kmptargets.doctor
+
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The doctor report is a pure function of primitives (no `Project`, extension, or `KmpTargetSet`
+ * reaches it), exactly like the `kmpTargetsInfo` formatter — which is what keeps the task action
+ * configuration-cache safe and this formatter unit-testable without Gradle.
+ *
+ * Doctor *renders*, it does not *own* predicates: each `[!]` finding here corresponds to a boolean
+ * the plugin already computes with the same decision function the advisory and `kmpTargetsInfo` use
+ * ([com.rsicarelli.kmptargets.shouldWarnInertModule] and friends). These tests pin the explanatory
+ * prose; the in-process suite pins that the booleans come from that shared state.
+ */
+class KmpTargetsDoctorFormatTest {
+
+    @Test
+    fun `given an inert module when formatted then it explains the cause effect and fix`() {
+        val output =
+            format(
+                selectionIds = listOf("wasmJs"),
+                supportedIds = listOf("jvm"),
+                registeredIds = emptyList(),
+                emptyOverlap = true,
+                inertModule = true,
+            )
+        assertContains(output, "[!] inert module")
+        assertContains(output, "commonMain metadata compilation")
+        assertContains(output, "gate on registered().isEmpty()")
+    }
+
+    @Test
+    fun `given a JVM-less module when formatted then it explains the metadata rejection and scoped fix`() {
+        val output =
+            format(
+                selectionIds = listOf("iosArm64"),
+                supportedIds = listOf("iosArm64", "jvm"),
+                registeredIds = listOf("iosArm64"),
+                nativeOnlyMetadata = true,
+            )
+        assertContains(output, "[!]")
+        assertContains(output, "@JvmInline")
+        assertContains(output, "gate on registered(jvmFamily).isEmpty()")
+    }
+
+    @Test
+    fun `given an android-without-AGP module when formatted then it names the skip and the remedy`() {
+        val output =
+            format(
+                selectionIds = listOf("androidTarget"),
+                supportedIds = listOf("androidTarget"),
+                registeredIds = listOf("androidTarget"),
+                androidWithoutAgp = true,
+                inertModule = true,
+            )
+        assertContains(output, "[!] androidTarget skipped")
+        assertContains(output, "no Android Gradle plugin")
+        assertContains(output, "before supports { }")
+    }
+
+    @Test
+    fun `given a host-impossible registration when formatted then it lists the leaves and the host`() {
+        val output =
+            format(
+                registeredIds = listOf("iosArm64", "jvm"),
+                hostImpossibleIds = listOf("iosArm64"),
+                hostLabel = "LINUX_X64",
+            )
+        assertContains(output, "[!]")
+        assertContains(output, "iosArm64")
+        assertContains(output, "LINUX_X64")
+        assertFalse("jvm" in output.substringAfter("LINUX_X64").substringBefore("\n"), output)
+    }
+
+    @Test
+    fun `given deprecated registered leaves when formatted then it names them`() {
+        val output =
+            format(
+                registeredIds = listOf("jvm", "watchosX64"),
+                registeredDeprecatedIds = listOf("watchosX64"),
+            )
+        assertContains(output, "[!]")
+        assertContains(output, "watchosX64")
+        assertContains(output, "deprecated")
+    }
+
+    @Test
+    fun `given an empty overlap when formatted then it names the disjoint selection and supported sets`() {
+        val output =
+            format(
+                selectionIds = listOf("wasmJs"),
+                supportedIds = listOf("jvm"),
+                registeredIds = emptyList(),
+                emptyOverlap = true,
+                inertModule = true,
+            )
+        assertContains(output, "wasmJs")
+        assertContains(output, "jvm")
+        assertContains(output, "matches none")
+    }
+
+    @Test
+    fun `given a healthy fully registered module when formatted then it reports a clean bill and no warnings`() {
+        val output = format(registeredIds = listOf("iosArm64", "jvm"))
+        assertContains(output, "clean bill of health")
+        assertContains(output, "iosArm64, jvm")
+        assertFalse("[!]" in output, output)
+    }
+
+    @Test
+    fun `given a module that never declared supports when formatted then it explains the silence is intentional`() {
+        val output =
+            format(
+                supportsDeclared = false,
+                selectionIds = listOf("jvm"),
+                supportedIds = emptyList(),
+                registeredIds = emptyList(),
+            )
+        assertContains(output, "never called supports { }")
+        assertContains(output, "intentional")
+        assertFalse("[!]" in output, output)
+    }
+
+    @Test
+    fun `given a renamed jvm leaf when formatted then it notes the registered name without flagging a problem`() {
+        val output = format(registeredIds = listOf("jvm"), jvmRegisteredAs = "desktop")
+        assertContains(output, "registered as: desktop")
+        assertFalse("[!]" in output, output)
+    }
+
+    @Test
+    fun `given a project edge gap when formatted then it names the dependency the missing leaves and the fix`() {
+        val output =
+            format(
+                registeredIds = listOf("iosArm64", "jvm"),
+                closureDepCount = 1,
+                closureGaps =
+                    listOf(
+                        ClosureGap(
+                            dependencyPath = ":core-jvm",
+                            missingLeafIds = listOf("iosArm64"),
+                        )
+                    ),
+            )
+        assertContains(output, ":core-jvm")
+        assertContains(output, "iosArm64")
+        assertContains(output, "Project-edge closure")
+    }
+
+    @Test
+    fun `given a valid closure when formatted then the closure section reports no gaps`() {
+        val output =
+            format(registeredIds = listOf("jvm"), closureDepCount = 2, closureGaps = emptyList())
+        assertContains(output, "Project-edge closure")
+        assertContains(output, "no gaps")
+        assertFalse("[!] :" in output, output)
+    }
+
+    @Test
+    fun `given the closure section renders when formatted then both honest limits are printed`() {
+        val output =
+            format(
+                registeredIds = listOf("jvm"),
+                closureDepCount = 1,
+                closureGaps =
+                    listOf(ClosureGap(dependencyPath = ":a", missingLeafIds = listOf("jvm"))),
+            )
+        assertContains(output, "external")
+        assertContains(output, "approximate")
+    }
+
+    @Test
+    fun `given no project dependencies when formatted then no closure section appears`() {
+        val output = format(registeredIds = listOf("jvm"), closureDepCount = 0)
+        assertFalse("Project-edge closure" in output, output)
+    }
+
+    @Test
+    fun `given identical inputs when formatted twice then the output is identical`() {
+        // Config-cache contract: pure function of primitives.
+        assertTrue(format() == format())
+    }
+
+    private fun format(
+        projectPath: String = ":feature-mobile",
+        supportsDeclared: Boolean = true,
+        selectionIds: List<String> = listOf("jvm"),
+        supportedIds: List<String> = listOf("jvm"),
+        registeredIds: List<String> = listOf("jvm"),
+        emptyOverlap: Boolean = false,
+        inertModule: Boolean = false,
+        nativeOnlyMetadata: Boolean = false,
+        androidWithoutAgp: Boolean = false,
+        hostImpossibleIds: List<String> = emptyList(),
+        hostLabel: String = "",
+        registeredDeprecatedIds: List<String> = emptyList(),
+        jvmRegisteredAs: String? = null,
+        closureDepCount: Int = 0,
+        closureGaps: List<ClosureGap> = emptyList(),
+    ): String =
+        formatKmpTargetsDoctor(
+            projectPath = projectPath,
+            supportsDeclared = supportsDeclared,
+            selectionIds = selectionIds,
+            supportedIds = supportedIds,
+            registeredIds = registeredIds,
+            emptyOverlap = emptyOverlap,
+            inertModule = inertModule,
+            nativeOnlyMetadata = nativeOnlyMetadata,
+            androidWithoutAgp = androidWithoutAgp,
+            hostImpossibleIds = hostImpossibleIds,
+            hostLabel = hostLabel,
+            registeredDeprecatedIds = registeredDeprecatedIds,
+            jvmRegisteredAs = jvmRegisteredAs,
+            closureDepCount = closureDepCount,
+            closureGaps = closureGaps,
+        )
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
       - 'Recipes': user-guide/recipes.md
       - 'Advisories & Strict Mode': user-guide/advisories.md
       - 'Inspecting with kmpTargetsInfo': user-guide/kmp-targets-info.md
+      - 'Doctor Mode': user-guide/doctor-mode.md
       - 'CI Matrix': user-guide/ci-matrix.md
       - 'Renaming the JVM Target': user-guide/jvm-rename.md
   - 'Samples': samples/index.md


### PR DESCRIPTION
## What

Adds **doctor mode** — a per-module diagnostic surface that *explains* why a module is inert or had targets disabled, and flags cross-module project-edge closure gaps. Capstone of the consumer-pain backlog: it renders signals every sibling already emits.

Two new tasks (group `help`), registered in every project:
- **`kmpTargetsDoctor`** — the human triage report.
- **`kmpTargetsDoctorData`** — a per-module emitter whose file dependents consume for the closure check.

```console
$ ./gradlew :feature-mobile:kmpTargetsDoctor -q

kmp-targets doctor — :feature-mobile

[!] inert module
    why:    declared supports { } but registered zero targets
    effect: KGP still materializes the commonMain metadata compilation, which fails with no platform targets
    fix:    gate on registered().isEmpty() in build-logic

Project-edge closure (project dependencies only)
[!] :feature-mobile → :core-jvm
    missing: iosArm64 — the dependency registers none of these leaves this module needs
    fix:     widen :core-jvm's supports { } (or the selection) to register them
  limits: external (non-project) dependencies are invisible; the android→jvm fallback is approximate
```

## Design decisions (issue's open questions)

**New task vs verbosity flag → new `kmpTargetsDoctor` task.** `kmpTargetsInfo` stays the neutral *state dump*; doctor is the problem-*triage* surface (silent/clean when healthy, explanatory when not). House style favours tightly-scoped surfaces, and a flag would couple two intents and bloat the info formatter. Zero regression risk to the info-task tests (verified).

**Renders, not owns — and how it's held.** Doctor duplicates **no** detection predicate. `registerInfoTask` and `registerDoctorTask` now wire the *identical* diagnostic primitives from one set of shared private `…Provider` builders, each calling the same decision function as its advisory (`shouldWarnInertModule`, `shouldWarnNativeOnlyMetadata`, `shouldWarnAndroidWithoutAgp`, the host/deprecation/empty-overlap predicates). One source ⇒ the two surfaces can structurally never drift. The one place I was tempted to re-detect — "registered deprecated leaves" — is sourced as `registered() ∩ KmpTarget.deprecated`, reusing the model's deprecation truth, not a fresh scan. #73 (commonMain-KSP) added no observable plugin state, so doctor surfaces it only as a recipe pointer (documented), holding the line.

**Closure (#80): included, via the IP-legal file-join shape.** #80's literal *rootProject* aggregator is unbuildable under Isolated Projects (a root task can't enumerate/read subprojects at configuration time). The faithful realization is **per-project consumer**: each module emits its own `(path, registered)` primitives to a file, exposes it as an outgoing artifact on a dedicated consumable configuration (a unique custom attribute keeps it clear of KGP's variants), and a dependent's doctor resolves its **own declared `project(...)` dependencies'** data files through a lenient `ArtifactView` over a resolvable config that live-mirrors those deps (config-time, own-project coordinates only — **no `afterEvaluate`, no peer `Project` read**). The artifact's `builtBy` gives correct cross-project ordering for free. I spiked this end-to-end (raw mechanism, then with KMP applied) under `org.gradle.unsafe.isolated-projects=true` before building on it: IP-clean, config-cache store+reuse, no variant ambiguity.

Both **permanent limits** are printed inline and documented, not papered over:
1. **No external-dependency coverage** — only `project(...)` edges are visible; the canonical android→jvm pain from external `jvm`-only libs is invisible, so co-selecting `jvm` with `android` remains the real rule.
2. **The android→jvm fallback is hardcoded and approximate** — it only approximates Gradle's attribute matching.

## Signal inventory covered

inert (#71), native-only-metadata (#72), android-without-AGP (#51), host-impossible (#32), deprecated (#43), empty-overlap (#10), jvm-rename note (#49); plus project-edge closure (#80).

## Tests

- **Pure**: `KmpTargetsDoctorFormatTest` (every finding + clean bill + intentional-silence + determinism), `DoctorClosureTest` (gap, false-positive guard, android→jvm fallback, both limits, render/parse round-trip).
- **In-process**: `KmpTargetsDoctorInProcessTest` — doctor properties sourced from the same state as the advisories (setup-proving), and the emitter writes only its own primitives.
- **Functional** (`KmpTargetsDoctorFunctionalTest`): healthy → clean bill + CC store-then-reuse; disjoint → inert explanation; **multi-project closure gap + clean edge + limits running under Isolated Projects** (the real IP test).

`task dod` green (pre-commit gate). Manually exercised on the real `hello-world` (inert / JVM-less / renamed / full) and `isolated-projects` (closure clean) samples; `samples/hello-world build` and `samples/isolated-projects build` both green with the new eager wiring.

## Docs

New `docs/user-guide/doctor-mode.md` (nav-wired), README "Doctor mode" section, cross-links from advisories / recipes / kmp-targets-info, CHANGELOG entry, KDoc on the new tasks + formatter. Closes the #70 recipes-hub loop.

Closes #82
Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)