### PR TITLE
feat: XCFramework assembly via appleFramework(xcframework = true) (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Full story: [Compatibility](https://rsicarelli.github.io/kmp-targets/compatibili
 
 ## Documentation
 
-**Status:** alpha. Roadmap: user-defined hierarchy groups, XCFramework assembly (the [Apple framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) helper is the foundation).
+**Status:** alpha. Roadmap: user-defined hierarchy groups. The [Apple framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) helper now covers framework declaration and XCFramework assembly.
 
 Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.github.io/kmp-targets/)**:
 

--- a/docs/user-guide/apple-framework.md
+++ b/docs/user-guide/apple-framework.md
@@ -29,6 +29,24 @@ kmpTargets {
 - **Exports stay lazy.** A version-catalog `Provider` is realized by KGP at attach time, not at declaration.
 - **One per module** in v1 — a second call, a blank name, or `on ⊄ apple` fails fast. (Multiple frameworks need a `namePrefix` strategy; a follow-up.)
 
+## XCFramework assembly
+
+Set `xcframework = true` to also bundle the registered slices into one `.xcframework` (the artifact an Xcode app links):
+
+```kotlin
+kmpTargets {
+    supports { appleMobile }
+    appleFramework("KotlinShared", xcframework = true) { isStatic = false }
+}
+```
+
+KGP registers `assembleKotlinSharedDebugXCFramework`, `assembleKotlinSharedReleaseXCFramework`, and the parent `assembleKotlinSharedXCFramework`.
+
+- **Opt-in**, matching the umbrella-task precedent — assembly tasks add edges, so they're off by default.
+- **Lazy**: the `XCFrameworkConfig` is created on the first Apple attach, so a selection that registers no Apple leaf (e.g. a jvm-only lane) wires **zero** `assemble…XCFramework` tasks.
+- **Invariant-safe by construction**: KGP requires every framework in an XCFramework to share a `baseName` and match on `buildType` — both come from the single declaration, so there's nothing to maintain by hand. `buildTypes` flows through (`buildTypes = listOf(NativeBuildType.DEBUG)` produces only the Debug assemble variant).
+- **macOS to run, host-blind to register**: the assemble tasks shell out to `xcodebuild`, so they only *execute* on a macOS host. Registration is host-independent (same as the link tasks), so your selection stays host-blind.
+
 ## `onAppleTarget` — the no-magic primitive
 
 `appleFramework` is thin sugar over `onAppleTarget`, which hands you the live KGP `KotlinNativeTarget` for every registered Apple leaf. Reach for it for anything that isn't a single framework — multiple binaries, cinterops, linker options:
@@ -61,4 +79,4 @@ extensions.configure<KmpTargetsExtension> {
 
 ## Out of scope
 
-XCFramework assembly, an unattached-framework advisory, build types via a layered property, multiple frameworks per module, and non-Apple binaries (`sharedLib`/`staticLib`/`executable`) are deliberate follow-ups.
+An unattached-framework advisory, build types via a layered property, multiple frameworks per module (and aggregating several into one XCFramework), and non-Apple binaries (`sharedLib`/`staticLib`/`executable`) are deliberate follow-ups.

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFrameworkConfig
 
 /**
  * Public DSL surface exposed by the plugin as the `kmpTargets` extension.
@@ -363,11 +364,22 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
      * convention plugins declare frameworks without the type-safe DSL receiver. One framework per
      * module in v1 — a second call, a blank [baseName], or an [on] not ⊆ apple fails fast with the
      * offending ids.
+     *
+     * Set [xcframework] to `true` to also assemble the registered slices into one `.xcframework`
+     * (issue #106) — KGP registers `assemble<BaseName><BuildType>XCFramework` plus the parent
+     * `assemble<BaseName>XCFramework`. Opt-in, matching the umbrella-task precedent (#77): the
+     * `XCFrameworkConfig` is created **lazily on the first Apple attach**, so a jvm-only selection
+     * leaves zero dangling tasks. The shared-`baseName`/`buildTypes` invariant KGP demands holds by
+     * construction (one declaration feeds both the config and every `framework(buildTypes)`).
+     * Assembly tasks **execute** on a macOS host only (KGP shells out to `xcodebuild`);
+     * registration is host-blind, same as the link tasks, so selection stays host-independent
+     * (#32).
      */
     public fun appleFramework(
         baseName: String,
         on: KmpTargetSet = KmpTargetSet.apple,
         buildTypes: Collection<NativeBuildType> = NativeBuildType.DEFAULT_BUILD_TYPES,
+        xcframework: Boolean = false,
         configure: Framework.() -> Unit = {},
     ) {
         if (baseName.isBlank()) {
@@ -388,10 +400,27 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
             )
         }
         appleFrameworkDeclared = true
+        // Lazy XCFramework config (#106): created on the first Apple attach via the target's own
+        // project (AbstractKotlinTarget.getProject), so a selection that registers no Apple leaf
+        // never materializes an assemble…XCFramework task. onRegistered fires synchronously at
+        // configuration time, so the plain var needs no synchronization.
+        var xcframeworkConfig: XCFrameworkConfig? = null
         onAppleNativeTarget(on) {
+            val config =
+                if (xcframework) {
+                    xcframeworkConfig
+                        ?: XCFrameworkConfig(project, baseName, buildTypes.toSet()).also {
+                            xcframeworkConfig = it
+                        }
+                } else {
+                    null
+                }
             binaries.framework(buildTypes = buildTypes) {
                 this.baseName = baseName
                 configure()
+                // Add each per-buildType slice after its baseName is set; XCFrameworkConfig groups
+                // them into the assemble tasks and enforces the buildType match.
+                config?.add(this)
             }
         }
     }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AppleFrameworkFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AppleFrameworkFunctionalTest.kt
@@ -35,7 +35,24 @@ class AppleFrameworkFunctionalTest {
         assertTrue("Configuration cache entry reused" in second.output, second.output)
     }
 
-    private fun writeFixture(dir: Path) {
+    @Test
+    fun `given xcframework true when the build configures then the assemble XCFramework task exists and the config cache is reused`(
+        @TempDir dir: Path
+    ) {
+        writeFixture(dir, xcframework = true)
+
+        val first = runner(dir).withArguments("assertFramework", "--configuration-cache").build()
+        assertTrue("XCFRAMEWORK_TASK_PRESENT=true" in first.output, first.output)
+        assertTrue("Configuration cache entry stored" in first.output, first.output)
+
+        // The lazily-created XCFrameworkConfig registers KGP-owned, config-cache-compatible tasks
+        // and captures no Project of ours, so the entry is reused. (Never executed — xcodebuild is
+        // macOS-only; we only assert the task exists.)
+        val second = runner(dir).withArguments("assertFramework", "--configuration-cache").build()
+        assertTrue("Configuration cache entry reused" in second.output, second.output)
+    }
+
+    private fun writeFixture(dir: Path, xcframework: Boolean = false) {
         dir.resolve("gradle.properties")
             .writeText("kmptargets.targets=iosArm64,iosSimulatorArm64\n")
         dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
@@ -52,7 +69,7 @@ class AppleFrameworkFunctionalTest {
 
                 kmpTargets {
                     supports { appleMobile }
-                    appleFramework("KotlinShared") { isStatic = false }
+                    appleFramework("KotlinShared", xcframework = $xcframework) { isStatic = false }
                 }
 
                 // Asserted at configuration time and printed here (a build-script `doLast` would
@@ -65,6 +82,7 @@ class AppleFrameworkFunctionalTest {
                     }
                 }
                 println("LINK_TASK_PRESENT=" + (tasks.findByName("linkDebugFrameworkIosSimulatorArm64") != null))
+                println("XCFRAMEWORK_TASK_PRESENT=" + (tasks.findByName("assembleKotlinSharedXCFramework") != null))
                 tasks.register("assertFramework")
                 """
                     .trimIndent()

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AppleFrameworkInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/AppleFrameworkInProcessTest.kt
@@ -200,6 +200,60 @@ class AppleFrameworkInProcessTest {
         assertEquals(KmpTargetSet.empty, project.kmpTargets().registered())
     }
 
+    @Test
+    fun `given xcframework true and two ios leaves when declared then the assemble XCFramework tasks exist`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,iosSimulatorArm64")
+        project.kmpTargets().appleFramework("KotlinShared", xcframework = true)
+        project.kmpTargets().supports(KmpTargetSet.appleMobile)
+        // KGP also registers per-family fat-framework intermediates, so assert the canonical three
+        // are present rather than pinning the full set.
+        val tasks = project.xcframeworkTaskNames()
+        assertTrue("assembleKotlinSharedDebugXCFramework" in tasks, tasks.toString())
+        assertTrue("assembleKotlinSharedReleaseXCFramework" in tasks, tasks.toString())
+        assertTrue("assembleKotlinSharedXCFramework" in tasks, tasks.toString())
+    }
+
+    @Test
+    fun `given xcframework true but a jvm-only selection when declared then no XCFramework task is registered`(
+        @TempDir dir: Path
+    ) {
+        // Laziness: the config is created on the first Apple attach, which never happens here.
+        val project = projectWithSelection(dir, "jvm")
+        project.kmpTargets().appleFramework("KotlinShared", xcframework = true)
+        project.kmpTargets().supports(KmpTargetSet.of(KmpTarget.Jvm.Desktop))
+        assertEquals(emptySet(), project.xcframeworkTaskNames())
+    }
+
+    @Test
+    fun `given xcframework true with buildTypes narrowed to DEBUG when declared then only the debug assemble variant exists`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,iosSimulatorArm64")
+        project
+            .kmpTargets()
+            .appleFramework(
+                "KotlinShared",
+                buildTypes = listOf(NativeBuildType.DEBUG),
+                xcframework = true,
+            )
+        project.kmpTargets().supports(KmpTargetSet.appleMobile)
+        val tasks = project.xcframeworkTaskNames()
+        assertTrue("assembleKotlinSharedDebugXCFramework" in tasks, tasks.toString())
+        assertTrue("assembleKotlinSharedReleaseXCFramework" !in tasks, tasks.toString())
+    }
+
+    @Test
+    fun `given xcframework defaulting to false when declared then no XCFramework task is registered`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWithSelection(dir, "iosArm64,iosSimulatorArm64")
+        project.kmpTargets().appleFramework("KotlinShared")
+        project.kmpTargets().supports(KmpTargetSet.appleMobile)
+        assertEquals(emptySet(), project.xcframeworkTaskNames())
+    }
+
     private fun projectWithSelection(dir: Path, selection: String): Project {
         dir.resolve("gradle.properties").writeText("kmptargets.targets=$selection\n")
         val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
@@ -219,4 +273,8 @@ class AppleFrameworkInProcessTest {
             .withType(KotlinNativeTarget::class.java)
             .associate { it.targetName to it.binaries.withType(Framework::class.java).toList() }
             .filterValues { it.isNotEmpty() }
+
+    /** The registered task names KGP's XCFrameworkConfig contributes (assemble…XCFramework). */
+    private fun Project.xcframeworkTaskNames(): Set<String> =
+        tasks.names.filter { it.endsWith("XCFramework") }.toSet()
 }

--- a/samples/hello-world/core-and-apple/build.gradle.kts
+++ b/samples/hello-world/core-and-apple/build.gradle.kts
@@ -17,5 +17,8 @@ kmpTargets {
     // registered Apple leaf via the existing onRegistered replay — no target loop, no ad-hoc
     // property picker. The configure block is the *real* KGP `Framework`, so `isStatic` and any
     // future framework option come straight from KGP with nothing mirrored in this plugin.
-    appleFramework("KotlinShared") { isStatic = false }
+    // `xcframework = true` (opt-in) also assembles the registered slices into one `.xcframework`
+    // (`assembleKotlinSharedXCFramework`); the config is created lazily, so a jvm-only lane wires
+    // nothing. Assembly runs on a macOS host (xcodebuild); registration is host-blind.
+    appleFramework("KotlinShared", xcframework = true) { isStatic = false }
 }


### PR DESCRIPTION
## Summary

Closes the XCFramework half of the Apple roadmap, building on the merged #105. #106's chosen direction (a) folded XCFramework into a mutable spec block (`framework("…") { xcframework = true }`) that the merged #105 doesn't have — its configure lambda is the real KGP `Framework`. This realizes the same intent as an **opt-in `xcframework` parameter** on the existing `appleFramework(...)`, so the syntax is nearly identical (`appleFramework("KotlinShared", xcframework = true) { … }`) and nothing is mirrored.

## Changes

- **`appleFramework(..., xcframework: Boolean = false, ...)`** — when `true`, the plugin creates an `XCFrameworkConfig(project, baseName, buildTypes)` **lazily on the first Apple attach** (via `AbstractKotlinTarget`'s public `project`, so no new Project capture) and `add()`s each per-buildType framework slice. KGP registers `assemble<Name>{Debug,Release,}XCFramework`.
- Every #106 criterion holds **by construction**: lazy ⇒ a jvm-only selection wires zero `assemble…XCFramework` tasks; shared `baseName`/`buildTypes` come from the one declaration (KGP's XCFramework invariant, enforced for free); `buildTypes = [DEBUG]` ⇒ only the Debug assemble variant; registration is host-blind (no `hostIsMac` guard — same as the link tasks) while execution is macOS-only (`xcodebuild`).
- Config-cache clean (registers no tasks of our own; the lazy-holder `var` + closures are configuration-time only).
- Sample `core-and-apple` flips to `xcframework = true`; `docs/user-guide/apple-framework.md` gains an XCFramework section; README roadmap line closed.

## Test plan

- [x] `task ci` green locally (`:gradle-plugin:test` + `ktfmtCheck`; sample `core-and-apple` exposes `assembleKotlinShared{,Debug,Release}XCFramework`)
- [x] Added tests — 4 ProjectBuilder cases (canonical assemble tasks present; jvm-only ⇒ none; `buildTypes = [DEBUG]` ⇒ Debug-only; default `false` ⇒ none) + a TestKit functional test asserting `assembleKotlinSharedXCFramework` exists with the config cache **reused** (never executed — `xcodebuild` is macOS-only)
- [x] Updated docs/README (user-facing)
- [x] No new public API beyond the one opt-in param on the existing method

## Related

- Realizes #106; supersedes its `xcframework = true` *spec-flag* direction with a parameter on the merged #105 API.
- Builds on the Apple framework helper (#105) and `onAppleTarget` / `onRegistered` (#52).
- Honest scope note: since `onAppleTarget` already removed the target loop, a consumer can hand-roll this in ~2 lines today; the param earns its place purely on the lazy lifecycle + invariant enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bc5M7ySmfJ6Y11GqcnMLGn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bc5M7ySmfJ6Y11GqcnMLGn)_