### PR TITLE
feat: apple framework helper — route to the real KGP Framework (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Full story: [Compatibility](https://rsicarelli.github.io/kmp-targets/compatibili
 
 ## Documentation
 
-**Status:** alpha. Roadmap: user-defined hierarchy groups, XCFramework helpers.
+**Status:** alpha. Roadmap: user-defined hierarchy groups, XCFramework assembly (the [Apple framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) helper is the foundation).
 
 Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.github.io/kmp-targets/)**:
 
@@ -67,6 +67,7 @@ Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.gith
 - [Targets Reference](https://rsicarelli.github.io/kmp-targets/user-guide/targets-reference/) — every preset and leaf
 - [Hierarchy](https://rsicarelli.github.io/kmp-targets/user-guide/hierarchy-template/) — minimal template, no-collapse
 - [Build Logic](https://rsicarelli.github.io/kmp-targets/user-guide/build-logic/) — conventions, `onRegistered`, helpers
+- [Apple Framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) — `appleFramework`, `onAppleTarget`, route-to-real-KGP
 - [Recipes](https://rsicarelli.github.io/kmp-targets/user-guide/recipes/) — KSP gates, AGP gating, dependency-graph rules
 - [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/user-guide/advisories/) — the six advisories and CI strictness
 - [Diagnostics](https://rsicarelli.github.io/kmp-targets/user-guide/diagnostics/) — `kmpTargetsInfo` and `kmpTargetsDoctor`

--- a/docs/user-guide/apple-framework.md
+++ b/docs/user-guide/apple-framework.md
@@ -1,0 +1,64 @@
+# Apple Framework
+
+Modules that ship a Kotlin framework to an iOS/macOS app usually hand-roll the same block: pick native targets from ad-hoc properties, loop them, call `binaries.framework { baseName = …; export(…) }`. The plugin already owns that loop's input — the registration log ([`onRegistered`](build-logic.md)) — so it can attach the framework for you.
+
+It does that **without copying KGP's `Framework` API**. The plugin owns only the loop, the base name, the build types, and the Apple-subset filter; the configure block is the *real* `org.jetbrains.kotlin.gradle.plugin.mpp.Framework`. Nothing here is reviewed on a Kotlin release — a new framework option shows up in your block for free.
+
+## `appleFramework`
+
+Declare the framework once; it attaches to every registered Apple leaf:
+
+```kotlin
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+
+kmpTargets {
+    supports { appleMobile }
+
+    appleFramework("KotlinShared") {           // this: Framework (real KGP)
+        isStatic = false                       // KGP
+        export(libs.shared.core)               // KGP export(Any): catalog Provider / project / "g:a:v"
+        binaryOption("bundleId", "com.example.shared")
+    }
+}
+```
+
+- **`baseName`** is the first argument; KGP's `namePrefix` stays `""`, so link-task names (`linkDebugFrameworkIosSimulatorArm64`) and the `embedAndSign…` contract match plain KGP byte-for-byte.
+- **`on`** (default `apple`) narrows which Apple leaves attach, using the same target algebra as `supports`: `appleFramework("KotlinShared", on = KmpTargetSet.appleMobile) { … }`. An `on` not ⊆ `apple` fails at declaration, naming the offending ids.
+- **`buildTypes`** (default KGP's `NativeBuildType.DEFAULT_BUILD_TYPES` = DEBUG + RELEASE) is passed straight to KGP's `binaries.framework(buildTypes = …)` factory. The plugin never silently narrows a KGP default.
+- **Ordering-immune.** `appleFramework` declared *before* or *after* `supports {}` behaves identically (it rides the `onRegistered` replay); a later `supports {}` union attaches only the delta.
+- **Exports stay lazy.** A version-catalog `Provider` is realized by KGP at attach time, not at declaration.
+- **One per module** in v1 — a second call, a blank name, or `on ⊄ apple` fails fast. (Multiple frameworks need a `namePrefix` strategy; a follow-up.)
+
+## `onAppleTarget` — the no-magic primitive
+
+`appleFramework` is thin sugar over `onAppleTarget`, which hands you the live KGP `KotlinNativeTarget` for every registered Apple leaf. Reach for it for anything that isn't a single framework — multiple binaries, cinterops, linker options:
+
+```kotlin
+kmpTargets {
+    supports { appleMobile }
+    onAppleTarget {                            // this: KotlinNativeTarget (real KGP)
+        binaries.framework("KotlinShared") { isStatic = false }
+        compilations.getByName("main").cinterops.create("analytics")
+    }
+}
+```
+
+Same replay/ordering guarantees as `onRegistered`; fires only when KGP is applied; runs at configuration time only (don't hold the target from a task action).
+
+## From build-logic
+
+Both are plain extension calls — no type-safe receiver to bypass — so a convention plugin uses them directly, and `on` already takes a raw `KmpTargetSet`:
+
+```kotlin
+import com.rsicarelli.kmptargets.KmpTargetsExtension
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+
+extensions.configure<KmpTargetsExtension> {
+    appleFramework("KotlinShared", on = KmpTargetSet.appleMobile) { isStatic = false }
+    supports(KmpTargetSet.appleMobile)
+}
+```
+
+## Out of scope
+
+XCFramework assembly, an unattached-framework advisory, build types via a layered property, multiple frameworks per module, and non-Apple binaries (`sharedLib`/`staticLib`/`executable`) are deliberate follow-ups.

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -9,6 +9,10 @@ import org.gradle.api.Task
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 
 /**
  * Public DSL surface exposed by the plugin as the `kmpTargets` extension.
@@ -207,6 +211,24 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     internal val onRegisteredActions: MutableList<(RegisteredTarget) -> Unit> = mutableListOf()
 
     /**
+     * Resolves a registered target's `gradleName` to the **live KGP [KotlinTarget]**, so
+     * [onAppleTarget] / [appleFramework] can route to the real type instead of re-deriving it. The
+     * plugin installs it once inside `withPlugin(KGP_ID)` (where the `KotlinMultiplatformExtension`
+     * exists); it stays null until then, so the apple hooks are inert when KGP is absent — which is
+     * also when nothing registers and [onRegistered] never fires. A configuration-time-only
+     * carrier: invoked solely from `onRegistered` actions, never held by a task action, so no
+     * `Project` (or the KMP extension it closes over) is serialized into the configuration cache.
+     */
+    internal var kotlinTargetByName: ((String) -> KotlinTarget?)? = null
+
+    /**
+     * True once [appleFramework] has been called, so a second call fails loudly. One framework per
+     * module in v1: KGP's binary names collide on the empty `namePrefix`, and multi-framework needs
+     * a deliberate `namePrefix` strategy (a follow-up). The duplicate-fail keeps that door open.
+     */
+    internal var appleFrameworkDeclared: Boolean = false
+
+    /**
      * The per-module `kmpCompileAll` umbrella task (#77), registered unconditionally at apply time.
      * The eager registration loop appends one compile-task dependency per registered leaf, so the
      * umbrella ends up depending on exactly the registered intersection — selection-agnostic and
@@ -287,5 +309,104 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     public fun onRegistered(action: (RegisteredTarget) -> Unit) {
         registeredLog.toList().forEach(action)
         onRegisteredActions += action
+    }
+
+    /**
+     * Runs [action] against the **live KGP [KotlinNativeTarget]** of every registered Apple leaf —
+     * the no-mirror foundation for per-target Apple wiring. It is [onRegistered] routed one rung
+     * closer to the metal: same replay-then-subscribe, ordering-immune guarantees (a `framework`
+     * declared before or after `supports {}` behaves identically), but the receiver is the real
+     * target, so frameworks, cinterops, linker options, and binary options are plain KGP you
+     * already know — nothing this plugin has to re-declare and review on each Kotlin release:
+     * ```kotlin
+     * kmpTargets {
+     *     supports { appleMobile }
+     *     onAppleTarget {                       // this: KotlinNativeTarget
+     *         binaries.framework("KotlinShared") { isStatic = false }
+     *     }
+     * }
+     * ```
+     *
+     * Apple-ness comes from the model leaf ([KmpTarget.Native.Apple]), so no konan `Family`
+     * introspection leaks in. Fires only when KGP is applied (otherwise nothing registers); runs at
+     * configuration time only — mirror the [onRegistered] discipline and never hold the target (or
+     * the extension) from a task action.
+     */
+    public fun onAppleTarget(action: KotlinNativeTarget.() -> Unit): Unit =
+        onAppleNativeTarget(KmpTargetSet.apple, action)
+
+    /**
+     * Declares a Kotlin **Apple framework** once and attaches it to every registered Apple leaf in
+     * [on] — replacing the hand-rolled "pick native targets, loop, `binaries.framework { … }`"
+     * block (issue #105). Thin sugar over [onAppleTarget]: this plugin owns only the [baseName],
+     * the creation-time [buildTypes], and the [on] filter (its own target algebra); the [configure]
+     * body is the **real KGP [Framework]**, so `isStatic`, `export(…)`, `binaryOption(…)`, and
+     * every future framework option come straight from KGP with no mirrored vocabulary:
+     * ```kotlin
+     * kmpTargets {
+     *     supports { appleMobile }
+     *     appleFramework("KotlinShared") {       // this: Framework
+     *         isStatic = false
+     *         export(libs.shared.core)           // KGP export(Any): catalog Provider / project / "g:a:v"
+     *     }
+     * }
+     * ```
+     *
+     * [baseName] becomes the framework's `baseName`; KGP's `namePrefix` stays `""` so link-task
+     * names (`linkDebugFrameworkIosArm64`) and the `embedAndSign…` contract match plain-KGP
+     * conventions byte-for-byte. [buildTypes] defaults to KGP's own `DEFAULT_BUILD_TYPES` (DEBUG +
+     * RELEASE) — the plugin never silently narrows a KGP default. Exports are realized lazily by
+     * KGP at attach time (a version-catalog `Provider` is not `.get()`-ed at declaration). The
+     * [configure] block runs after the `baseName` is set, so it always wins.
+     *
+     * Build-logic friendly: [on] is a raw [KmpTargetSet] (mirroring `supports(value)`), so
+     * convention plugins declare frameworks without the type-safe DSL receiver. One framework per
+     * module in v1 — a second call, a blank [baseName], or an [on] not ⊆ apple fails fast with the
+     * offending ids.
+     */
+    public fun appleFramework(
+        baseName: String,
+        on: KmpTargetSet = KmpTargetSet.apple,
+        buildTypes: Collection<NativeBuildType> = NativeBuildType.DEFAULT_BUILD_TYPES,
+        configure: Framework.() -> Unit = {},
+    ) {
+        if (baseName.isBlank()) {
+            throw GradleException("kmp-targets: appleFramework baseName must not be blank.")
+        }
+        val nonApple = (on - KmpTargetSet.apple).members
+        if (nonApple.isNotEmpty()) {
+            throw GradleException(
+                "kmp-targets: appleFramework `on` must be a subset of apple targets. " +
+                    "Offending: ${nonApple.map { it.id }.sorted()}."
+            )
+        }
+        if (appleFrameworkDeclared) {
+            throw GradleException(
+                "kmp-targets: appleFramework can be declared at most once per module (v1) — KGP " +
+                    "binary names collide on the empty namePrefix. Multiple frameworks need a " +
+                    "namePrefix strategy (a follow-up)."
+            )
+        }
+        appleFrameworkDeclared = true
+        onAppleNativeTarget(on) {
+            binaries.framework(buildTypes = buildTypes) {
+                this.baseName = baseName
+                configure()
+            }
+        }
+    }
+
+    /**
+     * Shared resolve path for [onAppleTarget] and [appleFramework]: replays + subscribes via
+     * [onRegistered], keeps only Apple leaves inside [within], and resolves each to its live KGP
+     * [KotlinNativeTarget] through [kotlinTargetByName] before invoking [block]. The null-safe
+     * chain means it is inert until the plugin installs the resolver under `withPlugin(KGP_ID)`.
+     */
+    private fun onAppleNativeTarget(within: KmpTargetSet, block: KotlinNativeTarget.() -> Unit) {
+        onRegistered { registered ->
+            if (registered.leaf is KmpTarget.Native.Apple && registered.leaf in within) {
+                (kotlinTargetByName?.invoke(registered.gradleName) as? KotlinNativeTarget)?.block()
+            }
+        }
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -699,6 +699,13 @@ public class KmpTargetsPlugin : Plugin<Project> {
         strict: Boolean,
     ) {
         val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        // Install the gradleName → live KotlinTarget resolver that backs onAppleTarget /
+        // appleFramework (#105). Set before the registration loop below, so it is in place by the
+        // time recordRegistration fires the onRegistered subscriptions those hooks ride. Idempotent
+        // across supports{} passes; closes over the config-time KMP extension only, never a
+        // Project,
+        // and is invoked solely from configuration-time onRegistered actions — config-cache safe.
+        ext.kotlinTargetByName = { name -> kotlin.targets.findByName(name) }
         val selection = ext.resolvedSelection()
         val supported = ext.resolvedSupported()
         val active = selection intersect supported

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AppleFrameworkFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AppleFrameworkFunctionalTest.kt
@@ -1,0 +1,76 @@
+package com.rsicarelli.kmptargets
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Functional (TestKit) proof that [KmpTargetsExtension.appleFramework] attaches a real KGP
+ * framework — that the canonical link task (`linkDebugFrameworkIosSimulatorArm64`) materializes
+ * with the declared `baseName` — and that doing so is **configuration-cache clean** (entry stored
+ * then reused), which the in-process `ProjectBuilder` tests cannot observe. Configuration only: the
+ * assert task reads the registered binaries at configuration time and prints primitives in its
+ * action, so no Kotlin/Native toolchain is provisioned (the framework is never linked).
+ */
+class AppleFrameworkFunctionalTest {
+
+    @Test
+    fun `given appleFramework when the build configures then the iOS link task exists with the baseName and the config cache is reused`(
+        @TempDir dir: Path
+    ) {
+        writeFixture(dir)
+
+        val first = runner(dir).withArguments("assertFramework", "--configuration-cache").build()
+        assertTrue("FRAMEWORK=iosSimulatorArm64:KotlinShared" in first.output, first.output)
+        assertTrue("LINK_TASK_PRESENT=true" in first.output, first.output)
+        assertTrue("Configuration cache entry stored" in first.output, first.output)
+
+        // Second run: the framework wiring (resolver capturing the KMP extension, onRegistered
+        // firing) contributed nothing un-serializable to the requested task graph, so the entry is
+        // reused rather than rejected.
+        val second = runner(dir).withArguments("assertFramework", "--configuration-cache").build()
+        assertTrue("Configuration cache entry reused" in second.output, second.output)
+    }
+
+    private fun writeFixture(dir: Path) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=iosArm64,iosSimulatorArm64\n")
+        dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
+        dir.resolve("build.gradle.kts")
+            .writeText(
+                """
+                import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+                import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
+                plugins {
+                    kotlin("multiplatform")
+                    id("com.rsicarelli.kmptargets")
+                }
+
+                kmpTargets {
+                    supports { appleMobile }
+                    appleFramework("KotlinShared") { isStatic = false }
+                }
+
+                // Asserted at configuration time and printed here (a build-script `doLast` would
+                // capture the script object and trip the config cache on its own — unrelated to the
+                // plugin). The requested `assertFramework` task carries no action, so the only
+                // configuration-time work the cache must store is the plugin's framework wiring.
+                kotlin.targets.withType(KotlinNativeTarget::class.java).forEach { t ->
+                    t.binaries.withType(Framework::class.java).forEach {
+                        println("FRAMEWORK=" + t.targetName + ":" + it.baseName)
+                    }
+                }
+                println("LINK_TASK_PRESENT=" + (tasks.findByName("linkDebugFrameworkIosSimulatorArm64") != null))
+                tasks.register("assertFramework")
+                """
+                    .trimIndent()
+            )
+    }
+
+    private fun runner(dir: Path): GradleRunner =
+        GradleRunner.create().withProjectDir(dir.toFile()).withPluginClasspath()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AppleFrameworkInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AppleFrameworkInProcessTest.kt
@@ -1,0 +1,222 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * The Apple framework helper (issue #105): [KmpTargetsExtension.appleFramework] declares a
+ * framework once and attaches it to every registered Apple leaf, and
+ * [KmpTargetsExtension.onAppleTarget] hands back the live KGP [KotlinNativeTarget] for arbitrary
+ * per-target wiring. Both ride the existing `onRegistered` replay path, so they are
+ * ordering-immune; neither re-declares KGP's `Framework` vocabulary — the configure block is the
+ * real type.
+ */
+class AppleFrameworkInProcessTest {
+
+    @Test
+    fun `given appleFramework before supports when supports runs then it attaches to every apple leaf with the baseName`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,iosSimulatorArm64,jvm")
+        project.kmpTargets().appleFramework("KotlinShared") { isStatic = true }
+        project
+            .kmpTargets()
+            .supports(KmpTargetSet.appleMobile + KmpTargetSet.of(KmpTarget.Jvm.Desktop))
+
+        val frameworks = project.frameworksByTarget()
+        assertEquals(setOf("iosArm64", "iosSimulatorArm64"), frameworks.keys)
+        frameworks.values.flatten().forEach {
+            assertEquals("KotlinShared", it.baseName)
+            assertTrue(it.isStatic, "configure block must run against the real Framework")
+        }
+    }
+
+    @Test
+    fun `given appleFramework after supports when declared then it attaches identically via replay`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,iosSimulatorArm64")
+        project.kmpTargets().supports(KmpTargetSet.appleMobile)
+        project.kmpTargets().appleFramework("KotlinShared")
+
+        val frameworks = project.frameworksByTarget()
+        assertEquals(setOf("iosArm64", "iosSimulatorArm64"), frameworks.keys)
+        assertTrue(frameworks.values.flatten().all { it.baseName == "KotlinShared" })
+    }
+
+    @Test
+    fun `given a second supports union when it adds an apple leaf then the framework attaches to the delta only`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,iosSimulatorArm64")
+        project.kmpTargets().appleFramework("KotlinShared")
+        project.kmpTargets().supports(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64))
+        val firstPass = project.frameworksByTarget()
+        assertEquals(setOf("iosArm64"), firstPass.keys)
+        val arm64FrameworkCount = firstPass.getValue("iosArm64").size
+
+        project.kmpTargets().supports(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.SimulatorArm64))
+        val secondPass = project.frameworksByTarget()
+        assertEquals(setOf("iosArm64", "iosSimulatorArm64"), secondPass.keys)
+        // The already-attached leaf is not re-attached: its framework count is unchanged.
+        assertEquals(
+            arm64FrameworkCount,
+            secondPass.getValue("iosArm64").size,
+            "iosArm64 must not be re-attached by the second supports union",
+        )
+    }
+
+    @Test
+    fun `given a selection with non-apple leaves when appleFramework declared then only apple targets get a framework`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,jvm,linuxX64")
+        project.kmpTargets().appleFramework("KotlinShared")
+        project
+            .kmpTargets()
+            .supports(
+                KmpTargetSet.of(
+                    KmpTarget.Native.Apple.Ios.Arm64,
+                    KmpTarget.Jvm.Desktop,
+                    KmpTarget.Native.Linux.X64,
+                )
+            )
+        assertEquals(setOf("iosArm64"), project.frameworksByTarget().keys)
+    }
+
+    @Test
+    fun `given an on filter narrower than the registered apple leaves when declared then only the filtered leaves attach`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,macosArm64")
+        // Supports both iOS and macOS, but the framework targets appleMobile only.
+        project.kmpTargets().appleFramework("KotlinShared", on = KmpTargetSet.appleMobile)
+        project
+            .kmpTargets()
+            .supports(
+                KmpTargetSet.of(
+                    KmpTarget.Native.Apple.Ios.Arm64,
+                    KmpTarget.Native.Apple.Macos.Arm64,
+                )
+            )
+        assertEquals(setOf("iosArm64"), project.frameworksByTarget().keys)
+    }
+
+    @Test
+    fun `given buildTypes narrowed to DEBUG when declared then only the debug framework binary is created`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64")
+        project
+            .kmpTargets()
+            .appleFramework("KotlinShared", buildTypes = listOf(NativeBuildType.DEBUG))
+        project.kmpTargets().supports(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64))
+        val frameworks = project.frameworksByTarget().getValue("iosArm64")
+        assertEquals(listOf(NativeBuildType.DEBUG), frameworks.map { it.buildType })
+    }
+
+    @Test
+    fun `given onAppleTarget when supports registers apple and non-apple leaves then it fires the live target for apple only`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,jvm,linuxX64")
+        val seen = mutableMapOf<String, String>()
+        project.kmpTargets().onAppleTarget { seen[targetName] = this::class.simpleName ?: "" }
+        project
+            .kmpTargets()
+            .supports(
+                KmpTargetSet.of(
+                    KmpTarget.Native.Apple.Ios.Arm64,
+                    KmpTarget.Jvm.Desktop,
+                    KmpTarget.Native.Linux.X64,
+                )
+            )
+        assertEquals(setOf("iosArm64"), seen.keys)
+        assertTrue(
+            seen.getValue("iosArm64").contains("Native"),
+            "receiver must be a KotlinNativeTarget",
+        )
+    }
+
+    @Test
+    fun `given on not a subset of apple when appleFramework declared then it fails naming the offending ids`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64")
+        val failure =
+            assertFailsWith<org.gradle.api.GradleException> {
+                project.kmpTargets().appleFramework("KotlinShared", on = KmpTargetSet.mobile)
+            }
+        // mobile = androidTarget + ios*; the offending non-apple id is androidTarget.
+        assertTrue("androidTarget" in failure.message!!, failure.message!!)
+    }
+
+    @Test
+    fun `given a blank baseName when appleFramework declared then it fails`(@TempDir dir: Path) {
+        val project = projectWithSelection(dir, "iosArm64")
+        assertFailsWith<org.gradle.api.GradleException> {
+            project.kmpTargets().appleFramework("  ")
+        }
+    }
+
+    @Test
+    fun `given a second appleFramework call when declared then it fails loudly`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64")
+        project.kmpTargets().appleFramework("KotlinShared")
+        val failure =
+            assertFailsWith<org.gradle.api.GradleException> {
+                project.kmpTargets().appleFramework("Other")
+            }
+        assertTrue("at most once" in failure.message!!, failure.message!!)
+    }
+
+    @Test
+    fun `given KGP absent when appleFramework and onAppleTarget are used then nothing fires and nothing crashes`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        var appleFired = false
+        project.kmpTargets().onAppleTarget { appleFired = true }
+        project.kmpTargets().appleFramework("KotlinShared")
+        project.kmpTargets().supports(KmpTargetSet.appleMobile)
+        assertEquals(false, appleFired)
+        assertEquals(KmpTargetSet.empty, project.kmpTargets().registered())
+    }
+
+    private fun projectWithSelection(dir: Path, selection: String): Project {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=$selection\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        return project
+    }
+
+    private fun Project.kmpTargets(): KmpTargetsExtension =
+        extensions.getByType(KmpTargetsExtension::class.java)
+
+    /** Every [Framework] binary the plugin attached, grouped by the KGP target name. */
+    private fun Project.frameworksByTarget(): Map<String, List<Framework>> =
+        extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .withType(KotlinNativeTarget::class.java)
+            .associate { it.targetName to it.binaries.withType(Framework::class.java).toList() }
+            .filterValues { it.isNotEmpty() }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
       - 'Targets Reference': user-guide/targets-reference.md
       - 'Hierarchy': user-guide/hierarchy-template.md
       - 'Build Logic': user-guide/build-logic.md
+      - 'Apple Framework': user-guide/apple-framework.md
       - 'Recipes': user-guide/recipes.md
       - 'Advisories & Strict Mode': user-guide/advisories.md
       - 'Diagnostics': user-guide/diagnostics.md

--- a/samples/hello-world/build-logic/src/main/kotlin/KmpModule.kt
+++ b/samples/hello-world/build-logic/src/main/kotlin/KmpModule.kt
@@ -4,6 +4,7 @@ import com.rsicarelli.kmptargets.model.KmpTargetSet
 import com.rsicarelli.kmptargets.model.RegisteredTarget
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 
 /**
  * Declares this module's supported set and hands every registered target to [perTarget] via
@@ -19,12 +20,25 @@ import org.gradle.kotlin.dsl.getByType
  * The pre-#52 version of this helper read `kotlin.targets.names` synchronously right after
  * `supports` — possible because registration is eager, but it left every convention re-deriving
  * name filtering itself (and KSP-style family slicing meant importing KGP konan internals).
+ *
+ * When [appleFramework] is non-null, the helper also declares an Apple framework of that base name
+ * via [KmpTargetsExtension.appleFramework], narrowed by the raw [on] set ([KmpTargetSet], not the
+ * type-safe receiver — the build-logic-friendly overload). [framework] configures the **real KGP
+ * [Framework]**, so a convention can set `isStatic`/`export(…)` without this build re-rolling the
+ * per-target loop or mirroring KGP's framework vocabulary. [perTarget] stays the trailing parameter
+ * so existing `kmpModule(supported = …) { … }` call sites are unaffected.
  */
 fun Project.kmpModule(
     supported: KmpTargetsDsl.() -> KmpTargetSet,
+    appleFramework: String? = null,
+    on: KmpTargetSet = KmpTargetSet.apple,
+    framework: Framework.() -> Unit = {},
     perTarget: (RegisteredTarget) -> Unit = {},
 ) {
     val kmpTargets = extensions.getByType<KmpTargetsExtension>()
     kmpTargets.onRegistered(perTarget)
+    if (appleFramework != null) {
+        kmpTargets.appleFramework(appleFramework, on = on, configure = framework)
+    }
     kmpTargets.supports(supported)
 }

--- a/samples/hello-world/core-and-apple/build.gradle.kts
+++ b/samples/hello-world/core-and-apple/build.gradle.kts
@@ -10,4 +10,12 @@ plugins {
     alias(libs.plugins.kmpTargets)
 }
 
-kmpTargets { supports { apple + jvm } }
+kmpTargets {
+    supports { apple + jvm }
+
+    // FRAMEWORK PROOF (.kts). Declare the iOS/macOS framework once; the plugin attaches it to every
+    // registered Apple leaf via the existing onRegistered replay — no target loop, no ad-hoc
+    // property picker. The configure block is the *real* KGP `Framework`, so `isStatic` and any
+    // future framework option come straight from KGP with nothing mirrored in this plugin.
+    appleFramework("KotlinShared") { isStatic = false }
+}

--- a/samples/hello-world/eager-conventions/build.gradle.kts
+++ b/samples/hello-world/eager-conventions/build.gradle.kts
@@ -11,7 +11,15 @@ plugins {
 // configuration wiring needs. With kmptargets.targets=jvm,iosArm64,iosSimulatorArm64 intersected
 // against supports { jvm + iosArm64 }, the convention sees exactly [iosArm64, jvm] — at
 // configuration time, in the same pass. (Pre-#52 this read `kotlin.targets.names` by hand.)
-kmpModule(supported = { jvm + iosArm64 }) { target ->
+// FRAMEWORK PROOF (.kt / build-logic). `appleFramework = "EagerShared"` declares the framework from
+// the convention via the raw `on: KmpTargetSet` overload (no type-safe receiver needed in
+// build-logic), and `framework { … }` configures the real KGP `Framework`. It attaches only to the
+// registered Apple leaf (iosArm64), never to jvm.
+kmpModule(
+    supported = { jvm + iosArm64 },
+    appleFramework = "EagerShared",
+    framework = { isStatic = false },
+) { target ->
     tasks.register("describe${target.gradleNameCapitalized}") {
         val gradleName = target.gradleName
         doLast { logger.lifecycle("eager-wired target: $gradleName") }


### PR DESCRIPTION
## Summary

Closes the framework gap from #105, but **declines the issue's chosen direction (a)**. Direction (a) declared a framework through a bespoke spec DSL (`isStatic`, `buildTypes`, `export`, `exportAll`, `transitiveExport`, `configure`) that re-implements KGP's `Framework` API — a parallel vocabulary to review and sync on every Kotlin release, with a `configure {}` escape hatch that already concedes it can't cover the real type. Instead, **route to the real thing**: the plugin owns only the loop; KGP owns the framework body verbatim.

## Changes

**New public API on `KmpTargetsExtension`:**

- **`onAppleTarget { /* this: KotlinNativeTarget */ }`** — the no-magic primitive. Hands back the live KGP target for every registered Apple leaf, so frameworks, cinterops, and linker options are plain KGP. Same replay/ordering-immune guarantees as `onRegistered`; Apple-ness from the model leaf (`KmpTarget.Native.Apple`), no konan `Family` introspection.
- **`appleFramework("Name", on = apple, buildTypes = DEFAULT_BUILD_TYPES) { /* this: Framework */ }`** — thin sugar over the primitive. The plugin owns only `baseName`, the creation-time `buildTypes` (KGP's own enum, passed through to `binaries.framework`), and the `on` apple-subset filter (its own `KmpTargetSet` algebra). The configure block is the **real** `org.jetbrains.kotlin.gradle.plugin.mpp.Framework`, so `isStatic`/`export(…)`/`binaryOption(…)` and every future option come from KGP with nothing mirrored.

**Why this answers the maintenance worry:** the plugin's entire contact surface with the KGP binaries API shrinks to two stable calls — `targets.findByName(name) as KotlinNativeTarget` and `binaries.framework(buildTypes) { baseName = …; configure() }`. No `Framework` member is named here, so a new Kotlin release costs zero review.

**Semantics (acceptance criteria from #105):**
- Declared **before or after** `supports {}` attaches identically (rides the `onRegistered` replay); a second `supports {}` union attaches the delta only.
- `name` = `baseName`; KGP `namePrefix` stays `""` so `linkDebugFrameworkIosArm64` and the `embedAndSign…` contract match plain KGP byte-for-byte.
- `buildTypes` defaults to KGP's `DEFAULT_BUILD_TYPES` (DEBUG + RELEASE) — never silently narrows a KGP default.
- Exports realized lazily by KGP at attach (a version-catalog `Provider` is not `.get()`-ed at declaration).
- One framework per module in v1 — a second call, a blank name, or `on ⊄ apple` fails fast with the offending ids. (Multi-framework needs a `namePrefix` strategy — door kept open by the duplicate-fail.)

**Wiring** (`KmpTargetsPlugin.apply` → `register`): installs a config-time-only `gradleName → KotlinTarget` resolver inside `withPlugin(KGP_ID)`. No `Project` (or the KMP extension it closes over) is serialized into task state.

**Samples** — `.kts`: `core-and-apple` declares `appleFramework("KotlinShared") { isStatic = false }`. `.kt`/build-logic: `kmpModule` gains an optional framework declaration (raw `on: KmpTargetSet` overload), used by `eager-conventions`.

**Docs** — new `docs/user-guide/apple-framework.md` (nav-wired), README roadmap line updated.

## Test plan

- [x] `task ci` is green locally (`:gradle-plugin:test` + `ktfmtCheck`; sample configures, `core-and-apple` exposes `linkDebugFrameworkIosArm64`/`…IosSimulatorArm64`)
- [x] Added tests — 11 ProjectBuilder cases (both declaration orders, delta-on-union, non-Apple exclusion, `on`-filter, `buildTypes` narrowing, blank/duplicate/`on ⊄ apple` validation, KGP-absent) + a TestKit functional test asserting `linkDebugFrameworkIosSimulatorArm64` exists with the `baseName` and the config cache is **stored then reused**
- [x] Updated docs/README (user-facing)
- [x] New public API with **explicit intent** — `onAppleTarget` + `appleFramework`, both routing to real KGP types (no mirrored vocabulary)

## Related

- Supersedes the "chosen direction (a)" in #105; same acceptance criteria, no bespoke `Framework` DSL.
- Built on `onRegistered` / `RegisteredTarget` (#52).
- Foundation for the "XCFramework assembly" roadmap item (a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bc5M7ySmfJ6Y11GqcnMLGn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bc5M7ySmfJ6Y11GqcnMLGn)_