### PR TITLE
Fix broken docs rendering, add strict-build guards, close README↔docs gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,21 @@ jobs:
       # via `task sample:abi-bcv`).
       - name: ABI sample configures (kotlinx BCV sample)
         run: ./gradlew -p samples/abi-bcv kmpTargetsInfo "-Pkmptargets.targets=jvm"
+
+  docs:
+    name: Docs (strict build)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install MkDocs dependencies
+        run: pip install --requirement .github/workflows/mkdocs-requirements.txt
+
+      - name: Build docs (strict)
+        run: mkdocs build --strict

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           pip install --requirement .github/workflows/mkdocs-requirements.txt
 
+      - name: Validate docs build (strict)
+        run: |
+          mkdocs build --strict
+
       - name: Configure Git for Mike
         uses: ./.github/actions/configure-release-bot
         with:

--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -1,4 +1,6 @@
-click==8.2.2
+# click is pinned below 8.2: mkdocs 1.6.1's CLI breaks on click 8.2.x (boolean
+# flags like --strict are silently ignored and use_directory_urls is forced off)
+click==8.1.8
 future==1.0.0
 Jinja2==3.1.6
 livereload==2.7.1
@@ -8,17 +10,15 @@ MarkupSafe==3.0.2
 mike==2.1.3
 mkdocs==1.6.1
 mkdocs-get-deps==0.2.0
-mkdocs-macros-plugin==1.3.9
 mkdocs-material==9.6.16
 mkdocs-material-extensions==1.3.1
-mkdocs-callouts==1.16.0
 Pygments==2.20.0
-pymdown-extensions==10.16.1
+# pymdown-extensions 10.16.1 ships a superfences that fails to parse fenced code
+# blocks entirely (rendered the literal ``` markers on the published site)
+pymdown-extensions==10.21.3
 python-dateutil==2.9.0.post0
 PyYAML==6.0.2
-repackage==0.7.3
 six==1.17.0
-termcolor==3.1.0
 tornado==6.5.5
 
 # Imaging dependencies for mkdocs-material social plugin

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,11 @@ tasks:
     cmds:
       - mkdocs serve
 
+  docs:build:
+    desc: Build the docs site with strict warnings (same gate as CI)
+    cmds:
+      - mkdocs build --strict
+
   clean:
     desc: Clean root build + sample build artifacts
     cmds:

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1,5 +1,7 @@
 # FAQ
 
+Short answers to the questions that come up when adopting kmp-targets — each links to the page with the full story.
+
 ## Selection model
 
 **Why is the selection global instead of per-module?**

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,8 @@ kmpTargets {
 
 The plugin registers `selection ∩ supported` per module: the module declares what it *can* build, the global selection decides what you *want* right now.
 
+**Status:** alpha (pre-1.0). Roadmap: user-defined hierarchy groups, XCFramework helpers.
+
 **[Why explicit selection? →](why-kmp-targets.md)**
 
 ---
@@ -45,10 +47,11 @@ The plugin registers `selection ∩ supported` per module: the module declares w
 
 ## 🚀 Start here
 
-1. **[Installation](get-started/index.md)** — coordinates, repositories, prerequisites
-2. **[Quick Start](get-started/quick-start.md)** — apply, declare, select, inspect, in 5 minutes
-3. **[Selection DSL](user-guide/selection-dsl.md)** — `supports { }`, eagerness, set algebra
-4. **[CI Matrix](user-guide/ci-matrix.md)** — one selection vocabulary across every CI host
+1. **[Why kmp-targets?](why-kmp-targets.md)** — the problem and the thesis, in 2 minutes
+2. **[Installation](get-started/index.md)** — coordinates, repositories, prerequisites
+3. **[Quick Start](get-started/quick-start.md)** — apply, declare, select, inspect, in 5 minutes
+4. **[Selection DSL](user-guide/selection-dsl.md)** — `supports { }`, eagerness, set algebra
+5. **[CI Matrix](user-guide/ci-matrix.md)** — one selection vocabulary across every CI host
 
 ---
 

--- a/docs/user-guide/ci-matrix.md
+++ b/docs/user-guide/ci-matrix.md
@@ -38,6 +38,9 @@ jobs:
       - run: ./gradlew build "-Pkmptargets.targets=${{ matrix.targets }}"
 ```
 
+!!! tip "Compile-only jobs"
+    For jobs that only need to compile (no tests, no full `build`), replace `build` with the opt-in [`kmpCompileAll` umbrella task](umbrella-tasks.md) — one stable name that follows the lane's registered set and survives a [jvm rename](jvm-rename.md).
+
 ## Host → target mapping
 
 | Runner | `kmptargets.targets` | Rationale |

--- a/docs/user-guide/jvm-rename.md
+++ b/docs/user-guide/jvm-rename.md
@@ -17,6 +17,7 @@ kmpTargets {
 - **jvm leaf only.** `androidTarget`'s name is fixed by AGP, and native/web names are derived by KGP — renaming them would break konan/source-set conventions. `targetName` fails loud on any other leaf (or a preset), on a blank name, and when called after `supports { }` already registered the jvm leaf (a late rename could never apply).
 - **Hierarchy unaffected.** KGP's hierarchy matchers (`withJvm()`) key off the platform type, not the target name, so the [minimal template](hierarchy-template.md) attaches a renamed target exactly as it would a plain `jvm`.
 - **Introspection.** [`kmpTargetsInfo`](kmp-targets-info.md) surfaces the rename on the registered line: `jvm (registered as: desktop)`. Build-logic sees it through [`RegisteredTarget.gradleName`](build-logic.md#registeredtarget), so [`onRegistered`-driven wiring](build-logic.md) keeps working without knowing about the rename.
+- **CI task names.** A hardcoded `compileKotlinJvm` silently matches zero tasks under the rename — the exact false-green the opt-in [umbrella tasks](umbrella-tasks.md) are proof against: `kmpCompileAll` wires the real `compileKotlinDesktop`.
 
 ## See it running
 

--- a/docs/user-guide/recipes.md
+++ b/docs/user-guide/recipes.md
@@ -92,7 +92,7 @@ Aggregate tasks (`build`, `check`) only cover registered targets, so the **same 
 ./gradlew check "-Pkmptargets.targets=$LANE_TARGETS"
 ```
 
-Avoid hardcoding per-target task names (`:m:iosArm64Test`) in CI scripts: they break under renames and lane changes. If you must derive test tasks, derive them from `registered()` in a small task-listing helper, not from string conventions.
+Avoid hardcoding per-target task names (`:m:iosArm64Test`) in CI scripts: they break under renames and lane changes. If you must derive test tasks, derive them from `registered()` in a small task-listing helper, not from string conventions. For explicit compile/test umbrellas instead of `build`/`check`, opt into the [`kmpCompileAll` / `kmpTestAll` umbrella tasks](umbrella-tasks.md) — selection-agnostic and rename-proof by construction.
 
 ## Selection vs the dependency graph
 

--- a/docs/user-guide/selection-layers.md
+++ b/docs/user-guide/selection-layers.md
@@ -32,6 +32,7 @@ kmptargets.targets=jvm,iosArm64
 kmptargets.hierarchyTemplate=true
 # kmptargets.hierarchyCollapse=false   # see "No-Collapse Mode"
 # kmptargets.strict=true               # see "Advisories & Strict Mode"
+# kmptargets.umbrellaTasks=true        # see "Umbrella Tasks"
 ```
 
 `kmp-targets.local.properties` (git-ignored) mirrors `try-import`: absent it's ignored; present, its keys override the committed file's. Both files accept **only** known `kmptargets.*` keys — an unknown key fails the build with a "did you mean …?" suggestion, so a typo can't silently no-op. Both are tracked configuration-cache inputs: editing one invalidates the cache, leaving them untouched keeps cache hits.

--- a/docs/user-guide/umbrella-tasks.md
+++ b/docs/user-guide/umbrella-tasks.md
@@ -1,0 +1,52 @@
+# Umbrella Tasks
+
+`kmpCompileAll` and `kmpTestAll` are **opt-in, per-module lifecycle tasks** that depend on exactly the registered intersection — selection-agnostic and rename-proof. One stable task name compiles (or tests) whatever the current lane registered, in every module, under any [jvm rename](jvm-rename.md).
+
+## Why hardcoded task lists break
+
+Teams commonly drive compile-only CI jobs with explicit task names:
+
+```bash
+# Brittle: a snapshot of one particular selection.
+./gradlew compileCommonMainKotlinMetadata compileKotlinJvm compileReleaseKotlinAndroid compileKotlinIosArm64
+```
+
+Once the selection is variable, that list has two failure modes:
+
+- **Hard 404** — a name that exists in *no* module under the current lane (`compileReleaseKotlinAndroid` on an android-less selection) → `Task '…' not found`, the job fails before it starts.
+- **Silent false-green (worse)** — under a [renamed jvm leaf](jvm-rename.md) (`targetName(jvm, "desktop")`) the real task is `compileKotlinDesktop`, so a literal `compileKotlinJvm` matches *zero* tasks and the job passes **while compiling nothing**. The test side is higher-stakes still: a hardcoded `jvmTest` never runs.
+
+The plugin already knows exactly what registered in every module, so it can expose umbrella tasks that depend on the registered set instead:
+
+- **`kmpCompileAll`** — compiles every registered target's main compilation.
+- **`kmpTestAll`** — runs every registered target's tests (the targets that have a test task; a device-only native like `iosArm64` has none and is skipped).
+
+## Enabling
+
+The tasks are **opt-in** — they add dependency edges to every registered target's compile/test tasks, and most builds only want them for CI:
+
+```properties
+# kmp-targets.properties
+kmptargets.umbrellaTasks=true
+```
+
+The flag reads through the same [precedence chain](selection-layers.md) as every other `kmptargets.` key (`-P`, env, `kmp-targets(.local).properties`, `gradle.properties`).
+
+## Semantics
+
+Both tasks are registered in **every** module the plugin is applied to (even one that never called `supports { }`), so an unqualified `./gradlew kmpCompileAll` from the root **fans out** to every project that has the task — no root aggregator, no cross-project wiring. Under a narrowed lane the umbrella simply depends on fewer tasks (a module with nothing registered is a clean no-op — never a 404), and under a renamed jvm leaf it wires the real `compileKotlinDesktop` / `desktopTest`.
+
+They depend on registered **platform** compilations only and **never** on `compileCommonMainKotlinMetadata` (or any `*KotlinMetadata` compilation), so they cannot re-introduce the [inert-module](recipes.md#gate-compilation-on-inert-modules) or JVM-less-fragment failures — exactly the compilations build-logic deliberately disables for those modules.
+
+## In the CI matrix
+
+Drop them straight into the [CI matrix](ci-matrix.md): replace `build` with `kmpCompileAll` for compile-only jobs (or add `kmpTestAll` where the host can run the lane's tests):
+
+```bash
+# Stable: one name, correct in every lane and under any rename.
+./gradlew kmpCompileAll "-Pkmptargets.targets=${{ matrix.targets }}"
+```
+
+## The living example
+
+The [`desktop-named` sample](../samples/index.md) asserts the rename-proofing as a living regression gate: its jvm leaf is renamed to `desktop`, and `kmpCompileAll` still wires the real `compileKotlinDesktop`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,34 +42,45 @@ theme:
 plugins:
   - search
   - mike
-  - callouts
 
+# Material for MkDocs recommended set; codehilite/smarty/nl2br are
+# incompatible with superfences-rendered fenced code — do not re-add them.
 markdown_extensions:
-  - smarty
-  - codehilite:
-      guess_lang: false
+  # Python Markdown
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
   - footnotes
-  - meta
+  - md_in_html
+  - tables
   - toc:
       permalink: true
+
+  # PyMdown Extensions
   - pymdownx.betterem:
       smart_enable: all
   - pymdownx.caret
-  - pymdownx.inlinehilite
-  - pymdownx.magiclink
-  - pymdownx.smartsymbols
-  - pymdownx.superfences
-  - pymdownx.emoji
   - pymdownx.details
-  - pymdownx.tabbed:
-      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
-  - tables
-  - admonition
-  - attr_list
-  - md_in_html
-  - nl2br
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      repo_url_shorthand: true
+      user: rsicarelli
+      repo: kmp-targets
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tilde
 
 extra_css:
   - stylesheets/kmp-targets-brand.css
@@ -97,6 +108,7 @@ nav:
       - 'Doctor Mode': user-guide/doctor-mode.md
       - 'ABI Validation & Selection': user-guide/abi-validation.md
       - 'CI Matrix': user-guide/ci-matrix.md
+      - 'Umbrella Tasks': user-guide/umbrella-tasks.md
       - 'Renaming the JVM Target': user-guide/jvm-rename.md
   - 'Samples': samples/index.md
   - 'Compatibility': compatibility.md


### PR DESCRIPTION
# Fix broken docs rendering + docs quality audit follow-ups

The published site rendered every page broken: code fences appeared as literal ```` ``` ```` text, `.properties` comments blew up into H1 headings, quotes inside code turned curly, and prose rendered as `<br>` walls.

## Root causes (reproduced locally)

1. **`pymdown-extensions==10.16.1` is a broken release** — its superfences fails to parse fenced code entirely (hotfixed upstream in 10.16.2; verified 10.16.1 BROKEN / 10.16.2 OK at the pure-library level). Bumped to 10.21.3.
2. **`click==8.2.2` breaks mkdocs 1.6.1's CLI** — `--strict` is silently ignored and `use_directory_urls` is forced off (the site was deploying flat `.html` pages). Pinned to 8.1.8.
3. **Hostile extension stack** — `smarty` (curly quotes in code), `nl2br` (`<br>` on every newline), `codehilite` mixed with superfences. Replaced with the Material for MkDocs recommended set; dropped the unused `callouts` plugin (docs use `!!!` admonitions) and the never-enabled `macros` plugin + its exclusive deps.

Nothing in CI ever ran `mkdocs build --strict`, so this shipped unnoticed.

## Changes

- **mkdocs.yml**: Material-recommended `markdown_extensions` set; `plugins: search, mike` only.
- **mkdocs-requirements.txt**: bump pymdown-extensions, pin click below 8.2, prune unused plugins/deps.
- **Regression guards**: `docs` job in ci.yml, strict pre-flight build in deploy-docs.yml before `mike deploy`, and `task docs:build` — verified the guard fails on an injected broken link.
- **New page `user-guide/umbrella-tasks.md`**: the README's `kmpCompileAll`/`kmpTestAll` "Lane-agnostic compilation" section had zero docs-site coverage (the one critical gap from a README↔docs parity audit, ~93% otherwise). Cross-linked from ci-matrix, recipes, jvm-rename, and selection-layers.
- **Docs polish**: home page states alpha/pre-1.0 status + roadmap (matching README), "Start here" leads with *Why kmp-targets?*, FAQ gets an opening line.

Deferred to separate PRs per repo scoping rules: splitting recipes.md, merging jvm-rename into hierarchy-template, User Guide nav reordering. Audit verdict: 22 pages is right-sized.

## Verification

Clean venv from the pinned requirements → `mkdocs build --strict` passes with zero warnings; built HTML checked: fences highlighted (`language-properties`/`language-kotlin`), no phantom H1s, straight quotes preserved in code, no `<br>` walls, directory URLs restored, admonition-nested fences render. The live site picks this up on the next docs deploy.

https://claude.ai/code/session_01UdzY19CPPPgSua3sjUnRE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdzY19CPPPgSua3sjUnRE3)_