### PR TITLE
feat(#107): advisory + info/doctor surfacing — framework declared but no Apple target attached

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.gith
 - [Build Logic](https://rsicarelli.github.io/kmp-targets/user-guide/build-logic/) — conventions, `onRegistered`, helpers
 - [Apple Framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) — `appleFramework`, `onAppleTarget`, route-to-real-KGP
 - [Recipes](https://rsicarelli.github.io/kmp-targets/user-guide/recipes/) — KSP gates, AGP gating, dependency-graph rules
-- [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/user-guide/advisories/) — the six advisories and CI strictness
+- [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/user-guide/advisories/) — the seven advisories and CI strictness
 - [Diagnostics](https://rsicarelli.github.io/kmp-targets/user-guide/diagnostics/) — `kmpTargetsInfo` and `kmpTargetsDoctor`
 - [CI](https://rsicarelli.github.io/kmp-targets/user-guide/ci-matrix/) — per-host matrix, umbrella tasks
 - [Design](https://rsicarelli.github.io/kmp-targets/why-kmp-targets/) — rationale and trade-offs

--- a/docs/user-guide/advisories.md
+++ b/docs/user-guide/advisories.md
@@ -1,6 +1,6 @@
 # Advisories & Strict Mode
 
-The plugin emits six configuration-time advisories. Five are signal-only; one (android-without-AGP) skips a leaf — the reasoning is on the [Design page](../why-kmp-targets.md#diagnostics-philosophy). [Strict mode](#strict-mode) promotes all six to build failures with identical message text. [`kmpTargetsDoctor`](diagnostics.md#kmptargetsdoctor) renders each advisory as a finding with the fix attached.
+The plugin emits seven configuration-time advisories. Six are signal-only; one (android-without-AGP) skips a leaf — the reasoning is on the [Design page](../why-kmp-targets.md#diagnostics-philosophy). [Strict mode](#strict-mode) promotes all seven to build failures with identical message text. [`kmpTargetsDoctor`](diagnostics.md#kmptargetsdoctor) renders each advisory as a finding with the fix attached.
 
 ## Host compatibility
 
@@ -88,9 +88,23 @@ if (kmpTargets.registered().isNotEmpty() && kmpTargets.registered(jvmFamily).isE
 }
 ```
 
+## Framework without an Apple target
+
+Fires when a module declares an [`appleFramework`](apple-framework.md) but the current selection registers no Apple target in the framework's `on` scope — so the framework attaches to nothing and never builds. A jvm-only lane (`kmptargets.targets=jvm`) is the common cause; so is an `on` scope narrower than what registered (a framework scoped to `appleMobile` while only `macosArm64` registered). The artifact silently never materializes, and an Xcode build consuming it fails far downstream with a missing-framework error that says nothing about target selection:
+
+```
+kmp-targets: ':shared' declared appleFramework("KotlinShared") but this selection registered no
+Apple target in its scope — the framework attaches to nothing and never builds, so an Xcode build
+consuming it fails downstream with a missing-framework error. Widen the selection (or this module's
+supports { }) to register an Apple target in the framework's `on` scope, or gate the appleFramework(…)
+declaration in build-logic when kmpTargets.registered(apple).isEmpty().
+```
+
+Keyed off the leaves the framework **actually attached to** (`registered ∩ on ∩ apple`), not `registered(apple)` — so it is correct for an `on`-scoped framework even when other Apple leaves registered. A module that never calls `supports { }` is not flagged (explicit-selection doctrine), though [`kmpTargetsDoctor`](diagnostics.md#kmptargetsdoctor) still renders the declared-but-unattached state. Registration is one-way: a later `supports { }` union that attaches an Apple leaf resolves it permanently. Strict mode is the point here — a release lane with a misconfigured selection fails loudly at configuration instead of shipping a frameworkless artifact that breaks Xcode downstream.
+
 ## Strict mode
 
-`kmptargets.strict=true` promotes all six advisories to configuration-time build failures (`GradleException`) with identical message text. Severity changes; policy does not — it never changes which configurations are flagged or what registers (the AGP skip happens with or without strict). Default off. Recommended: strict in CI only:
+`kmptargets.strict=true` promotes all seven advisories to configuration-time build failures (`GradleException`) with identical message text. Severity changes; policy does not — it never changes which configurations are flagged or what registers (the AGP skip happens with or without strict). Default off. Recommended: strict in CI only:
 
 ```yaml
 # CI only — e.g. a GitHub Actions env block

--- a/docs/user-guide/apple-framework.md
+++ b/docs/user-guide/apple-framework.md
@@ -28,6 +28,7 @@ kmpTargets {
 - **Ordering-immune.** `appleFramework` declared *before* or *after* `supports {}` behaves identically (it rides the `onRegistered` replay); a later `supports {}` union attaches only the delta.
 - **Exports stay lazy.** A version-catalog `Provider` is realized by KGP at attach time, not at declaration.
 - **One per module** in v1 — a second call, a blank name, or `on ⊄ apple` fails fast. (Multiple frameworks need a `namePrefix` strategy; a follow-up.)
+- **Attaches to nothing? You're warned.** If the current selection registers no Apple target in the framework's `on` scope (a jvm-only lane, or an `on` narrower than what registered), the framework silently never builds and an Xcode consumer fails downstream — so the plugin emits the [framework-without-an-Apple-target advisory](advisories.md#framework-without-an-apple-target) (a configuration failure under `kmptargets.strict`). [`kmpTargetsInfo`](diagnostics.md#kmptargetsinfo) and [`kmpTargetsDoctor`](diagnostics.md#kmptargetsdoctor) render the declared name and the leaves it attached to.
 
 ## XCFramework assembly
 
@@ -79,4 +80,4 @@ extensions.configure<KmpTargetsExtension> {
 
 ## Out of scope
 
-An unattached-framework advisory, build types via a layered property, multiple frameworks per module (and aggregating several into one XCFramework), and non-Apple binaries (`sharedLib`/`staticLib`/`executable`) are deliberate follow-ups.
+Build types via a layered property, multiple frameworks per module (and aggregating several into one XCFramework), and non-Apple binaries (`sharedLib`/`staticLib`/`executable`) are deliberate follow-ups.

--- a/docs/user-guide/diagnostics.md
+++ b/docs/user-guide/diagnostics.md
@@ -22,6 +22,12 @@ Supported (what this module can build)
 Registered (selection ∩ supported)
   targets:  iosArm64, iosSimulatorArm64, jvm
 
+Apple framework
+  name:        KotlinShared
+  attached:    iosArm64, iosSimulatorArm64
+  buildTypes:  DEBUG, RELEASE
+  xcframework: off
+
 Vocabulary
   presets:  all, native, appleMobile, appleDesktop, appleWatch, appleTv, apple, linux, mingw, windows, androidNative, web, jvmFamily, mobile
   leaves:   androidNativeArm32, ..., macosX64 (deprecated), ..., watchosX64 (deprecated) (25)
@@ -32,6 +38,7 @@ Vocabulary
 - **`Selection`** — the resolved global selection and its winning [layer](selection-layers.md) by name: `command line (-Pkmptargets.targets)`, `kmp-targets.local.properties`, `local.properties`, or the `defaultSelection` / built-in fallbacks. Values from `-Dorg.gradle.project.kmptargets.targets` and `~/.gradle/gradle.properties` report as the fused `gradle.properties (...)` layer.
 - **`Supported`** — whether the module declared [`supports { }`](selection-dsl.md) and what it expanded to.
 - **`Registered`** — the intersection that registered. Every empty case states its reason: no `supports { }` call, a selection narrowed to nothing, or a disjoint `selection ∩ supported`.
+- **`Apple framework`** — present when the module declares [`appleFramework`](apple-framework.md): the declared name, the Apple leaves it attached to (`registered ∩ on`), its buildTypes, and whether XCFramework assembly is on. An empty `attached` is the [framework-without-an-Apple-target](advisories.md#framework-without-an-apple-target) state — the framework never builds.
 - **`Vocabulary`** — the parser's full preset and leaf list; a copy-paste surface for valid tokens.
 
 ### Per-leaf annotations
@@ -81,6 +88,7 @@ kmp-targets doctor — :jvm-tools
 | `selection matches nothing supported` | [empty overlap](advisories.md#empty-overlap) |
 | `inert module` | [inert modules](advisories.md#inert-modules) |
 | `JVM-less commonMain` | [native-only metadata](advisories.md#native-only-metadata) |
+| `framework declared but unattached` | [framework without an Apple target](advisories.md#framework-without-an-apple-target) |
 | `androidTarget skipped` | [android without AGP](advisories.md#android-target-without-agp) |
 | `not compilable on this host` | [host compatibility](advisories.md#host-compatibility) |
 | `deprecated targets registered` | [deprecated targets](advisories.md#deprecated-targets) |
@@ -88,6 +96,8 @@ kmp-targets doctor — :jvm-tools
 | `note: jvm (registered as: …)` | a [renamed target](selection-dsl.md#renaming-the-jvm-target) — context, not a problem |
 
 `single-target KSP` is doctor-only: it fires when a KSP plugin is applied and exactly one target is registered, so the commonMain metadata route (`kspCommonMainKotlinMetadata`, which needs [≥2 targets](recipes.md#commonmain-ksp-needs-two-targets)) is absent. Whether the module *actually* generates into `commonMain` is unobservable, so the finding flags the risk rather than a certainty — and there is no build-time advisory or strict-mode escalation for it.
+
+Doctor also renders the same **Apple framework** facts block as [`kmpTargetsInfo`](#kmptargetsinfo) (declared name, attached leaves, buildTypes, XCFramework on/off), from the same providers so the two surfaces can't drift. It renders even for a module that declared a framework but never called `supports { }` — so a declared-but-unattached framework is always visible, even where there is no advisory.
 
 ### Project-edge closure
 

--- a/docs/why-kmp-targets.md
+++ b/docs/why-kmp-targets.md
@@ -34,7 +34,7 @@ Because the plugin knows each module's registered set, it applies a [minimal tem
 
 ## Diagnostics philosophy
 
-- **Advisories are signal-only.** Five of the six never change what registers. The exception is [android-without-AGP](user-guide/advisories.md#android-target-without-agp), which skips the leaf because the alternative is KGP's raw `AndroidGradlePluginIsMissing` crash with no module-level guidance — during build-logic migrations that crash reads as "kmp-targets dropped my target".
+- **Advisories are signal-only.** Six of the seven never change what registers. The exception is [android-without-AGP](user-guide/advisories.md#android-target-without-agp), which skips the leaf because the alternative is KGP's raw `AndroidGradlePluginIsMissing` crash with no module-level guidance — during build-logic migrations that crash reads as "kmp-targets dropped my target".
 - **Strict mode changes severity, never policy.** `kmptargets.strict=true` turns the same advisories with the same text into failures. It never changes which configurations are flagged or what registers.
 - **Doctor renders, it does not own predicates.** Every [`kmpTargetsDoctor`](user-guide/diagnostics.md#kmptargetsdoctor) finding keys off the same decision its advisory used, so the report cannot disagree with what happened.
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -230,6 +230,50 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     internal var appleFrameworkDeclared: Boolean = false
 
     /**
+     * Immutable facts captured the moment [appleFramework] is declared (#107): the baseName, the
+     * `on` scope, the creation-time buildTypes, and whether an XCFramework was requested. Null
+     * until a framework is declared. Config-cache safe — only immutable values (a String, a
+     * [KmpTargetSet] of `data object` leaves, a [NativeBuildType] enum set, a Boolean); no
+     * `Project` or task. The `kmpTargetsInfo`/`kmpTargetsDoctor` providers render these so the two
+     * surfaces can never drift from what was declared.
+     */
+    internal var appleFrameworkFacts: AppleFrameworkFacts? = null
+
+    /**
+     * The Apple leaves the declared framework was **actually attached to** — the ground truth of
+     * `registered ∩ on ∩ apple`, added in the [appleFramework] attach callback as each leaf
+     * resolves to its live KGP target (#107). The framework-unattached advisory keys off this being
+     * empty; info/doctor render it as the attached leaf ids. Mutated only from synchronous,
+     * configuration-time `onRegistered` actions, so the plain set needs no synchronization.
+     */
+    internal val appleFrameworkAttachedLeaves: MutableSet<KmpTarget> = mutableSetOf()
+
+    /**
+     * True once the framework-unattached advisory (#107) fired, so it fires at most once per
+     * module. A boolean (not a set), mirroring [inertWarned]/[nativeOnlyMetadataWarned]: being
+     * unattached is a whole-module property and registration is one-way — once an Apple leaf in the
+     * framework's scope attaches, the module can never become unattached again.
+     */
+    internal var frameworkUnattachedWarned: Boolean = false
+
+    /**
+     * Fired at the end of [appleFramework], once its attach subscription has replayed against any
+     * already-registered Apple leaves; the plugin wires this to re-evaluate the
+     * framework-unattached advisory (#107). Null until the plugin runs. The replay-path twin of
+     * [onSupports]: a framework declared AFTER a (say jvm-only) `supports { }` attaches nothing on
+     * replay, and only this hook — not another `supports { }` call — gives the advisory its chance
+     * to fire.
+     */
+    internal var onAppleFrameworkDeclared: (() -> Unit)? = null
+
+    /**
+     * Snapshot of [appleFrameworkAttachedLeaves] as a [KmpTargetSet] (#107) — what the advisory
+     * predicate and the info/doctor providers read, mirroring [registered]'s snapshot style.
+     */
+    internal fun frameworkAttachedLeaves(): KmpTargetSet =
+        KmpTargetSet.of(*appleFrameworkAttachedLeaves.toTypedArray())
+
+    /**
      * The per-module `kmpCompileAll` umbrella task (#77), registered unconditionally at apply time.
      * The eager registration loop appends one compile-task dependency per registered leaf, so the
      * umbrella ends up depending on exactly the registered intersection — selection-agnostic and
@@ -334,7 +378,7 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
      * the extension) from a task action.
      */
     public fun onAppleTarget(action: KotlinNativeTarget.() -> Unit): Unit =
-        onAppleNativeTarget(KmpTargetSet.apple, action)
+        onAppleNativeTarget(KmpTargetSet.apple) { action() }
 
     /**
      * Declares a Kotlin **Apple framework** once and attaches it to every registered Apple leaf in
@@ -400,12 +444,18 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
             )
         }
         appleFrameworkDeclared = true
+        appleFrameworkFacts = AppleFrameworkFacts(baseName, on, buildTypes.toSet(), xcframework)
         // Lazy XCFramework config (#106): created on the first Apple attach via the target's own
         // project (AbstractKotlinTarget.getProject), so a selection that registers no Apple leaf
         // never materializes an assemble…XCFramework task. onRegistered fires synchronously at
         // configuration time, so the plain var needs no synchronization.
         var xcframeworkConfig: XCFrameworkConfig? = null
-        onAppleNativeTarget(on) {
+        onAppleNativeTarget(on) { leaf ->
+            // Record the genuine attach (#107): this block runs only once a registered Apple leaf
+            // in
+            // `on` resolved to a live KGP target, so the set is exactly what the framework built
+            // for.
+            appleFrameworkAttachedLeaves += leaf
             val config =
                 if (xcframework) {
                     xcframeworkConfig
@@ -423,6 +473,12 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
                 config?.add(this)
             }
         }
+        // The subscription above replayed synchronously against any already-registered Apple
+        // leaves,
+        // so the attached-leaf set is now final for the current selection. Re-evaluate the
+        // framework-unattached advisory (#107): this is the only firing path when the framework is
+        // declared AFTER a supports { } that no longer re-runs register().
+        onAppleFrameworkDeclared?.invoke()
     }
 
     /**
@@ -431,11 +487,31 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
      * [KotlinNativeTarget] through [kotlinTargetByName] before invoking [block]. The null-safe
      * chain means it is inert until the plugin installs the resolver under `withPlugin(KGP_ID)`.
      */
-    private fun onAppleNativeTarget(within: KmpTargetSet, block: KotlinNativeTarget.() -> Unit) {
+    private fun onAppleNativeTarget(
+        within: KmpTargetSet,
+        block: KotlinNativeTarget.(KmpTarget) -> Unit,
+    ) {
         onRegistered { registered ->
-            if (registered.leaf is KmpTarget.Native.Apple && registered.leaf in within) {
-                (kotlinTargetByName?.invoke(registered.gradleName) as? KotlinNativeTarget)?.block()
+            val leaf = registered.leaf
+            if (leaf is KmpTarget.Native.Apple && leaf in within) {
+                (kotlinTargetByName?.invoke(registered.gradleName) as? KotlinNativeTarget)?.block(
+                    leaf
+                )
             }
         }
     }
 }
+
+/**
+ * Immutable snapshot of an [KmpTargetsExtension.appleFramework] declaration (#107), captured at
+ * declaration time so `kmpTargetsInfo`/`kmpTargetsDoctor` can render the framework facts without
+ * re-deriving them. Config-cache safe by construction: every field is an immutable value — no
+ * `Project`, task, or live KGP type is held. Mirrors the immutable-record style of
+ * [com.rsicarelli.kmptargets.model.RegisteredTarget].
+ */
+internal data class AppleFrameworkFacts(
+    val baseName: String,
+    val on: KmpTargetSet,
+    val buildTypes: Set<NativeBuildType>,
+    val xcframework: Boolean,
+)

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -98,6 +98,17 @@ public class KmpTargetsPlugin : Plugin<Project> {
             }
         }
 
+        // The framework-unattached advisory (#107) also fires on the appleFramework() replay path:
+        // a
+        // framework declared AFTER a (e.g. jvm-only) supports { } attaches nothing and no longer
+        // re-runs register(), so this hook re-evaluates it under the same KGP guard and the same
+        // apply-time strict primitive — never capturing a Project into a task.
+        ext.onAppleFrameworkDeclared = {
+            target.pluginManager.withPlugin(KGP_ID) {
+                maybeWarnFrameworkUnattached(target, ext, strict)
+            }
+        }
+
         registerInfoTask(target, ext, configOrigin)
         registerDoctorTask(target, ext)
 
@@ -238,6 +249,11 @@ public class KmpTargetsPlugin : Plugin<Project> {
             task.androidWithoutAgp.set(androidWithoutAgpProvider(target, ext))
             task.inertModule.set(inertModuleProvider(target, ext))
             task.nativeOnlyMetadata.set(nativeOnlyMetadataProvider(target, ext))
+            task.frameworkDeclared.set(frameworkDeclaredProvider(target, ext))
+            task.frameworkBaseName.set(frameworkBaseNameProvider(target, ext))
+            task.frameworkAttachedIds.set(frameworkAttachedIdsProvider(target, ext))
+            task.frameworkBuildTypes.set(frameworkBuildTypesProvider(target, ext))
+            task.frameworkXcframework.set(frameworkXcframeworkProvider(target, ext))
             // The config-layer origin is fixed at apply time, but the fallback labels must read
             // `defaultSelection` lazily — the body may override it after apply.
             task.originLabel.set(
@@ -331,6 +347,12 @@ public class KmpTargetsPlugin : Plugin<Project> {
             task.registeredDeprecatedIds.set(registeredDeprecatedIdsProvider(target, ext))
             task.singleTargetKsp.set(singleTargetKspProvider(target, ext))
             task.jvmRegisteredAs.set(jvmRegisteredAsProvider(target, ext))
+            task.frameworkDeclared.set(frameworkDeclaredProvider(target, ext))
+            task.frameworkBaseName.set(frameworkBaseNameProvider(target, ext))
+            task.frameworkAttachedIds.set(frameworkAttachedIdsProvider(target, ext))
+            task.frameworkBuildTypes.set(frameworkBuildTypesProvider(target, ext))
+            task.frameworkXcframework.set(frameworkXcframeworkProvider(target, ext))
+            task.frameworkUnattached.set(frameworkUnattachedProvider(target, ext))
             task.dependencyData.from(dependencyDataFiles)
         }
     }
@@ -390,6 +412,42 @@ public class KmpTargetsPlugin : Plugin<Project> {
                     )
                 }
             }
+        }
+    }
+
+    /**
+     * Fires the framework-unattached advisory (#107) at most once per module: when a framework is
+     * declared, this module declared `supports { }`, and zero Apple leaves in the framework's `on`
+     * scope attached. Shared by the end of every [register] pass and the [appleFramework] replay
+     * hook, so it fires regardless of whether the framework was declared before or after `supports
+     * { }`. The dedup flag is set AFTER [warnOrFail] (mirroring the sibling advisories) so a strict
+     * failure leaves no bookkeeping behind. Keyed off the `on`-scoped attached-leaf set, so a
+     * framework scoped to leaves the selection never registered is flagged even when other Apple
+     * leaves did register.
+     */
+    private fun maybeWarnFrameworkUnattached(
+        project: Project,
+        ext: KmpTargetsExtension,
+        strict: Boolean,
+    ) {
+        if (
+            !ext.frameworkUnattachedWarned &&
+                shouldWarnFrameworkUnattached(
+                    ext.appleFrameworkDeclared,
+                    ext.supportsProperty.isPresent,
+                    ext.frameworkAttachedLeaves(),
+                )
+        ) {
+            warnOrFail(
+                strict,
+                frameworkUnattachedWarning(
+                    project.path,
+                    ext.appleFrameworkFacts?.baseName.orEmpty(),
+                ),
+            ) {
+                project.logger.warn(it)
+            }
+            ext.frameworkUnattachedWarned = true
         }
     }
 
@@ -475,6 +533,47 @@ public class KmpTargetsPlugin : Plugin<Project> {
         target.provider {
             hasKgp(target) &&
                 shouldWarnSingleTargetKsp(target.pluginManager.hasPlugin(KSP_ID), ext.registered())
+        }
+
+    // Framework facts (#107), rendered identically by kmpTargetsInfo and kmpTargetsDoctor. The
+    // declaration facts (declared / name / buildTypes / xcframework) are KGP-independent — a
+    // framework is declared whether or not KGP applied — while the attached-leaf and unattached
+    // providers reflect what actually registered (naturally empty/false without KGP).
+    // frameworkUnattached calls the SAME predicate the advisory uses, so doctor's finding can never
+    // drift from the warning.
+    private fun frameworkDeclaredProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            ext.appleFrameworkDeclared
+        }
+
+    private fun frameworkBaseNameProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            ext.appleFrameworkFacts?.baseName.orEmpty()
+        }
+
+    private fun frameworkAttachedIdsProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            ids(ext.frameworkAttachedLeaves())
+        }
+
+    private fun frameworkBuildTypesProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            ext.appleFrameworkFacts?.buildTypes?.map { it.name }?.sorted().orEmpty()
+        }
+
+    private fun frameworkXcframeworkProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            ext.appleFrameworkFacts?.xcframework ?: false
+        }
+
+    private fun frameworkUnattachedProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            hasKgp(target) &&
+                shouldWarnFrameworkUnattached(
+                    ext.appleFrameworkDeclared,
+                    ext.supportsProperty.isPresent,
+                    ext.frameworkAttachedLeaves(),
+                )
         }
 
     internal companion object {
@@ -837,6 +936,17 @@ public class KmpTargetsPlugin : Plugin<Project> {
             ext.nativeOnlyMetadataWarned = true
         }
 
+        // Framework-unattached advisory (#107): a framework is declared but this selection attached
+        // it to no Apple leaf in its `on` scope (jvm-only, or an `on` narrower than what
+        // registered),
+        // so it never materializes and an Xcode build consuming it fails downstream. LAST in the
+        // consequence channel: under strict the cause advisories and the more fundamental
+        // inert/JVM-less consequences above win the exception; this is the most specific
+        // consequence
+        // and reads last. The helper is shared with the appleFramework() replay hook so the firing
+        // is order-independent; it dedups and records bookkeeping AFTER warnOrFail.
+        maybeWarnFrameworkUnattached(project, ext, strict)
+
         // Deliberately receives the unfiltered active set even when android was skipped above:
         // android is ungrouped in the hierarchy taxonomy (it attaches straight to common and
         // never affects the native collapse), so filtering would change nothing.
@@ -1086,6 +1196,40 @@ internal fun nativeOnlyMetadataWarning(path: String): String =
         "constructs (e.g. @JvmInline): klibs build, metadata fails. Gate it in build-logic when " +
         "kmpTargets.registered(jvmFamily).isEmpty(), disabling only the *KotlinMetadata* " +
         "compilations."
+
+/**
+ * Whether to emit [frameworkUnattachedWarning] (#107): an `appleFramework` was declared, this
+ * module declared `supports { }`, yet [attachedLeaves] — the Apple leaves the framework actually
+ * attached to (`registered ∩ on ∩ apple`) — is empty. Keyed off the real attached set rather than
+ * the issue's literal `registered(apple)`, so a framework scoped via `on` to leaves the selection
+ * never registered is flagged even when other Apple leaves did register (e.g. `on = appleMobile`
+ * with only macOS registered). The `supportsDeclared` conjunct upholds the explicit-selection
+ * doctrine: a module that never declared `supports { }` registered nothing intentionally and is
+ * never flagged (the doctor still renders the declared-but-unattached facts). Pure over its inputs,
+ * so it is unit-testable without Gradle; the same decision drives the doctor finding.
+ */
+internal fun shouldWarnFrameworkUnattached(
+    frameworkDeclared: Boolean,
+    supportsDeclared: Boolean,
+    attachedLeaves: KmpTargetSet,
+): Boolean = frameworkDeclared && supportsDeclared && attachedLeaves.isEmpty()
+
+/**
+ * The framework-unattached advisory (#107). Mirrors its siblings in shape; serves as both the
+ * warning and the strict-mode failure text through [warnOrFail], so the two can never drift. Names
+ * the module, the framework ([baseName]), the gate (no Apple target in the framework's scope
+ * registered), the downstream consequence (an Xcode build consuming it fails with a missing
+ * framework), and the fix. Strict mode is the point: a release lane with `kmptargets.strict` and a
+ * misconfigured selection fails loudly at configuration instead of shipping a frameworkless
+ * artifact that breaks Xcode far downstream.
+ */
+internal fun frameworkUnattachedWarning(path: String, baseName: String): String =
+    "kmp-targets: '$path' declared appleFramework(\"$baseName\") but this selection registered no " +
+        "Apple target in its scope — the framework attaches to nothing and never builds, so an " +
+        "Xcode build consuming it fails downstream with a missing-framework error. Widen the " +
+        "selection (or this module's supports { }) to register an Apple target in the framework's " +
+        "`on` scope, or gate the appleFramework(…) declaration in build-logic when " +
+        "kmpTargets.registered(apple).isEmpty()."
 
 /**
  * Whether the `single-target KSP` **doctor finding** fires: a KSP plugin is applied yet exactly one

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormat.kt
@@ -39,9 +39,29 @@ internal fun formatKmpTargetsDoctor(
     jvmRegisteredAs: String?,
     closureDepCount: Int,
     closureGaps: List<ClosureGap>,
+    frameworkDeclared: Boolean = false,
+    frameworkBaseName: String = "",
+    frameworkAttachedIds: List<String> = emptyList(),
+    frameworkBuildTypes: List<String> = emptyList(),
+    frameworkXcframework: Boolean = false,
+    frameworkUnattached: Boolean = false,
 ): String = buildString {
     appendLine("kmp-targets doctor — $projectPath")
     appendLine()
+
+    // The Apple framework facts (#107) render BEFORE the supports early-exit, so a module that
+    // declared a framework but never called supports { } still reports its declared-but-unattached
+    // state (`attached: (none)`) — there is no advisory there, but the state is worth surfacing.
+    // The
+    // `[!]` framework finding below is separate and only fires when the advisory does.
+    if (frameworkDeclared) {
+        appendLine("Apple framework")
+        appendLine("  name:        $frameworkBaseName")
+        appendLine("  attached:    ${render(frameworkAttachedIds)}")
+        appendLine("  buildTypes:  ${render(frameworkBuildTypes)}")
+        appendLine("  xcframework: ${if (frameworkXcframework) "on" else "off"}")
+        appendLine()
+    }
 
     // A module that never declared supports { } registers nothing *intentionally* (explicit-
     // selection doctrine) — never a problem, and there is nothing downstream to check.
@@ -123,6 +143,20 @@ internal fun formatKmpTargetsDoctor(
                         "reject JVM-flavored constructs (e.g. @JvmInline)",
                     "fix:    gate on registered(jvmFamily).isEmpty() in build-logic, disabling " +
                         "only the *KotlinMetadata* compilations",
+                )
+            )
+        }
+        if (frameworkUnattached) {
+            add(
+                finding(
+                    "framework declared but unattached",
+                    "why:    appleFramework(\"$frameworkBaseName\") is declared but this selection " +
+                        "registered no Apple target in its scope",
+                    "effect: the framework attaches to nothing and never builds; an Xcode build " +
+                        "consuming it fails downstream with a missing-framework error",
+                    "fix:    widen the selection (or supports { }) to register an Apple target in " +
+                        "the framework's scope, or gate appleFramework(…) in build-logic when " +
+                        "registered(apple).isEmpty()",
                 )
             )
         }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorTask.kt
@@ -75,6 +75,29 @@ public abstract class KmpTargetsDoctorTask : DefaultTask() {
     @get:Internal public abstract val jvmRegisteredAs: Property<String>
 
     /**
+     * Whether this module declared an `appleFramework` (#107). The four facts below render the same
+     * values `kmpTargetsInfo` shows, from the same providers, so the surfaces can never drift. They
+     * render even when `supports { }` was never declared — a declared-but-unattached framework is
+     * still reported (`attached: (none)`), distinct from the no-advisory state.
+     */
+    @get:Internal public abstract val frameworkDeclared: Property<Boolean>
+
+    /** The declared framework's baseName (#107); blank when no framework was declared. */
+    @get:Internal public abstract val frameworkBaseName: Property<String>
+
+    /** Sorted ids of the Apple leaves the framework actually attached to (`registered ∩ on`). */
+    @get:Internal public abstract val frameworkAttachedIds: ListProperty<String>
+
+    /** The framework's creation-time native build types (e.g. `DEBUG`, `RELEASE`), sorted. */
+    @get:Internal public abstract val frameworkBuildTypes: ListProperty<String>
+
+    /** Whether the framework opted into XCFramework assembly (#106). */
+    @get:Internal public abstract val frameworkXcframework: Property<Boolean>
+
+    /** Same decision as the framework-unattached advisory (#107) — drives the `[!]` finding. */
+    @get:Internal public abstract val frameworkUnattached: Property<Boolean>
+
+    /**
      * The doctor-data files of this module's `project(...)` dependencies, resolved at execution
      * time through the lenient ArtifactView. Declaring them as inputs wires the dependency emit
      * tasks, so a `kmpTargetsDoctor` run materializes its dependencies' data first.
@@ -104,6 +127,12 @@ public abstract class KmpTargetsDoctorTask : DefaultTask() {
                 registeredDeprecatedIds = registeredDeprecatedIds.get(),
                 singleTargetKsp = singleTargetKsp.get(),
                 jvmRegisteredAs = jvmRegisteredAs.orNull?.takeIf { it.isNotBlank() },
+                frameworkDeclared = frameworkDeclared.get(),
+                frameworkBaseName = frameworkBaseName.get(),
+                frameworkAttachedIds = frameworkAttachedIds.get(),
+                frameworkBuildTypes = frameworkBuildTypes.get(),
+                frameworkXcframework = frameworkXcframework.get(),
+                frameworkUnattached = frameworkUnattached.get(),
                 closureDepCount = dependencies.size,
                 closureGaps = gaps,
             )

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
@@ -25,6 +25,11 @@ internal fun formatKmpTargetsInfo(
     androidWithoutAgp: Boolean = false,
     inertModule: Boolean = false,
     nativeOnlyMetadata: Boolean = false,
+    frameworkDeclared: Boolean = false,
+    frameworkBaseName: String = "",
+    frameworkAttachedIds: List<String> = emptyList(),
+    frameworkBuildTypes: List<String> = emptyList(),
+    frameworkXcframework: Boolean = false,
 ): String = buildString {
     appendLine("kmp-targets — $projectPath")
     appendLine()
@@ -84,6 +89,20 @@ internal fun formatKmpTargetsInfo(
             "  jvm-less: no JVM-family target registered — *KotlinMetadata* compilations reject " +
                 "@JvmInline etc. while the klibs compile; gate on registered(jvmFamily).isEmpty()"
         )
+    }
+    // The Apple framework section (#107) renders whenever a framework is declared — the same facts
+    // kmpTargetsDoctor shows, from the same providers. An empty `attached` is the unattached state:
+    // the framework will not build for this selection (the doctor explains the consequence + fix).
+    if (frameworkDeclared) {
+        appendLine()
+        appendLine("Apple framework")
+        appendLine("  name:        $frameworkBaseName")
+        appendLine(
+            "  attached:    " +
+                idsOrNone(frameworkAttachedIds, "no Apple target in its scope registered")
+        )
+        appendLine("  buildTypes:  ${frameworkBuildTypes.joinToString(", ")}")
+        appendLine("  xcframework: ${if (frameworkXcframework) "on" else "off"}")
     }
     appendLine()
     appendLine("Vocabulary")

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
@@ -97,6 +97,24 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
      */
     @get:Internal public abstract val nativeOnlyMetadata: Property<Boolean>
 
+    /**
+     * Whether this module declared an `appleFramework` (#107) — gates the Apple framework section.
+     * The facts below render the same values `kmpTargetsDoctor` shows, from the same providers.
+     */
+    @get:Internal public abstract val frameworkDeclared: Property<Boolean>
+
+    /** The declared framework's baseName (#107); blank when no framework was declared. */
+    @get:Internal public abstract val frameworkBaseName: Property<String>
+
+    /** Sorted ids of the Apple leaves the framework actually attached to (`registered ∩ on`). */
+    @get:Internal public abstract val frameworkAttachedIds: ListProperty<String>
+
+    /** The framework's creation-time native build types (e.g. `DEBUG`, `RELEASE`), sorted. */
+    @get:Internal public abstract val frameworkBuildTypes: ListProperty<String>
+
+    /** Whether the framework opted into XCFramework assembly (#106). */
+    @get:Internal public abstract val frameworkXcframework: Property<Boolean>
+
     @TaskAction
     public fun report() {
         println(
@@ -116,6 +134,11 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
                 androidWithoutAgp = androidWithoutAgp.get(),
                 inertModule = inertModule.get(),
                 nativeOnlyMetadata = nativeOnlyMetadata.get(),
+                frameworkDeclared = frameworkDeclared.get(),
+                frameworkBaseName = frameworkBaseName.get(),
+                frameworkAttachedIds = frameworkAttachedIds.get(),
+                frameworkBuildTypes = frameworkBuildTypes.get(),
+                frameworkXcframework = frameworkXcframework.get(),
             )
         )
     }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkFactsSurfaceParityTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkFactsSurfaceParityTest.kt
@@ -1,0 +1,75 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.doctor.formatKmpTargetsDoctor
+import com.rsicarelli.kmptargets.info.formatKmpTargetsInfo
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.parser.presetNames
+import kotlin.test.assertContains
+import org.junit.jupiter.api.Test
+
+/**
+ * Cross-surface parity (#107): `kmpTargetsInfo` and `kmpTargetsDoctor` render the framework facts —
+ * declared name, attached leaf ids, buildTypes, xcframework on/off — from the SAME shared
+ * providers, so the two surfaces can never drift. The in-process suites pin that both read the same
+ * extension state; this pins that, given identical facts, both formatters print byte-identical fact
+ * lines.
+ */
+class FrameworkFactsSurfaceParityTest {
+
+    @Test
+    fun `given identical framework facts when both surfaces render then they print the same name attached buildTypes and xcframework`() {
+        val attached = listOf("iosArm64", "iosSimulatorArm64")
+        val buildTypes = listOf("DEBUG", "RELEASE")
+
+        val info =
+            formatKmpTargetsInfo(
+                projectPath = ":shared",
+                selectionIds = attached,
+                supportedIds = attached,
+                supportsDeclared = true,
+                registeredIds = attached,
+                originLabel = "built-in default (all)",
+                presetNames = presetNames,
+                leafIds = KmpTarget.all.map { it.id }.sorted(),
+                hostImpossibleIds = emptyList(),
+                hostLabel = "",
+                deprecatedIds = emptyList(),
+                frameworkDeclared = true,
+                frameworkBaseName = "KotlinShared",
+                frameworkAttachedIds = attached,
+                frameworkBuildTypes = buildTypes,
+                frameworkXcframework = true,
+            )
+        val doctor =
+            formatKmpTargetsDoctor(
+                projectPath = ":shared",
+                supportsDeclared = true,
+                selectionIds = attached,
+                supportedIds = attached,
+                registeredIds = attached,
+                emptyOverlap = false,
+                inertModule = false,
+                nativeOnlyMetadata = false,
+                androidWithoutAgp = false,
+                hostImpossibleIds = emptyList(),
+                hostLabel = "",
+                registeredDeprecatedIds = emptyList(),
+                singleTargetKsp = false,
+                jvmRegisteredAs = null,
+                closureDepCount = 0,
+                closureGaps = emptyList(),
+                frameworkDeclared = true,
+                frameworkBaseName = "KotlinShared",
+                frameworkAttachedIds = attached,
+                frameworkBuildTypes = buildTypes,
+                frameworkXcframework = true,
+            )
+
+        listOf(info, doctor).forEach { output ->
+            assertContains(output, "name:        KotlinShared")
+            assertContains(output, "attached:    iosArm64, iosSimulatorArm64")
+            assertContains(output, "buildTypes:  DEBUG, RELEASE")
+            assertContains(output, "xcframework: on")
+        }
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkUnattachedAdvisoryInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkUnattachedAdvisoryInProcessTest.kt
@@ -1,0 +1,253 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.doctor.KmpTargetsDoctorTask
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * The framework-unattached advisory (#107) wired into eager registration: when a module declares an
+ * `appleFramework` and `supports { }`, but the selection attaches it to no Apple leaf in its `on`
+ * scope, the framework never materializes and an Xcode build consuming it fails downstream. The
+ * advisory names the module, the framework, and the gate, failing with the identical text under
+ * `kmptargets.strict=true` through the same [warnOrFail] escalation as every other advisory.
+ *
+ * It fires at the end of every `register()` pass AND on the `appleFramework()` replay hook, so it
+ * is order-immune (framework declared before or after `supports { }`). It is keyed off the
+ * genuinely attached leaves rather than `registered(apple)`, so an `on` scope narrower than what
+ * registered is flagged correctly. Last in the consequence channel: under strict, the cause
+ * advisories and the more fundamental inert/JVM-less consequences win the exception.
+ */
+class FrameworkUnattachedAdvisoryInProcessTest {
+
+    @Test
+    fun `given a jvm-only selection and a declared framework when supports is declared then the advisory fires`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared")
+        extension.supports { jvm }
+        assertEquals(setOf("jvm"), registeredTargets(project))
+        assertTrue(extension.frameworkAttachedLeaves().isEmpty())
+        assertTrue(extension.frameworkUnattachedWarned)
+    }
+
+    @Test
+    fun `given a framework scoped to appleMobile but only macOS registered when supports is declared then the advisory fires despite apple leaves registering`(
+        @TempDir dir: Path
+    ) {
+        // The on-scoped gate (#107): registered(apple) is non-empty (macOS registered), yet the
+        // framework — scoped to appleMobile — attached to nothing, so it still never builds. This
+        // is
+        // exactly the case the literal `registered(apple).isEmpty()` gate would miss.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=macosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared", on = KmpTargetSet.appleMobile)
+        extension.supports(KmpTargetSet.of(KmpTarget.Native.Apple.Macos.Arm64))
+        assertEquals(setOf("macosArm64"), registeredTargets(project))
+        assertEquals(KmpTargetSet.of(KmpTarget.Native.Apple.Macos.Arm64), extension.registered())
+        assertTrue(extension.frameworkAttachedLeaves().isEmpty())
+        assertTrue(extension.frameworkUnattachedWarned)
+    }
+
+    @Test
+    fun `given an apple leaf in the framework scope registers when supports is declared then the advisory stays silent`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared")
+        extension.supports(KmpTargetSet.appleMobile)
+        assertEquals(setOf("iosArm64"), registeredTargets(project))
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64),
+            extension.frameworkAttachedLeaves(),
+        )
+        assertFalse(extension.frameworkUnattachedWarned)
+    }
+
+    @Test
+    fun `given a framework declared AFTER a jvm-only supports when declared then the replay hook fires the advisory`(
+        @TempDir dir: Path
+    ) {
+        // The order that needs the dedicated hook: supports { } already ran register() (no
+        // framework
+        // then), and declaring the framework no longer re-runs register() — only its replay hook
+        // gives the advisory a chance to fire.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { jvm }
+        assertFalse(extension.frameworkUnattachedWarned)
+        extension.appleFramework("KotlinShared")
+        assertTrue(extension.frameworkUnattachedWarned)
+    }
+
+    @Test
+    fun `given a framework declared on a jvm-only module when a later supports union attaches an apple leaf then the state resolves`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64,jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared")
+        extension.supports { jvm }
+        assertTrue(extension.frameworkUnattachedWarned)
+        // Registration is one-way: the union registers iosArm64, the framework attaches, and the
+        // attached set goes (permanently) non-empty — the predicate can never flag this module
+        // again.
+        extension.supports(KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64))
+        assertEquals(setOf("iosArm64", "jvm"), registeredTargets(project))
+        assertEquals(
+            KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64),
+            extension.frameworkAttachedLeaves(),
+        )
+    }
+
+    @Test
+    fun `given a framework but supports never called when the project configures then no advisory fires but the doctor renders the facts`(
+        @TempDir dir: Path
+    ) {
+        // Explicit-selection doctrine: no supports { } means register() never runs and the
+        // predicate
+        // is gated off, so there is no advisory — but the declared-but-unattached state is still
+        // worth surfacing, so the doctor renders it (attached: empty, no finding).
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared")
+        assertFalse(extension.frameworkUnattachedWarned)
+        val doctor = doctor(project)
+        assertTrue(doctor.frameworkDeclared.get())
+        assertEquals("KotlinShared", doctor.frameworkBaseName.get())
+        assertEquals(emptyList(), doctor.frameworkAttachedIds.get())
+        assertFalse(doctor.frameworkUnattached.get())
+    }
+
+    @Test
+    fun `given no KGP applied when a framework and supports are declared then no advisory fires`(
+        @TempDir dir: Path
+    ) {
+        // Without KGP nothing registers and onRegistered never fires, so the framework attaches to
+        // nothing — but there is no link/embed task to break either. The replay hook's KGP guard
+        // keeps it quiet, consistent with the sibling advisories.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosArm64\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared")
+        extension.supports(KmpTargetSet.appleMobile)
+        assertFalse(extension.frameworkUnattachedWarned)
+    }
+
+    @Test
+    fun `given strict on and a framework declared before a jvm-only supports when supports runs then the build fails with the framework text`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared")
+        val ex = assertFailsWith<GradleException> { extension.supports { jvm } }
+        assertEquals(frameworkUnattachedWarning(project.path, "KotlinShared"), ex.message)
+    }
+
+    @Test
+    fun `given strict on and a framework declared after a jvm-only supports when declared then the replay hook fails with the framework text`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.supports { jvm }
+        val ex = assertFailsWith<GradleException> { extension.appleFramework("KotlinShared") }
+        assertEquals(frameworkUnattachedWarning(project.path, "KotlinShared"), ex.message)
+    }
+
+    @Test
+    fun `given strict on when the framework advisory throws then it leaves no dedup bookkeeping behind`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared")
+        assertFailsWith<GradleException> { extension.supports { jvm } }
+        // Mirrors the sibling advisories: the flag is recorded AFTER warnOrFail, so a strict
+        // failure
+        // does not mark the module as already-warned.
+        assertFalse(extension.frameworkUnattachedWarned)
+    }
+
+    @Test
+    fun `given strict on and an explicitly empty selection with a declared framework when supports is declared then inert wins over the framework advisory`(
+        @TempDir dir: Path
+    ) {
+        // Ordering proof: an inert module (registered nothing) with a declared framework trips BOTH
+        // inert and framework-unattached. Inert is emitted first (the more fundamental
+        // consequence),
+        // so its text wins the strict exception; the framework advisory — last — is never reached.
+        dir.resolve("gradle.properties")
+            .writeText("kmptargets.targets=jvm,-jvm\nkmptargets.strict=true\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared")
+        val ex = assertFailsWith<GradleException> { extension.supports(KmpTargetSet.appleMobile) }
+        assertEquals(inertModuleWarning(project.path), ex.message)
+        assertFalse(extension.frameworkUnattachedWarned)
+    }
+
+    @Test
+    fun `given an unattached framework when the doctor finding input is read then it is true`(
+        @TempDir dir: Path
+    ) {
+        // Same decision source as the advisory (shouldWarnFrameworkUnattached over the attached
+        // set),
+        // realized lazily at task-graph calculation — so doctor's finding cannot drift.
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=jvm\n")
+        val project = newProjectWithKgp(dir)
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared")
+        extension.supports { jvm }
+        assertTrue(doctor(project).frameworkUnattached.get())
+    }
+
+    private fun newProjectWithKgp(dir: Path): Project {
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        return project
+    }
+
+    private fun ext(project: Project): KmpTargetsExtension =
+        project.extensions.getByType(KmpTargetsExtension::class.java)
+
+    private fun doctor(project: Project): KmpTargetsDoctorTask =
+        project.tasks.getByName("kmpTargetsDoctor") as KmpTargetsDoctorTask
+
+    private fun registeredTargets(project: Project): Set<String> =
+        project.extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .names
+            .filter { it != "metadata" }
+            .toSet()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkUnattachedAdvisoryTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkUnattachedAdvisoryTest.kt
@@ -1,0 +1,83 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure decision/message facts of the framework-unattached advisory (#107): a module that declared
+ * an `appleFramework` and called `supports { }`, yet attached the framework to zero Apple leaves
+ * (`registered ∩ on ∩ apple` is empty), ships a frameworkless artifact that breaks an Xcode build
+ * downstream. The predicate keys off the actually-attached set, so it is cause-agnostic over WHY
+ * the set is empty (a jvm-only selection, or an `on` scope narrower than what registered); the
+ * `on`-scoped gate itself is proven end-to-end by [FrameworkUnattachedAdvisoryInProcessTest]. No
+ * Gradle here; the wiring (warnOrFail + dedup + ordering + replay) is proven by the in-process
+ * suite.
+ */
+class FrameworkUnattachedAdvisoryTest {
+
+    private val iosArm64 = KmpTarget.Native.Apple.Ios.Arm64
+
+    @Test
+    fun `given a declared framework and supports with zero attached leaves when the policy is computed then it flags`() {
+        assertTrue(
+            shouldWarnFrameworkUnattached(
+                frameworkDeclared = true,
+                supportsDeclared = true,
+                attachedLeaves = KmpTargetSet.empty,
+            )
+        )
+    }
+
+    @Test
+    fun `given a declared framework with an attached apple leaf when the policy is computed then it does not flag`() {
+        assertFalse(
+            shouldWarnFrameworkUnattached(
+                frameworkDeclared = true,
+                supportsDeclared = true,
+                attachedLeaves = KmpTargetSet.of(iosArm64),
+            )
+        )
+    }
+
+    @Test
+    fun `given no framework declared when the policy is computed then it does not flag`() {
+        // The advisory is scoped to declared frameworks: a module that never called appleFramework
+        // has nothing to attach, so an empty attached set is not a problem.
+        assertFalse(
+            shouldWarnFrameworkUnattached(
+                frameworkDeclared = false,
+                supportsDeclared = true,
+                attachedLeaves = KmpTargetSet.empty,
+            )
+        )
+    }
+
+    @Test
+    fun `given supports never declared when the policy is computed then it does not flag`() {
+        // Explicit-selection doctrine: a module that never called supports { } registered nothing
+        // intentionally — the doctor still renders the declared-but-unattached facts, but there is
+        // no advisory.
+        assertFalse(
+            shouldWarnFrameworkUnattached(
+                frameworkDeclared = true,
+                supportsDeclared = false,
+                attachedLeaves = KmpTargetSet.empty,
+            )
+        )
+    }
+
+    @Test
+    fun `given a module path and baseName when the warning is built then it names the module the framework the gate the consequence and the fix`() {
+        val message = frameworkUnattachedWarning(":shared", "KotlinShared")
+        assertContains(message, ":shared")
+        assertContains(message, "KotlinShared")
+        assertContains(message, "no Apple target in its scope")
+        assertContains(message, "Xcode")
+        assertContains(message, "Widen the selection")
+        assertContains(message, "registered(apple).isEmpty()")
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormatTest.kt
@@ -193,6 +193,60 @@ class KmpTargetsDoctorFormatTest {
     }
 
     @Test
+    fun `given an unattached framework when formatted then it explains the cause effect and fix`() {
+        val output =
+            format(
+                selectionIds = listOf("jvm"),
+                supportedIds = listOf("jvm"),
+                registeredIds = listOf("jvm"),
+                frameworkDeclared = true,
+                frameworkBaseName = "KotlinShared",
+                frameworkAttachedIds = emptyList(),
+                frameworkUnattached = true,
+            )
+        assertContains(output, "[!] framework declared but unattached")
+        assertContains(output, "KotlinShared")
+        assertContains(output, "missing-framework error")
+        assertContains(output, "registered(apple).isEmpty()")
+    }
+
+    @Test
+    fun `given a declared framework when formatted then the Apple framework facts render`() {
+        val output =
+            format(
+                registeredIds = listOf("iosArm64"),
+                frameworkDeclared = true,
+                frameworkBaseName = "KotlinShared",
+                frameworkAttachedIds = listOf("iosArm64"),
+                frameworkBuildTypes = listOf("DEBUG", "RELEASE"),
+                frameworkXcframework = true,
+            )
+        assertContains(output, "Apple framework")
+        assertContains(output, "name:        KotlinShared")
+        assertContains(output, "attached:    iosArm64")
+        assertContains(output, "buildTypes:  DEBUG, RELEASE")
+        assertContains(output, "xcframework: on")
+    }
+
+    @Test
+    fun `given a framework declared but supports never called when formatted then the facts render with no finding`() {
+        // Explicit-selection doctrine: no supports { } means no advisory, but the declared-but-
+        // unattached state is still surfaced — the facts render even though the report early-exits.
+        val output =
+            format(
+                supportsDeclared = false,
+                registeredIds = emptyList(),
+                frameworkDeclared = true,
+                frameworkBaseName = "KotlinShared",
+                frameworkAttachedIds = emptyList(),
+            )
+        assertContains(output, "Apple framework")
+        assertContains(output, "attached:    (none)")
+        assertContains(output, "never called supports { }")
+        assertFalse("[!]" in output, output)
+    }
+
+    @Test
     fun `given identical inputs when formatted twice then the output is identical`() {
         // Config-cache contract: pure function of primitives.
         assertTrue(format() == format())
@@ -215,6 +269,12 @@ class KmpTargetsDoctorFormatTest {
         jvmRegisteredAs: String? = null,
         closureDepCount: Int = 0,
         closureGaps: List<ClosureGap> = emptyList(),
+        frameworkDeclared: Boolean = false,
+        frameworkBaseName: String = "",
+        frameworkAttachedIds: List<String> = emptyList(),
+        frameworkBuildTypes: List<String> = emptyList(),
+        frameworkXcframework: Boolean = false,
+        frameworkUnattached: Boolean = false,
     ): String =
         formatKmpTargetsDoctor(
             projectPath = projectPath,
@@ -233,5 +293,11 @@ class KmpTargetsDoctorFormatTest {
             jvmRegisteredAs = jvmRegisteredAs,
             closureDepCount = closureDepCount,
             closureGaps = closureGaps,
+            frameworkDeclared = frameworkDeclared,
+            frameworkBaseName = frameworkBaseName,
+            frameworkAttachedIds = frameworkAttachedIds,
+            frameworkBuildTypes = frameworkBuildTypes,
+            frameworkXcframework = frameworkXcframework,
+            frameworkUnattached = frameworkUnattached,
         )
 }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
@@ -236,6 +236,45 @@ class KmpTargetsInfoFormatTest {
         assertFalse("iosX64 (deprecated)" in output, output)
     }
 
+    @Test
+    fun `given a declared framework when formatted then the Apple framework section renders all four facts`() {
+        val output =
+            format(
+                registeredIds = listOf("iosArm64"),
+                frameworkDeclared = true,
+                frameworkBaseName = "KotlinShared",
+                frameworkAttachedIds = listOf("iosArm64"),
+                frameworkBuildTypes = listOf("DEBUG", "RELEASE"),
+                frameworkXcframework = true,
+            )
+        assertContains(output, "Apple framework")
+        assertContains(output, "name:        KotlinShared")
+        assertContains(output, "attached:    iosArm64")
+        assertContains(output, "buildTypes:  DEBUG, RELEASE")
+        assertContains(output, "xcframework: on")
+    }
+
+    @Test
+    fun `given a declared framework with no attached leaves when formatted then the attached line names the empty scope`() {
+        val output =
+            format(
+                registeredIds = listOf("jvm"),
+                frameworkDeclared = true,
+                frameworkBaseName = "KotlinShared",
+                frameworkAttachedIds = emptyList(),
+                frameworkBuildTypes = listOf("DEBUG", "RELEASE"),
+                frameworkXcframework = false,
+            )
+        assertContains(output, "attached:    (none — no Apple target in its scope registered)")
+        assertContains(output, "xcframework: off")
+    }
+
+    @Test
+    fun `given no declared framework when formatted then no Apple framework section appears`() {
+        val output = format(registeredIds = listOf("jvm"))
+        assertFalse("Apple framework" in output, output)
+    }
+
     private fun format(
         selectionIds: List<String> = listOf("jvm"),
         supportedIds: List<String> = listOf("jvm"),
@@ -249,6 +288,11 @@ class KmpTargetsInfoFormatTest {
         androidWithoutAgp: Boolean = false,
         inertModule: Boolean = false,
         nativeOnlyMetadata: Boolean = false,
+        frameworkDeclared: Boolean = false,
+        frameworkBaseName: String = "",
+        frameworkAttachedIds: List<String> = emptyList(),
+        frameworkBuildTypes: List<String> = emptyList(),
+        frameworkXcframework: Boolean = false,
     ): String =
         formatKmpTargetsInfo(
             projectPath = ":shared-core",
@@ -266,5 +310,10 @@ class KmpTargetsInfoFormatTest {
             androidWithoutAgp = androidWithoutAgp,
             inertModule = inertModule,
             nativeOnlyMetadata = nativeOnlyMetadata,
+            frameworkDeclared = frameworkDeclared,
+            frameworkBaseName = frameworkBaseName,
+            frameworkAttachedIds = frameworkAttachedIds,
+            frameworkBuildTypes = frameworkBuildTypes,
+            frameworkXcframework = frameworkXcframework,
         )
 }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTaskTest.kt
@@ -37,6 +37,32 @@ class KmpTargetsInfoTaskTest {
     }
 
     @Test
+    fun `given a declared framework when the info task is realized then it exposes the framework facts`(
+        @TempDir dir: Path
+    ) {
+        // No KGP here, so nothing registers and the framework attaches to nothing — but the
+        // declared
+        // facts (name, buildTypes, xcframework) are captured at appleFramework() time regardless.
+        val project = newAppliedProject(dir)
+        project.extensions
+            .getByType(KmpTargetsExtension::class.java)
+            .appleFramework("KotlinShared", xcframework = true)
+        val task = infoTask(project)
+        assertTrue(task.frameworkDeclared.get())
+        assertEquals("KotlinShared", task.frameworkBaseName.get())
+        assertEquals(listOf("DEBUG", "RELEASE"), task.frameworkBuildTypes.get())
+        assertTrue(task.frameworkXcframework.get())
+        assertEquals(emptyList(), task.frameworkAttachedIds.get())
+    }
+
+    @Test
+    fun `given no declared framework when the info task is realized then frameworkDeclared is false`(
+        @TempDir dir: Path
+    ) {
+        assertFalse(infoTask(newAppliedProject(dir)).frameworkDeclared.get())
+    }
+
+    @Test
     fun `given defaultSelection overridden after apply when info task is realized then origin is the build-logic default`(
         @TempDir dir: Path
     ) {


### PR DESCRIPTION
## Summary

With #105/#106, a module can declare `appleFramework(...)` while the selection registers no Apple target in its `on` scope (e.g. `kmptargets.targets=jvm`). The framework then silently never materializes, and an Xcode build consuming it fails far downstream with a missing-framework error that says nothing about target selection. This adds the **seventh advisory**, modelled exactly on the inert-module (#71) consequence-channel pattern, plus framework facts in both diagnostic surfaces.

## Changes

- **Predicate** `shouldWarnFrameworkUnattached(frameworkDeclared, supportsDeclared, attachedLeaves)` — pure, no Gradle types. Warns by default; `kmptargets.strict` fails with identical text. Deduped once per module; registration is one-way, so a later attaching `supports {}` resolves it permanently.
- **Firing** at the end of every `register()` pass **and** on a new `appleFramework()` replay hook, so it is order-immune (framework declared before or after `supports {}`). Placed **last** in the consequence channel — inert / JVM-less win the strict exception first.
- **Extension** captures an immutable `AppleFrameworkFacts(baseName, on, buildTypes, xcframework)` plus an attached-leaf set recorded in the attach callback. Config-cache safe (immutable values, no `Project`/task captured).
- **`kmpTargetsInfo` + `kmpTargetsDoctor`** both render the framework facts (declared name, attached leaf ids, buildTypes, xcframework on/off) from the **same shared providers**, so the two surfaces can't drift. The doctor renders them even with no `supports {}` (explicit-selection doctrine: no advisory, but the declared-but-unattached state is still surfaced).
- **Docs**: `advisories.md` (six → seven + a new section), `diagnostics.md`, `why-kmp-targets.md`, `README.md`, and `apple-framework.md` (drops the now-implemented "unattached-framework advisory" out-of-scope item and adds a cross-reference).

### ⚠️ Deviation from the issue's acceptance text (approved)

The issue states the gate as "`registered(apple)` is empty". The merged `on` filter (#105) makes the honest gate **`registered ∩ on ∩ apple` is empty** — a framework scoped `on = appleMobile` with only `macosArm64` registered is genuinely unattached even though Apple leaves *are* registered. The predicate keys off the **actually-attached** leaf set, which is strictly more correct; the message names that gate. (Confirmed with the maintainer before implementation.) Two minor notes: strict-mode tests are co-located in the advisory's in-process suite (mirroring #71) rather than `KmpTargetsStrictModeTest`, and no CHANGELOG entry was added — matching #105/#106, which also did not changelog the Apple-framework line of work.

## Test plan

- [x] `./gradlew :gradle-plugin:test` and `:gradle-plugin:ktfmtCheck` green locally (full `task ci` not run: `task`/Kotlin-Native toolchain absent in the sandbox)
- [x] Verified end-to-end in the standalone `samples/hello-world` (`core-and-apple`): info + doctor render the facts when attached; the warning fires + doctor finding shows under a `jvm`-only lane
- [x] Added/updated tests (pure predicate; in-process firing / on-scoped gate / replay-order / resolution / strict / ordering / no-supports; info + doctor format + cross-surface parity)
- [x] Updated docs/README
- [x] No new public API without explicit intent (all new state is `internal`; `onAppleTarget`'s public signature is unchanged)

## Related

- Depends on #105 (appleFramework) and #106 (xcframework), both merged.
- Pattern siblings: #71 (inert module), #72 (native-only metadata). Surfaces: #33 (info), #82 (doctor). Strict mode: #34.
- Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVKE6dTW1aMMhZ6sfbYNK8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVKE6dTW1aMMhZ6sfbYNK8)_