### PR TITLE
docs: drop pre-release breaking-change notes (KMP_TARGETS rename, pre-1.0 disclaimers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file. The format is based on
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project is pre-1.0, so breaking
-changes may land in any release.
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
-
-### Changed (BREAKING)
-
-- **Unified property naming under the `kmptargets.` namespace** ([#31]). The selection key is
-  renamed; the hierarchy key was already on-convention and stays. This is a hard break — the old
-  names are **not read at all** (no deprecated alias): a build still setting only `KMP_TARGETS`
-  falls through to `defaultSelection` / the plugin default.
-
-  | Concern | Before | After |
-  |---|---|---|
-  | Selection (`gradle.properties` / files / `local.properties`) | `KMP_TARGETS=...` | `kmptargets.targets=...` |
-  | Selection (CLI) | `-PKMP_TARGETS=...` | `-Pkmptargets.targets=...` |
-  | Selection (env) | `ORG_GRADLE_PROJECT_KMP_TARGETS` or bare `KMP_TARGETS` | `ORG_GRADLE_PROJECT_kmptargets.targets` |
-  | Hierarchy template | `kmptargets.hierarchyTemplate` | `kmptargets.hierarchyTemplate` (unchanged) |
-
-- The bare `KMP_TARGETS` **environment variable** is no longer read; the env surface is Gradle's
-  native `ORG_GRADLE_PROJECT_<key>` mapping only (which now also works for
-  `kmptargets.hierarchyTemplate`, which previously had no env form).
 
 ### Added
 
@@ -196,7 +177,6 @@ changes may land in any release.
 
 [#10]: https://github.com/rsicarelli/kmp-targets/issues/10
 [#30]: https://github.com/rsicarelli/kmp-targets/issues/30
-[#31]: https://github.com/rsicarelli/kmp-targets/issues/31
 [#32]: https://github.com/rsicarelli/kmp-targets/issues/32
 [#43]: https://github.com/rsicarelli/kmp-targets/issues/43
 [#48]: https://github.com/rsicarelli/kmp-targets/issues/48

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Full story: [Compatibility](https://rsicarelli.github.io/kmp-targets/compatibili
 
 ## Documentation
 
-**Status:** alpha (pre-1.0). Roadmap: user-defined hierarchy groups, XCFramework helpers.
+**Status:** alpha. Roadmap: user-defined hierarchy groups, XCFramework helpers.
 
 Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.github.io/kmp-targets/)**:
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -19,6 +19,3 @@ The build pins the emitted output: Kotlin `languageVersion`/`apiVersion` 2.0, `j
 | kmp-targets | Kotlin/KGP | Gradle |
 |---|---|---|
 | 0.1.x | 2.2+ (built against 2.3.21) | 8.11+ (repo runs 9.5.1, configuration cache on) |
-
-!!! note
-    Pre-1.0, minor versions may contain breaking changes — they are called out in the [CHANGELOG](https://github.com/rsicarelli/kmp-targets/blob/main/CHANGELOG.md) (e.g. the `KMP_TARGETS` → `kmptargets.targets` key rename).

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -17,7 +17,6 @@ Start with [`kmpTargetsInfo`](../user-guide/diagnostics.md#kmptargetsinfo): it p
 | Build fails at configuration: `Unknown target token '...' — did you mean ...?` | typo in `kmptargets.targets`; the parser is strict | accept the suggestion; vocabulary is in [`kmpTargetsInfo`](../user-guide/diagnostics.md#kmptargetsinfo) or the [reference](../user-guide/targets-reference.md) |
 | Build fails: unknown key in `kmp-targets.properties` | the config files accept only known `kmptargets.*` keys | fix the key (the error suggests the nearest match) |
 | Selection ignored / surprising value wins | a higher-precedence source is set — often a stale `kmp-targets.local.properties` or an env var | `kmpTargetsInfo` names the winning source; check the [precedence chain](../user-guide/selection-layers.md) |
-| Setting `KMP_TARGETS` does nothing | pre-1.0 breaking rename — the old key is not read at all | use `kmptargets.targets` |
 | A module builds nothing | empty overlap: selection ∩ supported = ∅ | widen the selection or the module's `supports { }`; the [empty-overlap advisory](../user-guide/advisories.md#empty-overlap) names the module |
 | Every sync re-configures after changing selection | each distinct value is its own configuration-cache entry — only the first build of a value misses | expected; alternating between known values hits the cache ([the trade-off](../why-kmp-targets.md#the-configuration-cache-trade-off)) |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ kmpTargets {
 
 The plugin registers `selection ∩ supported` per module: the module declares what it *can* build, the global selection decides what you *want* right now.
 
-**Status:** alpha (pre-1.0). Roadmap: user-defined hierarchy groups, XCFramework helpers.
+**Status:** alpha. Roadmap: user-defined hierarchy groups, XCFramework helpers.
 
 ## Documentation
 

--- a/docs/user-guide/selection-layers.md
+++ b/docs/user-guide/selection-layers.md
@@ -50,9 +50,6 @@ Unknown tokens fail the build at configuration time with a "did you mean …?" s
 
 The full preset and leaf vocabulary lives in the [Targets Reference](targets-reference.md).
 
-!!! warning "Breaking rename (pre-1.0)"
-    The selection key used to be `KMP_TARGETS` (env: `ORG_GRADLE_PROJECT_KMP_TARGETS` or bare `KMP_TARGETS`). It is now `kmptargets.targets` — the old key is **not read at all**; a build still setting only `KMP_TARGETS` falls through to `defaultSelection` / the plugin default.
-
 ## Diagnosing a surprising selection
 
 [`kmpTargetsInfo`](diagnostics.md#kmptargetsinfo) prints the resolved selection and the winning source by name — `command line (-Pkmptargets.targets)`, `kmp-targets.local.properties`, etc. Values from `-Dorg.gradle.project.kmptargets.targets` and `~/.gradle/gradle.properties` are indistinguishable from root `gradle.properties`; all three report as the fused `gradle.properties (...)` layer.

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/host/HostAwarenessInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/host/HostAwarenessInProcessTest.kt
@@ -28,7 +28,7 @@ class HostAwarenessInProcessTest {
         // appleMobile + linux + mingw cannot all be compilable on any single host, so whatever
         // machine runs this test exercises the warning path for at least zero leaves — and the
         // registered set must be the full selection regardless.
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=all\n")
         val project =
             newEvaluatedProject(dir) { ext -> ext.supports { appleMobile + linux + mingw } }
         assertRegisteredTargets(
@@ -46,7 +46,7 @@ class HostAwarenessInProcessTest {
     fun `given supports called twice when configured then hostWarned stays a subset of the active set`(
         @TempDir dir: Path
     ) {
-        dir.resolve("gradle.properties").writeText("KMP_TARGETS=all\n")
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=all\n")
         lateinit var ext: KmpTargetsExtension
         val project =
             newEvaluatedProject(dir) {


### PR DESCRIPTION
# Drop pre-release breaking-change notes

The plugin has never been released, so notes documenting the `KMP_TARGETS` → `kmptargets.targets` rename and "pre-1.0 may break" disclaimers describe migrations no consumer can need.

## Changes

- **selection-layers.md**: removed the "Breaking rename (pre-1.0)" admonition
- **troubleshooting.md**: removed the "Setting `KMP_TARGETS` does nothing" table row
- **compatibility.md**: removed the pre-1.0 breaking-changes note
- **CHANGELOG.md**: removed the "Changed (BREAKING)" rename section (and its now-orphaned `[#31]` link definition) and the "pre-1.0, so breaking changes may land in any release" framing in the header
- **docs/index.md + README.md**: status line "alpha (pre-1.0)" → "alpha"
- **HostAwarenessInProcessTest.kt**: two fixtures still wrote the dead `KMP_TARGETS=all` key into `gradle.properties`; they now set `kmptargets.targets=all` (same resolved selection — `all` is also the plugin default — suite passes)

## Verification

- `grep -rni "breaking|pre-1.0|KMP_TARGETS"` over docs/, README, CHANGELOG → zero hits
- `mkdocs build --strict` passes clean
- `./gradlew :gradle-plugin:test --tests '*HostAwarenessInProcessTest*'` → BUILD SUCCESSFUL

https://claude.ai/code/session_01UdzY19CPPPgSua3sjUnRE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdzY19CPPPgSua3sjUnRE3)_