### PR TITLE
feat(#108): framework build types via the selection-sources chain (kmptargets.framework.buildTypes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.gith
 - [Build Logic](https://rsicarelli.github.io/kmp-targets/user-guide/build-logic/) — conventions, `onRegistered`, helpers
 - [Apple Framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) — `appleFramework`, `onAppleTarget`, route-to-real-KGP
 - [Recipes](https://rsicarelli.github.io/kmp-targets/user-guide/recipes/) — KSP gates, AGP gating, dependency-graph rules
-- [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/user-guide/advisories/) — the seven advisories and CI strictness
+- [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/user-guide/advisories/) — the eight advisories and CI strictness
 - [Diagnostics](https://rsicarelli.github.io/kmp-targets/user-guide/diagnostics/) — `kmpTargetsInfo` and `kmpTargetsDoctor`
 - [CI](https://rsicarelli.github.io/kmp-targets/user-guide/ci-matrix/) — per-host matrix, umbrella tasks
 - [Design](https://rsicarelli.github.io/kmp-targets/why-kmp-targets/) — rationale and trade-offs

--- a/docs/user-guide/advisories.md
+++ b/docs/user-guide/advisories.md
@@ -1,6 +1,6 @@
 # Advisories & Strict Mode
 
-The plugin emits seven configuration-time advisories. Six are signal-only; one (android-without-AGP) skips a leaf — the reasoning is on the [Design page](../why-kmp-targets.md#diagnostics-philosophy). [Strict mode](#strict-mode) promotes all seven to build failures with identical message text. [`kmpTargetsDoctor`](diagnostics.md#kmptargetsdoctor) renders each advisory as a finding with the fix attached.
+The plugin emits eight configuration-time advisories. Seven are signal-only; one (android-without-AGP) skips a leaf — the reasoning is on the [Design page](../why-kmp-targets.md#diagnostics-philosophy). [Strict mode](#strict-mode) promotes all eight to build failures with identical message text. [`kmpTargetsDoctor`](diagnostics.md#kmptargetsdoctor) renders each advisory as a finding with the fix attached.
 
 ## Host compatibility
 
@@ -102,9 +102,22 @@ declaration in build-logic when kmpTargets.registered(apple).isEmpty().
 
 Keyed off the leaves the framework **actually attached to** (`registered ∩ on ∩ apple`), not `registered(apple)` — so it is correct for an `on`-scoped framework even when other Apple leaves registered. A module that never calls `supports { }` is not flagged (explicit-selection doctrine), though [`kmpTargetsDoctor`](diagnostics.md#kmptargetsdoctor) still renders the declared-but-unattached state. Registration is one-way: a later `supports { }` union that attaches an Apple leaf resolves it permanently. Strict mode is the point here — a release lane with a misconfigured selection fails loudly at configuration instead of shipping a frameworkless artifact that breaks Xcode downstream.
 
+## Framework build types disjoint
+
+Fires when a framework attaches to ≥1 Apple leaf but the lane's [`kmptargets.framework.buildTypes`](apple-framework.md#build-types-per-lane) shares no `NativeBuildType` with what the module declared — so the effective set (`property ∩ declared`) is empty and no binary links, even though Apple targets registered. The build-type analog of [empty overlap](#empty-overlap) on the `selection ∩ supported` axis. Typical cause: a module pinned to one build type (`appleFramework("KotlinShared", buildTypes = listOf(NativeBuildType.DEBUG))`) under the opposite lane (`-Pkmptargets.framework.buildTypes=release`):
+
+```
+kmp-targets: ':shared' — appleFramework("KotlinShared") declares build types [DEBUG] but
+kmptargets.framework.buildTypes resolved to [RELEASE] for this lane; they do not overlap, so no
+framework binary (or XCFramework slice) links and an Xcode build consuming it fails downstream. Set
+kmptargets.framework.buildTypes to one of [DEBUG] (or widen the appleFramework(…) declaration).
+```
+
+Mutually exclusive with [framework-without-an-Apple-target](#framework-without-an-apple-target) by construction: that one needs zero attached leaves, this one needs ≥1. Because the property only ever **narrows** the declaration, the fix is to align the lane with a declared build type (or widen the declaration). Fires at most once per module.
+
 ## Strict mode
 
-`kmptargets.strict=true` promotes all seven advisories to configuration-time build failures (`GradleException`) with identical message text. Severity changes; policy does not — it never changes which configurations are flagged or what registers (the AGP skip happens with or without strict). Default off. Recommended: strict in CI only:
+`kmptargets.strict=true` promotes all eight advisories to configuration-time build failures (`GradleException`) with identical message text. Severity changes; policy does not — it never changes which configurations are flagged or what registers (the AGP skip happens with or without strict). Default off. Recommended: strict in CI only:
 
 ```yaml
 # CI only — e.g. a GitHub Actions env block

--- a/docs/user-guide/apple-framework.md
+++ b/docs/user-guide/apple-framework.md
@@ -24,7 +24,7 @@ kmpTargets {
 
 - **`baseName`** is the first argument; KGP's `namePrefix` stays `""`, so link-task names (`linkDebugFrameworkIosSimulatorArm64`) and the `embedAndSign…` contract match plain KGP byte-for-byte.
 - **`on`** (default `apple`) narrows which Apple leaves attach, using the same target algebra as `supports`: `appleFramework("KotlinShared", on = KmpTargetSet.appleMobile) { … }`. An `on` not ⊆ `apple` fails at declaration, naming the offending ids.
-- **`buildTypes`** (default KGP's `NativeBuildType.DEFAULT_BUILD_TYPES` = DEBUG + RELEASE) is passed straight to KGP's `binaries.framework(buildTypes = …)` factory. The plugin never silently narrows a KGP default.
+- **`buildTypes`** (default KGP's `NativeBuildType.DEFAULT_BUILD_TYPES` = DEBUG + RELEASE) is passed straight to KGP's `binaries.framework(buildTypes = …)` factory. The plugin never silently narrows a KGP default — the declaration is the ceiling. A lane can narrow it globally with [`kmptargets.framework.buildTypes`](#build-types-per-lane) (`effective = property ∩ declared`).
 - **Ordering-immune.** `appleFramework` declared *before* or *after* `supports {}` behaves identically (it rides the `onRegistered` replay); a later `supports {}` union attaches only the delta.
 - **Exports stay lazy.** A version-catalog `Provider` is realized by KGP at attach time, not at declaration.
 - **One per module** in v1 — a second call, a blank name, or `on ⊄ apple` fails fast. (Multiple frameworks need a `namePrefix` strategy; a follow-up.)
@@ -47,6 +47,26 @@ KGP registers `assembleKotlinSharedDebugXCFramework`, `assembleKotlinSharedRelea
 - **Lazy**: the `XCFrameworkConfig` is created on the first Apple attach, so a selection that registers no Apple leaf (e.g. a jvm-only lane) wires **zero** `assemble…XCFramework` tasks.
 - **Invariant-safe by construction**: KGP requires every framework in an XCFramework to share a `baseName` and match on `buildType` — both come from the single declaration, so there's nothing to maintain by hand. `buildTypes` flows through (`buildTypes = listOf(NativeBuildType.DEBUG)` produces only the Debug assemble variant).
 - **macOS to run, host-blind to register**: the assemble tasks shell out to `xcodebuild`, so they only *execute* on a macOS host. Registration is host-independent (same as the link tasks), so your selection stays host-blind.
+
+## Build types per lane
+
+Build type is **lane-shaped, not module-shaped**: local dev wants DEBUG-only links (fast), the release lane wants RELEASE. So which `NativeBuildType`s a framework links is a global, layered input — `kmptargets.framework.buildTypes` — resolved through the *same* [selection-sources chain](selection-layers.md) as `kmptargets.targets` (CLI `-P` → `ORG_GRADLE_PROJECT_*` env → `kmp-targets.local.properties` → `kmp-targets.properties` → `gradle.properties`), validated against the key registry, with the same did-you-mean on a typo.
+
+```properties
+# kmp-targets.properties — team default: fast local links
+kmptargets.framework.buildTypes=debug
+```
+
+```bash
+# the release lane overrides it, exactly like the targets key
+./gradlew assembleKotlinSharedXCFramework -Pkmptargets.framework.buildTypes=release
+```
+
+- **Effective = property ∩ declared** — the `selection ∩ supported` shape on the build-type axis. The property only ever **narrows** what the module declared; it can never link a build type the declaration didn't list. Absent property → the declared value wins (no silent narrowing of a KGP default).
+- **Grammar**: a comma-separated, case-insensitive list of `debug` / `release` (KGP's closed `NativeBuildType` enum). A junk value (`relese`) fails the build with a did-you-mean.
+- **Drives both** the per-buildType framework link tasks **and** the XCFramework assemble variants: `=debug` leaves only `linkDebugFramework…` and `assemble…DebugXCFramework`.
+- **Disjoint → nothing links.** A module that declares `buildTypes = listOf(NativeBuildType.DEBUG)` under a `=release` lane has an empty effective set: no binary (or XCFramework slice) links, and the plugin emits the [framework-build-types-disjoint advisory](advisories.md#framework-build-types-disjoint) (a configuration failure under `kmptargets.strict`).
+- **Surfaced.** [`kmpTargetsInfo`](diagnostics.md#kmptargetsinfo) prints the effective build types, the winning origin layer, and the declared set when a lane narrowed it.
 
 ## `onAppleTarget` — the no-magic primitive
 
@@ -80,4 +100,4 @@ extensions.configure<KmpTargetsExtension> {
 
 ## Out of scope
 
-Build types via a layered property, multiple frameworks per module (and aggregating several into one XCFramework), and non-Apple binaries (`sharedLib`/`staticLib`/`executable`) are deliberate follow-ups.
+Per-module build-type property variants, mapping Xcode's `CONFIGURATION` env var, and custom (non-DEBUG/RELEASE) build types are out of scope (KGP's enum is closed). Multiple frameworks per module (and aggregating several into one XCFramework), and non-Apple binaries (`sharedLib`/`staticLib`/`executable`) are deliberate follow-ups.

--- a/docs/user-guide/diagnostics.md
+++ b/docs/user-guide/diagnostics.md
@@ -38,7 +38,7 @@ Vocabulary
 - **`Selection`** — the resolved global selection and its winning [layer](selection-layers.md) by name: `command line (-Pkmptargets.targets)`, `kmp-targets.local.properties`, `local.properties`, or the `defaultSelection` / built-in fallbacks. Values from `-Dorg.gradle.project.kmptargets.targets` and `~/.gradle/gradle.properties` report as the fused `gradle.properties (...)` layer.
 - **`Supported`** — whether the module declared [`supports { }`](selection-dsl.md) and what it expanded to.
 - **`Registered`** — the intersection that registered. Every empty case states its reason: no `supports { }` call, a selection narrowed to nothing, or a disjoint `selection ∩ supported`.
-- **`Apple framework`** — present when the module declares [`appleFramework`](apple-framework.md): the declared name, the Apple leaves it attached to (`registered ∩ on`), its buildTypes, and whether XCFramework assembly is on. An empty `attached` is the [framework-without-an-Apple-target](advisories.md#framework-without-an-apple-target) state — the framework never builds.
+- **`Apple framework`** — present when the module declares [`appleFramework`](apple-framework.md): the declared name, the Apple leaves it attached to (`registered ∩ on`), its **effective** [build types](apple-framework.md#build-types-per-lane) (and, when a lane narrowed them, the winning `kmptargets.framework.buildTypes` origin layer plus the declared set), and whether XCFramework assembly is on. An empty `attached` is the [framework-without-an-Apple-target](advisories.md#framework-without-an-apple-target) state — the framework never builds.
 - **`Vocabulary`** — the parser's full preset and leaf list; a copy-paste surface for valid tokens.
 
 ### Per-leaf annotations
@@ -89,6 +89,7 @@ kmp-targets doctor — :jvm-tools
 | `inert module` | [inert modules](advisories.md#inert-modules) |
 | `JVM-less commonMain` | [native-only metadata](advisories.md#native-only-metadata) |
 | `framework declared but unattached` | [framework without an Apple target](advisories.md#framework-without-an-apple-target) |
+| `framework build types disjoint` | [framework build types disjoint](advisories.md#framework-build-types-disjoint) |
 | `androidTarget skipped` | [android without AGP](advisories.md#android-target-without-agp) |
 | `not compilable on this host` | [host compatibility](advisories.md#host-compatibility) |
 | `deprecated targets registered` | [deprecated targets](advisories.md#deprecated-targets) |

--- a/docs/user-guide/selection-layers.md
+++ b/docs/user-guide/selection-layers.md
@@ -32,6 +32,7 @@ kmptargets.hierarchyTemplate=true
 # kmptargets.hierarchyCollapse=false   # see "Hierarchy"
 # kmptargets.strict=true               # see "Advisories & Strict Mode"
 # kmptargets.umbrellaTasks=true        # see "CI"
+# kmptargets.framework.buildTypes=debug  # see "Apple Framework"
 ```
 
 `kmp-targets.local.properties` (git-ignored) is optional: absent it's ignored; present, its keys override the committed file's. Both files accept only known `kmptargets.*` keys — an unknown key fails the build with a "did you mean …?" suggestion. Both are tracked configuration-cache inputs: editing one invalidates the cache, leaving them untouched keeps cache hits.

--- a/docs/why-kmp-targets.md
+++ b/docs/why-kmp-targets.md
@@ -34,7 +34,7 @@ Because the plugin knows each module's registered set, it applies a [minimal tem
 
 ## Diagnostics philosophy
 
-- **Advisories are signal-only.** Six of the seven never change what registers. The exception is [android-without-AGP](user-guide/advisories.md#android-target-without-agp), which skips the leaf because the alternative is KGP's raw `AndroidGradlePluginIsMissing` crash with no module-level guidance — during build-logic migrations that crash reads as "kmp-targets dropped my target".
+- **Advisories are signal-only.** Seven of the eight never change what registers. The exception is [android-without-AGP](user-guide/advisories.md#android-target-without-agp), which skips the leaf because the alternative is KGP's raw `AndroidGradlePluginIsMissing` crash with no module-level guidance — during build-logic migrations that crash reads as "kmp-targets dropped my target".
 - **Strict mode changes severity, never policy.** `kmptargets.strict=true` turns the same advisories with the same text into failures. It never changes which configurations are flagged or what registers.
 - **Doctor renders, it does not own predicates.** Every [`kmpTargetsDoctor`](user-guide/diagnostics.md#kmptargetsdoctor) finding keys off the same decision its advisory used, so the report cannot disagree with what happened.
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsExtension.kt
@@ -158,6 +158,18 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
     internal var globalSelection: KmpTargetSet? = null
 
     /**
+     * The global Apple-framework build types resolved from `kmptargets.framework.buildTypes` at
+     * apply time, or `null` when no source provided one — the build-type twin of [globalSelection]
+     * (issue #108). When present, [appleFramework] links `property ∩ declared` (intersection only
+     * narrows, never widens; a disjoint pair links nothing and warns). Stored as an immutable set
+     * of KGP's own [NativeBuildType] enum, so it stays configuration-cache safe. A blank/absent
+     * property leaves this `null`, and a present-but-empty parse (e.g. `","`) is also treated as
+     * absent, so the declared build types win — symmetric with how a blank `kmptargets.targets`
+     * defers.
+     */
+    internal var globalBuildTypes: Set<NativeBuildType>? = null
+
+    /**
      * The selection actually used to register targets: the global `kmptargets.targets` if present,
      * otherwise [defaultSelection] (which itself defaults to [KmpTargetSet.all]). Public so
      * build-logic can read the resolved set (e.g. for conditional configuration).
@@ -255,6 +267,14 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
      * framework's scope attaches, the module can never become unattached again.
      */
     internal var frameworkUnattachedWarned: Boolean = false
+
+    /**
+     * True once the framework build-types-disjoint advisory (#108) fired, so it fires at most once
+     * per module. Mirrors [frameworkUnattachedWarned]: the global `kmptargets.framework.buildTypes`
+     * and the declared `buildTypes` are both fixed at apply/declaration time, so the disjoint
+     * verdict is permanent once the framework attaches to an Apple leaf.
+     */
+    internal var frameworkBuildTypesDisjointWarned: Boolean = false
 
     /**
      * Fired at the end of [appleFramework], once its attach subscription has replayed against any
@@ -444,7 +464,17 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
             )
         }
         appleFrameworkDeclared = true
-        appleFrameworkFacts = AppleFrameworkFacts(baseName, on, buildTypes.toSet(), xcframework)
+        // Effective build types (#108): the lane-shaped global `kmptargets.framework.buildTypes`
+        // intersected with what this module declared — the `selection ∩ supported` shape on the
+        // build-type axis. `null` global means "not set" → the declaration wins verbatim, so a KGP
+        // default is never silently narrowed. Intersection only narrows (it can never link a build
+        // type the module didn't declare); a disjoint pair yields an empty set — nothing links, and
+        // the build-types-disjoint advisory explains why.
+        val declaredBuildTypes = buildTypes.toSet()
+        val effectiveBuildTypes =
+            globalBuildTypes?.let { declaredBuildTypes intersect it } ?: declaredBuildTypes
+        appleFrameworkFacts =
+            AppleFrameworkFacts(baseName, on, declaredBuildTypes, xcframework, effectiveBuildTypes)
         // Lazy XCFramework config (#106): created on the first Apple attach via the target's own
         // project (AbstractKotlinTarget.getProject), so a selection that registers no Apple leaf
         // never materializes an assemble…XCFramework task. onRegistered fires synchronously at
@@ -454,18 +484,28 @@ public abstract class KmpTargetsExtension @Inject constructor(objects: ObjectFac
             // Record the genuine attach (#107): this block runs only once a registered Apple leaf
             // in
             // `on` resolved to a live KGP target, so the set is exactly what the framework built
-            // for.
+            // for. Recorded BEFORE the disjoint guard below, so an Apple leaf that registers but
+            // links nothing (disjoint build types) is still "attached" — that is what makes the
+            // unattached advisory (#107) and the build-types-disjoint advisory (#108) mutually
+            // exclusive.
             appleFrameworkAttachedLeaves += leaf
+            // Disjoint property ∩ declaration (#108): no build type survives, so there is nothing
+            // to
+            // link. Skip both the framework binaries and the XCFramework config (so no empty
+            // assemble…XCFramework task materializes); maybeWarnFrameworkBuildTypesDisjoint
+            // surfaces
+            // the consequence.
+            if (effectiveBuildTypes.isEmpty()) return@onAppleNativeTarget
             val config =
                 if (xcframework) {
                     xcframeworkConfig
-                        ?: XCFrameworkConfig(project, baseName, buildTypes.toSet()).also {
+                        ?: XCFrameworkConfig(project, baseName, effectiveBuildTypes).also {
                             xcframeworkConfig = it
                         }
                 } else {
                     null
                 }
-            binaries.framework(buildTypes = buildTypes) {
+            binaries.framework(buildTypes = effectiveBuildTypes) {
                 this.baseName = baseName
                 configure()
                 // Add each per-buildType slice after its baseName is set; XCFrameworkConfig groups
@@ -514,4 +554,12 @@ internal data class AppleFrameworkFacts(
     val on: KmpTargetSet,
     val buildTypes: Set<NativeBuildType>,
     val xcframework: Boolean,
+    /**
+     * The build types that actually link: `kmptargets.framework.buildTypes ∩ [buildTypes]`, or
+     * [buildTypes] verbatim when the global property is absent (issue #108). Defaults to
+     * [buildTypes] so call sites that don't narrow stay unchanged. Empty only when the global
+     * property and the declaration are disjoint — the state the build-types-disjoint advisory
+     * flags.
+     */
+    val effectiveBuildTypes: Set<NativeBuildType> = buildTypes,
 )

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -14,8 +14,10 @@ import com.rsicarelli.kmptargets.info.KmpTargetsInfoTask
 import com.rsicarelli.kmptargets.info.OriginLabels
 import com.rsicarelli.kmptargets.model.KmpTarget
 import com.rsicarelli.kmptargets.model.KmpTargetSet
+import com.rsicarelli.kmptargets.parser.BuildTypesParseResult
 import com.rsicarelli.kmptargets.parser.ParseResult
 import com.rsicarelli.kmptargets.parser.didYouMean
+import com.rsicarelli.kmptargets.parser.parseBuildTypes
 import com.rsicarelli.kmptargets.parser.parseKmpTargets
 import com.rsicarelli.kmptargets.parser.presetNames
 import com.rsicarelli.kmptargets.source.ConfigFileValueSource
@@ -37,6 +39,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.konan.target.HostManager
 
 public class KmpTargetsPlugin : Plugin<Project> {
@@ -74,6 +77,27 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // origin either — the report then falls through to the defaultSelection/built-in labels.
         val configOrigin: String? = winner?.takeIf { it.second.isNotBlank() }?.first
 
+        // Global Apple-framework build types (#108): the build-type twin of the selection above,
+        // resolved through the IDENTICAL layered winner-walk so precedence and origin reporting
+        // match `kmptargets.targets` exactly. A blank/absent winner — or a present-but-empty parse
+        // (e.g. `","`) — leaves `globalBuildTypes` null, so the declared build types win (the
+        // property only ever narrows, never widens). Read once here as a primitive set of KGP's own
+        // enum, so no `Project` is captured.
+        val buildTypesWinner: Pair<String, String>? =
+            labeledSources(target, ConfigKeys.FRAMEWORK_BUILD_TYPES, personal, committed)
+                .firstNotNullOfOrNull { (label, source) ->
+                    source.read()?.let { value -> label to value }
+                }
+        var buildTypesOrigin: String? = null
+        val buildTypesRaw: String? = buildTypesWinner?.second
+        if (buildTypesRaw != null && buildTypesRaw.isNotBlank()) {
+            val parsed = parseBuildTypesOrThrow(buildTypesRaw, ConfigKeys.FRAMEWORK_BUILD_TYPES)
+            if (parsed.isNotEmpty()) {
+                ext.globalBuildTypes = parsed
+                buildTypesOrigin = buildTypesWinner.first
+            }
+        }
+
         // Global defaults for the hierarchy template and its collapse rule (issue #50), each read
         // once at apply time as a primitive.
         val globalHierarchyEnabled: Boolean? =
@@ -106,10 +130,11 @@ public class KmpTargetsPlugin : Plugin<Project> {
         ext.onAppleFrameworkDeclared = {
             target.pluginManager.withPlugin(KGP_ID) {
                 maybeWarnFrameworkUnattached(target, ext, strict)
+                maybeWarnFrameworkBuildTypesDisjoint(target, ext, strict)
             }
         }
 
-        registerInfoTask(target, ext, configOrigin)
+        registerInfoTask(target, ext, configOrigin, buildTypesOrigin)
         registerDoctorTask(target, ext)
 
         // ABI × selection advisory (#81): when an ABI-validation task (kotlinx BCV or the built-in
@@ -222,7 +247,12 @@ public class KmpTargetsPlugin : Plugin<Project> {
      * registered unconditionally (not gated on KGP): without KGP or `supports`, the report states
      * explicitly that nothing is declared and nothing registers.
      */
-    private fun registerInfoTask(target: Project, ext: KmpTargetsExtension, configOrigin: String?) {
+    private fun registerInfoTask(
+        target: Project,
+        ext: KmpTargetsExtension,
+        configOrigin: String?,
+        buildTypesOrigin: String?,
+    ) {
         val projectPath = target.path
         target.tasks.register("kmpTargetsInfo", KmpTargetsInfoTask::class.java) { task ->
             task.group = "help"
@@ -253,6 +283,8 @@ public class KmpTargetsPlugin : Plugin<Project> {
             task.frameworkBaseName.set(frameworkBaseNameProvider(target, ext))
             task.frameworkAttachedIds.set(frameworkAttachedIdsProvider(target, ext))
             task.frameworkBuildTypes.set(frameworkBuildTypesProvider(target, ext))
+            task.frameworkBuildTypesDeclared.set(frameworkBuildTypesDeclaredProvider(target, ext))
+            task.frameworkBuildTypesOrigin.set(buildTypesOrigin.orEmpty())
             task.frameworkXcframework.set(frameworkXcframeworkProvider(target, ext))
             // The config-layer origin is fixed at apply time, but the fallback labels must read
             // `defaultSelection` lazily — the body may override it after apply.
@@ -351,8 +383,10 @@ public class KmpTargetsPlugin : Plugin<Project> {
             task.frameworkBaseName.set(frameworkBaseNameProvider(target, ext))
             task.frameworkAttachedIds.set(frameworkAttachedIdsProvider(target, ext))
             task.frameworkBuildTypes.set(frameworkBuildTypesProvider(target, ext))
+            task.frameworkBuildTypesDeclared.set(frameworkBuildTypesDeclaredProvider(target, ext))
             task.frameworkXcframework.set(frameworkXcframeworkProvider(target, ext))
             task.frameworkUnattached.set(frameworkUnattachedProvider(target, ext))
+            task.frameworkBuildTypesDisjoint.set(frameworkBuildTypesDisjointProvider(target, ext))
             task.dependencyData.from(dependencyDataFiles)
         }
     }
@@ -448,6 +482,46 @@ public class KmpTargetsPlugin : Plugin<Project> {
                 project.logger.warn(it)
             }
             ext.frameworkUnattachedWarned = true
+        }
+    }
+
+    /**
+     * Fires the framework build-types-disjoint advisory (#108) at most once per module: a framework
+     * is declared, attached to ≥1 Apple leaf, yet `kmptargets.framework.buildTypes ∩ declared
+     * buildTypes` is empty — so no binary (or XCFramework slice) links despite Apple targets being
+     * registered. The build-type analog of the empty-overlap advisory (#10) on the `selection ∩
+     * supported` axis. Mutually exclusive with the unattached advisory (#107) by construction: that
+     * one requires zero attached leaves, this one requires ≥1. Shared by the end of [register] and
+     * the [appleFramework] replay hook; the dedup flag is set AFTER [warnOrFail] so a strict
+     * failure leaves no bookkeeping behind.
+     */
+    private fun maybeWarnFrameworkBuildTypesDisjoint(
+        project: Project,
+        ext: KmpTargetsExtension,
+        strict: Boolean,
+    ) {
+        val facts = ext.appleFrameworkFacts ?: return
+        if (
+            !ext.frameworkBuildTypesDisjointWarned &&
+                shouldWarnFrameworkBuildTypesDisjoint(
+                    ext.appleFrameworkDeclared,
+                    ext.globalBuildTypes,
+                    facts.buildTypes,
+                    ext.frameworkAttachedLeaves(),
+                )
+        ) {
+            warnOrFail(
+                strict,
+                frameworkBuildTypesDisjointWarning(
+                    project.path,
+                    facts.baseName,
+                    ext.globalBuildTypes.orEmpty(),
+                    facts.buildTypes,
+                ),
+            ) {
+                project.logger.warn(it)
+            }
+            ext.frameworkBuildTypesDisjointWarned = true
         }
     }
 
@@ -556,7 +630,19 @@ public class KmpTargetsPlugin : Plugin<Project> {
             ids(ext.frameworkAttachedLeaves())
         }
 
+    // The build types that actually link (#108): `kmptargets.framework.buildTypes ∩ declared`, the
+    // narrowed set the framework binaries and XCFramework slices are built for. Equals the declared
+    // set when the global property is absent, so the #107 surfaces are unchanged without a
+    // property.
     private fun frameworkBuildTypesProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            ext.appleFrameworkFacts?.effectiveBuildTypes?.map { it.name }?.sorted().orEmpty()
+        }
+
+    // The build types the module DECLARED (#108), before the global property narrows them — what
+    // `kmpTargetsInfo` shows as "declared …" when a lane narrowed the effective set, and what the
+    // disjoint doctor finding names as the fix target.
+    private fun frameworkBuildTypesDeclaredProvider(target: Project, ext: KmpTargetsExtension) =
         target.provider {
             ext.appleFrameworkFacts?.buildTypes?.map { it.name }?.sorted().orEmpty()
         }
@@ -572,6 +658,17 @@ public class KmpTargetsPlugin : Plugin<Project> {
                 shouldWarnFrameworkUnattached(
                     ext.appleFrameworkDeclared,
                     ext.supportsProperty.isPresent,
+                    ext.frameworkAttachedLeaves(),
+                )
+        }
+
+    private fun frameworkBuildTypesDisjointProvider(target: Project, ext: KmpTargetsExtension) =
+        target.provider {
+            hasKgp(target) &&
+                shouldWarnFrameworkBuildTypesDisjoint(
+                    ext.appleFrameworkDeclared,
+                    ext.globalBuildTypes,
+                    ext.appleFrameworkFacts?.buildTypes.orEmpty(),
                     ext.frameworkAttachedLeaves(),
                 )
         }
@@ -777,6 +874,13 @@ public class KmpTargetsPlugin : Plugin<Project> {
             is ParseResult.Err -> throw GradleException("$propertyName: ${r.message}")
         }
 
+    /** The [parseOrThrow] twin for `kmptargets.framework.buildTypes` (#108). */
+    private fun parseBuildTypesOrThrow(raw: String, propertyName: String): Set<NativeBuildType> =
+        when (val r = parseBuildTypes(raw)) {
+            is BuildTypesParseResult.Ok -> r.buildTypes
+            is BuildTypesParseResult.Err -> throw GradleException("$propertyName: ${r.message}")
+        }
+
     /**
      * Registers `selection ∩ supported`, emits the empty-overlap and host-impossible advisories,
      * and applies the minimal hierarchy template — all off the cumulative supported set, so
@@ -946,6 +1050,14 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // and reads last. The helper is shared with the appleFramework() replay hook so the firing
         // is order-independent; it dedups and records bookkeeping AFTER warnOrFail.
         maybeWarnFrameworkUnattached(project, ext, strict)
+
+        // Framework build-types-disjoint advisory (#108): the framework attached to Apple leaves
+        // but
+        // `kmptargets.framework.buildTypes ∩ declared` is empty, so nothing links. Mutually
+        // exclusive with the unattached advisory above (that needs zero attached leaves, this needs
+        // ≥1), and shared with the appleFramework() replay hook so it fires regardless of
+        // declaration order.
+        maybeWarnFrameworkBuildTypesDisjoint(project, ext, strict)
 
         // Deliberately receives the unfiltered active set even when android was skipped above:
         // android is ungrouped in the hierarchy taxonomy (it attaches straight to common and
@@ -1230,6 +1342,52 @@ internal fun frameworkUnattachedWarning(path: String, baseName: String): String 
         "selection (or this module's supports { }) to register an Apple target in the framework's " +
         "`on` scope, or gate the appleFramework(…) declaration in build-logic when " +
         "kmpTargets.registered(apple).isEmpty()."
+
+/**
+ * Whether to emit [frameworkBuildTypesDisjointWarning] (#108): an `appleFramework` is declared and
+ * attached to ≥1 Apple leaf, but the global `kmptargets.framework.buildTypes` ([property], non-null
+ * only when the lane set one) shares no [NativeBuildType] with the module's [declared] set — so the
+ * effective build types are empty and nothing links. The build-type analog of
+ * [shouldWarnEmptyOverlap] on the `selection ∩ supported` axis. The [attachedLeaves]-non-empty
+ * conjunct makes this mutually exclusive with [shouldWarnFrameworkUnattached] (which requires zero
+ * attached leaves): exactly one of the two framework consequence advisories can fire per module.
+ * Pure over its inputs (KGP's enum and the plugin's own set), so it is unit-testable without
+ * Gradle; the same decision drives the doctor finding.
+ */
+internal fun shouldWarnFrameworkBuildTypesDisjoint(
+    frameworkDeclared: Boolean,
+    property: Set<NativeBuildType>?,
+    declared: Set<NativeBuildType>,
+    attachedLeaves: KmpTargetSet,
+): Boolean =
+    frameworkDeclared &&
+        property != null &&
+        declared.isNotEmpty() &&
+        attachedLeaves.isNotEmpty() &&
+        (property intersect declared).isEmpty()
+
+/**
+ * The framework build-types-disjoint advisory (#108). Like its siblings, one text serves both the
+ * warning and the strict-mode failure through [warnOrFail]. Names the module, the framework, the
+ * declared build types, the lane value that doesn't overlap them, the consequence (no binary or
+ * XCFramework slice links), and the fix. Strict mode is the point: a release lane that narrowed to
+ * a build type the module never declares fails loudly at configuration instead of shipping nothing.
+ */
+internal fun frameworkBuildTypesDisjointWarning(
+    path: String,
+    baseName: String,
+    property: Set<NativeBuildType>,
+    declared: Set<NativeBuildType>,
+): String =
+    "kmp-targets: '$path' — appleFramework(\"$baseName\") declares build types " +
+        "${buildTypeNames(declared)} but kmptargets.framework.buildTypes resolved to " +
+        "${buildTypeNames(property)} for this lane; they do not overlap, so no framework binary (or " +
+        "XCFramework slice) links and an Xcode build consuming it fails downstream. Set " +
+        "kmptargets.framework.buildTypes to one of ${buildTypeNames(declared)} (or widen the " +
+        "appleFramework(…) declaration)."
+
+private fun buildTypeNames(buildTypes: Set<NativeBuildType>): List<String> =
+    buildTypes.map { it.name }.sorted()
 
 /**
  * Whether the `single-target KSP` **doctor finding** fires: a KSP plugin is applied yet exactly one

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormat.kt
@@ -43,8 +43,10 @@ internal fun formatKmpTargetsDoctor(
     frameworkBaseName: String = "",
     frameworkAttachedIds: List<String> = emptyList(),
     frameworkBuildTypes: List<String> = emptyList(),
+    frameworkBuildTypesDeclared: List<String> = emptyList(),
     frameworkXcframework: Boolean = false,
     frameworkUnattached: Boolean = false,
+    frameworkBuildTypesDisjoint: Boolean = false,
 ): String = buildString {
     appendLine("kmp-targets doctor — $projectPath")
     appendLine()
@@ -157,6 +159,21 @@ internal fun formatKmpTargetsDoctor(
                     "fix:    widen the selection (or supports { }) to register an Apple target in " +
                         "the framework's scope, or gate appleFramework(…) in build-logic when " +
                         "registered(apple).isEmpty()",
+                )
+            )
+        }
+        if (frameworkBuildTypesDisjoint) {
+            add(
+                finding(
+                    "framework build types disjoint",
+                    "why:    kmptargets.framework.buildTypes resolved to a set sharing no build " +
+                        "type with appleFramework(\"$frameworkBaseName\")'s declared " +
+                        "${render(frameworkBuildTypesDeclared)}, so the effective set is empty",
+                    "effect: no framework binary (or XCFramework slice) links though Apple targets " +
+                        "registered; an Xcode build consuming it fails downstream",
+                    "fix:    set kmptargets.framework.buildTypes to one of " +
+                        "${render(frameworkBuildTypesDeclared)}, or widen the appleFramework(…) " +
+                        "declaration",
                 )
             )
         }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorTask.kt
@@ -88,14 +88,31 @@ public abstract class KmpTargetsDoctorTask : DefaultTask() {
     /** Sorted ids of the Apple leaves the framework actually attached to (`registered ∩ on`). */
     @get:Internal public abstract val frameworkAttachedIds: ListProperty<String>
 
-    /** The framework's creation-time native build types (e.g. `DEBUG`, `RELEASE`), sorted. */
+    /**
+     * The framework's **effective** native build types (`property ∩ declared`, e.g. `DEBUG`),
+     * sorted (#108). Equals [frameworkBuildTypesDeclared] without a narrowing property; empty on a
+     * disjoint (the [frameworkBuildTypesDisjoint] finding then explains).
+     */
     @get:Internal public abstract val frameworkBuildTypes: ListProperty<String>
+
+    /**
+     * The framework's **declared** native build types (#108), before any global narrowing — named
+     * as the fix in the build-types-disjoint finding.
+     */
+    @get:Internal public abstract val frameworkBuildTypesDeclared: ListProperty<String>
 
     /** Whether the framework opted into XCFramework assembly (#106). */
     @get:Internal public abstract val frameworkXcframework: Property<Boolean>
 
     /** Same decision as the framework-unattached advisory (#107) — drives the `[!]` finding. */
     @get:Internal public abstract val frameworkUnattached: Property<Boolean>
+
+    /**
+     * Same decision as the framework build-types-disjoint advisory (#108) — drives the `[!]`
+     * finding. True when the framework attached but `kmptargets.framework.buildTypes ∩ declared` is
+     * empty, so nothing links.
+     */
+    @get:Internal public abstract val frameworkBuildTypesDisjoint: Property<Boolean>
 
     /**
      * The doctor-data files of this module's `project(...)` dependencies, resolved at execution
@@ -131,8 +148,10 @@ public abstract class KmpTargetsDoctorTask : DefaultTask() {
                 frameworkBaseName = frameworkBaseName.get(),
                 frameworkAttachedIds = frameworkAttachedIds.get(),
                 frameworkBuildTypes = frameworkBuildTypes.get(),
+                frameworkBuildTypesDeclared = frameworkBuildTypesDeclared.get(),
                 frameworkXcframework = frameworkXcframework.get(),
                 frameworkUnattached = frameworkUnattached.get(),
+                frameworkBuildTypesDisjoint = frameworkBuildTypesDisjoint.get(),
                 closureDepCount = dependencies.size,
                 closureGaps = gaps,
             )

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
@@ -29,6 +29,8 @@ internal fun formatKmpTargetsInfo(
     frameworkBaseName: String = "",
     frameworkAttachedIds: List<String> = emptyList(),
     frameworkBuildTypes: List<String> = emptyList(),
+    frameworkBuildTypesDeclared: List<String> = emptyList(),
+    frameworkBuildTypesOrigin: String = "",
     frameworkXcframework: Boolean = false,
 ): String = buildString {
     appendLine("kmp-targets — $projectPath")
@@ -101,7 +103,14 @@ internal fun formatKmpTargetsInfo(
             "  attached:    " +
                 idsOrNone(frameworkAttachedIds, "no Apple target in its scope registered")
         )
-        appendLine("  buildTypes:  ${frameworkBuildTypes.joinToString(", ")}")
+        appendLine(
+            "  buildTypes:  " +
+                frameworkBuildTypesLine(
+                    frameworkBuildTypes,
+                    frameworkBuildTypesDeclared,
+                    frameworkBuildTypesOrigin,
+                )
+        )
         appendLine("  xcframework: ${if (frameworkXcframework) "on" else "off"}")
     }
     appendLine()
@@ -126,6 +135,30 @@ private fun annotated(plain: String, ids: List<String>, marker: (String) -> Stri
 
 private fun idsOrNone(ids: List<String>, emptyReason: String): String =
     if (ids.isEmpty()) "(none — $emptyReason)" else ids.joinToString(", ")
+
+/**
+ * The framework `buildTypes:` line (#108). Shows the **effective** set; when a global
+ * `kmptargets.framework.buildTypes` drove it ([origin] non-blank) it appends the winning layer (and
+ * the [declared] set when the lane narrowed it), so the report always names both the effective
+ * build types and their origin. A disjoint property ∩ declaration renders the explicit empty case —
+ * the framework links nothing for this lane. With no property the line is just the effective set,
+ * byte- identical to what it was before the property existed.
+ */
+private fun frameworkBuildTypesLine(
+    effective: List<String>,
+    declared: List<String>,
+    origin: String,
+): String =
+    when {
+        origin.isEmpty() -> effective.joinToString(", ")
+        effective.isEmpty() ->
+            "(none — $origin does not overlap the declared ${declared.joinToString(", ")}; " +
+                "nothing links)"
+        effective == declared -> "${effective.joinToString(", ")}  (source: $origin)"
+        else ->
+            "${effective.joinToString(", ")}  (source: $origin; declared " +
+                "${declared.joinToString(", ")})"
+    }
 
 /**
  * The registered line names *why* nothing registers, in precedence order: an empty selection and an

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoTask.kt
@@ -109,8 +109,24 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
     /** Sorted ids of the Apple leaves the framework actually attached to (`registered ∩ on`). */
     @get:Internal public abstract val frameworkAttachedIds: ListProperty<String>
 
-    /** The framework's creation-time native build types (e.g. `DEBUG`, `RELEASE`), sorted. */
+    /**
+     * The framework's **effective** native build types (`property ∩ declared`, e.g. `DEBUG`),
+     * sorted (#108). Equals [frameworkBuildTypesDeclared] when no `kmptargets.framework.buildTypes`
+     * narrowed them; empty when the property and the declaration are disjoint.
+     */
     @get:Internal public abstract val frameworkBuildTypes: ListProperty<String>
+
+    /**
+     * The framework's **declared** native build types (#108), before any global narrowing — shown
+     * as "declared …" when a lane narrowed the effective set, and named as the fix on a disjoint.
+     */
+    @get:Internal public abstract val frameworkBuildTypesDeclared: ListProperty<String>
+
+    /**
+     * The config layer that supplied `kmptargets.framework.buildTypes` (#108), e.g. `command line
+     * (-Pkmptargets.framework.buildTypes)`; blank when no source set it (the declaration wins).
+     */
+    @get:Internal public abstract val frameworkBuildTypesOrigin: Property<String>
 
     /** Whether the framework opted into XCFramework assembly (#106). */
     @get:Internal public abstract val frameworkXcframework: Property<Boolean>
@@ -138,6 +154,8 @@ public abstract class KmpTargetsInfoTask : DefaultTask() {
                 frameworkBaseName = frameworkBaseName.get(),
                 frameworkAttachedIds = frameworkAttachedIds.get(),
                 frameworkBuildTypes = frameworkBuildTypes.get(),
+                frameworkBuildTypesDeclared = frameworkBuildTypesDeclared.get(),
+                frameworkBuildTypesOrigin = frameworkBuildTypesOrigin.get(),
                 frameworkXcframework = frameworkXcframework.get(),
             )
         )

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/BuildTypesParser.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/parser/BuildTypesParser.kt
@@ -1,0 +1,74 @@
+package com.rsicarelli.kmptargets.parser
+
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+
+/**
+ * Outcome of parsing a `kmptargets.framework.buildTypes` value into a set of KGP [NativeBuildType]
+ * (issue #108). Mirrors [ParseResult] in shape — [Ok] carries the resolved set plus any non-fatal
+ * warnings, [Err] a human-readable message and the offending token — but resolves to KGP's **own**
+ * closed `NativeBuildType` enum rather than a [com.rsicarelli.kmptargets.model.KmpTargetSet], so
+ * the plugin routes build types straight to the real KGP vocabulary with nothing mirrored.
+ */
+internal sealed interface BuildTypesParseResult {
+
+    data class Ok(val buildTypes: Set<NativeBuildType>, val warnings: List<String> = emptyList()) :
+        BuildTypesParseResult
+
+    data class Err(val message: String, val offendingToken: String?) : BuildTypesParseResult
+}
+
+/**
+ * Parses a `kmptargets.framework.buildTypes` value into a set of [NativeBuildType].
+ *
+ * Grammar (informal): a comma-separated list of `debug` / `release`, each token trimmed and matched
+ * **case-insensitively** against KGP's closed [NativeBuildType] enum; the result is an
+ * order-insensitive, de-duplicated set. There is deliberately **no** `+`/`-` algebra (unlike
+ * `kmptargets.targets`): the vocabulary is two closed values KGP will never extend, so the
+ * additive/ subtractive grammar would be ceremony.
+ *
+ * - Empty input (or input containing only separators) returns [BuildTypesParseResult.Ok] with an
+ *   empty set and a warning; the plugin then treats it as "not set" and keeps the DSL-declared
+ *   build types — mirroring how an empty `kmptargets.targets` falls back to the default selection.
+ * - An unknown token fails strictly, with a did-you-mean suggestion when a known token is within
+ *   edit distance 2 (`relese` → `release`).
+ */
+internal fun parseBuildTypes(raw: String): BuildTypesParseResult {
+    val tokens = raw.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+    if (tokens.isEmpty()) {
+        return BuildTypesParseResult.Ok(
+            emptySet(),
+            warnings =
+                listOf("kmptargets.framework.buildTypes is empty; using the declared build types"),
+        )
+    }
+
+    val byName: Map<String, NativeBuildType> =
+        NativeBuildType.entries.associateBy { it.name.lowercase() }
+    val knownNames: Set<String> = byName.keys
+
+    val resolved = linkedSetOf<NativeBuildType>()
+    for (token in tokens) {
+        val buildType =
+            byName[token.lowercase()]
+                ?: return BuildTypesParseResult.Err(
+                    message = unknownBuildTypeMessage(token, token.lowercase(), knownNames),
+                    offendingToken = token,
+                )
+        resolved += buildType
+    }
+    return BuildTypesParseResult.Ok(resolved)
+}
+
+private fun unknownBuildTypeMessage(
+    original: String,
+    lowered: String,
+    knownNames: Set<String>,
+): String {
+    val known = knownNames.sorted().joinToString(", ")
+    val suggestion = didYouMean(lowered, knownNames)
+    return if (suggestion != null) {
+        "unknown build type '$original' — did you mean '$suggestion'? (known: $known)"
+    } else {
+        "unknown build type '$original' (known: $known)"
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
@@ -34,9 +34,24 @@ internal object ConfigKeys {
      */
     const val UMBRELLA_TASKS: String = "kmptargets.umbrellaTasks"
 
+    /**
+     * Global Apple-framework build types — which `NativeBuildType`s the framework links *now*
+     * (`debug`/`release`, comma grammar, case-insensitive; see `parseBuildTypes`). Lane-shaped like
+     * [TARGETS]: the effective build types are `property ∩ appleFramework(buildTypes = …)`, so the
+     * property only ever narrows the module's declaration, never widens it (issue #108).
+     */
+    const val FRAMEWORK_BUILD_TYPES: String = "kmptargets.framework.buildTypes"
+
     /** Every key the dedicated config files may legally contain (unknown keys fail the build). */
     val ALL: Set<String> =
-        setOf(TARGETS, HIERARCHY_TEMPLATE, HIERARCHY_COLLAPSE, STRICT, UMBRELLA_TASKS)
+        setOf(
+            TARGETS,
+            HIERARCHY_TEMPLATE,
+            HIERARCHY_COLLAPSE,
+            STRICT,
+            UMBRELLA_TASKS,
+            FRAMEWORK_BUILD_TYPES,
+        )
 
     /** Committed, team-shared config file at the root of the build. */
     const val COMMITTED_FILE: String = "kmp-targets.properties"

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkBuildTypesDisjointAdvisoryTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkBuildTypesDisjointAdvisoryTest.kt
@@ -1,0 +1,99 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure decision/message facts of the framework build-types-disjoint advisory (#108): a module that
+ * declared an `appleFramework`, attached it to ≥1 Apple leaf, yet whose lane
+ * `kmptargets.framework.buildTypes` shares no [NativeBuildType] with the declaration links nothing.
+ * The build-type analog of empty-overlap on the `selection ∩ supported` axis, and mutually
+ * exclusive with the unattached advisory (#107) — that one needs zero attached leaves, this one
+ * needs ≥1. No Gradle here; the wiring (warnOrFail + dedup + replay + mutual exclusivity) is proven
+ * by the in-process suite.
+ */
+class FrameworkBuildTypesDisjointAdvisoryTest {
+
+    private val attached = KmpTargetSet.of(KmpTarget.Native.Apple.Ios.Arm64)
+    private val debug = setOf(NativeBuildType.DEBUG)
+    private val release = setOf(NativeBuildType.RELEASE)
+
+    @Test
+    fun `given a declared framework attached with a disjoint property when the policy is computed then it flags`() {
+        assertTrue(
+            shouldWarnFrameworkBuildTypesDisjoint(
+                frameworkDeclared = true,
+                property = release,
+                declared = debug,
+                attachedLeaves = attached,
+            )
+        )
+    }
+
+    @Test
+    fun `given a property that overlaps the declaration when the policy is computed then it does not flag`() {
+        assertFalse(
+            shouldWarnFrameworkBuildTypesDisjoint(
+                frameworkDeclared = true,
+                property = setOf(NativeBuildType.DEBUG, NativeBuildType.RELEASE),
+                declared = debug,
+                attachedLeaves = attached,
+            )
+        )
+    }
+
+    @Test
+    fun `given no property set when the policy is computed then it does not flag`() {
+        // Absent property → the declaration wins verbatim; there is nothing to be disjoint from.
+        assertFalse(
+            shouldWarnFrameworkBuildTypesDisjoint(
+                frameworkDeclared = true,
+                property = null,
+                declared = debug,
+                attachedLeaves = attached,
+            )
+        )
+    }
+
+    @Test
+    fun `given zero attached leaves when the policy is computed then it does not flag`() {
+        // Mutually exclusive with the unattached advisory (#107): with nothing attached there is no
+        // framework to link, so the unattached advisory owns that state, not this one.
+        assertFalse(
+            shouldWarnFrameworkBuildTypesDisjoint(
+                frameworkDeclared = true,
+                property = release,
+                declared = debug,
+                attachedLeaves = KmpTargetSet.empty,
+            )
+        )
+    }
+
+    @Test
+    fun `given no framework declared when the policy is computed then it does not flag`() {
+        assertFalse(
+            shouldWarnFrameworkBuildTypesDisjoint(
+                frameworkDeclared = false,
+                property = release,
+                declared = debug,
+                attachedLeaves = attached,
+            )
+        )
+    }
+
+    @Test
+    fun `given a module path baseName property and declaration when the warning is built then it names them the consequence and the fix`() {
+        val message = frameworkBuildTypesDisjointWarning(":shared", "KotlinShared", release, debug)
+        assertContains(message, ":shared")
+        assertContains(message, "KotlinShared")
+        assertContains(message, "kmptargets.framework.buildTypes")
+        assertContains(message, "RELEASE")
+        assertContains(message, "DEBUG")
+        assertContains(message, "Xcode")
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkBuildTypesEnvPropertyMappingFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkBuildTypesEnvPropertyMappingFunctionalTest.kt
@@ -1,0 +1,104 @@
+package com.rsicarelli.kmptargets
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Functional (TestKit) proof that the dotted `kmptargets.framework.buildTypes` key (#108) resolves
+ * through Gradle's *launcher* paths exactly like `kmptargets.targets` — the env→project-property
+ * mapping accepts the doubly-dotted name, the `-P` CLI form outranks the committed config file —
+ * and that the resolved value narrows the **real** KGP `Framework.buildType` set. A junk value
+ * fails the launcher build with the parser's did-you-mean. The per-layer precedence machinery
+ * itself is the shared `labeledSources` chain (proven for the selection key by
+ * [EnvPropertyMappingFunctionalTest]); this pins that the new key rides it and reaches the real
+ * binaries.
+ */
+class FrameworkBuildTypesEnvPropertyMappingFunctionalTest {
+
+    @Test
+    fun `given ORG_GRADLE_PROJECT env var with the dotted build-types key when the build configures then the framework narrows to it`(
+        @TempDir dir: Path
+    ) {
+        writeFixture(dir)
+        val result =
+            runner(dir)
+                .withArguments("assertBuildTypes", "-q")
+                .withEnvironment(
+                    mapOf("ORG_GRADLE_PROJECT_kmptargets.framework.buildTypes" to "debug")
+                )
+                .build()
+        assertTrue("BUILDTYPES=DEBUG" in result.output, result.output)
+    }
+
+    @Test
+    fun `given the build-types key via -P over a committed file when the build configures then the CLI wins and the framework narrows to it`(
+        @TempDir dir: Path
+    ) {
+        // The committed file sets debug; the CLI sets release — a launcher-level proof that the CLI
+        // layer outranks the dedicated config file for the new key, exactly as for the targets key.
+        writeFixture(dir)
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.framework.buildTypes=debug\n")
+        val result =
+            runner(dir)
+                .withArguments(
+                    "assertBuildTypes",
+                    "-q",
+                    "-Pkmptargets.framework.buildTypes=release",
+                )
+                .build()
+        assertTrue("BUILDTYPES=RELEASE" in result.output, result.output)
+    }
+
+    @Test
+    fun `given a junk build-types value via -P when the build runs then it fails with a did-you-mean`(
+        @TempDir dir: Path
+    ) {
+        writeFixture(dir)
+        val result =
+            runner(dir)
+                .withArguments("assertBuildTypes", "-Pkmptargets.framework.buildTypes=relese")
+                .buildAndFail()
+        assertTrue("did you mean 'release'?" in result.output, result.output)
+    }
+
+    private fun writeFixture(dir: Path) {
+        dir.resolve("gradle.properties").writeText("kmptargets.targets=iosSimulatorArm64\n")
+        dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
+        dir.resolve("build.gradle.kts")
+            .writeText(
+                """
+                import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+                import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
+                plugins {
+                    kotlin("multiplatform")
+                    id("com.rsicarelli.kmptargets")
+                }
+
+                kmpTargets {
+                    supports { appleMobile }
+                    appleFramework("KotlinShared")
+                }
+
+                // Read the effective build types off the real KGP Framework binaries at
+                // configuration time and print them; the requested task carries no action, so the
+                // narrowing is the only configuration-time work under test.
+                val buildTypes =
+                    kotlin.targets.withType(KotlinNativeTarget::class.java)
+                        .flatMap { it.binaries.withType(Framework::class.java) }
+                        .map { it.buildType.name }
+                        .toSortedSet()
+                println("BUILDTYPES=" + buildTypes.joinToString(","))
+                tasks.register("assertBuildTypes")
+                """
+                    .trimIndent()
+            )
+    }
+
+    private fun runner(dir: Path): GradleRunner =
+        GradleRunner.create().withProjectDir(dir.toFile()).withPluginClasspath()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkBuildTypesInProcessTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/FrameworkBuildTypesInProcessTest.kt
@@ -1,0 +1,245 @@
+package com.rsicarelli.kmptargets
+
+import com.rsicarelli.kmptargets.doctor.KmpTargetsDoctorTask
+import com.rsicarelli.kmptargets.info.KmpTargetsInfoTask
+import com.rsicarelli.kmptargets.model.KmpTarget
+import com.rsicarelli.kmptargets.model.KmpTargetSet
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * `kmptargets.framework.buildTypes` (#108) wired end-to-end through the selection-sources chain:
+ * the effective build types are `property ∩ appleFramework(buildTypes = …)`, the lane only ever
+ * narrows the declaration (and so drives both the per-buildType link tasks and the XCFramework
+ * assemble variants), an absent property keeps the declared value, and a disjoint pair links
+ * nothing and fires the build-types-disjoint advisory (strict fails) — mutually exclusive with the
+ * unattached advisory (#107). `kmpTargetsInfo` surfaces the effective set and the winning origin
+ * layer.
+ */
+class FrameworkBuildTypesInProcessTest {
+
+    private val debugOnly = listOf(NativeBuildType.DEBUG)
+
+    @Test
+    fun `given the debug property and a default framework when declared then only the debug framework binary links`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, targets = "iosArm64", buildTypes = "debug")
+        ext(project).appleFramework("KotlinShared")
+        ext(project).supports(KmpTargetSet.appleMobile)
+        assertEquals(
+            listOf(NativeBuildType.DEBUG),
+            project.frameworksByTarget().getValue("iosArm64").map { it.buildType },
+        )
+    }
+
+    @Test
+    fun `given no build-types property when a default framework is declared then the declared build types win`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, targets = "iosArm64")
+        ext(project).appleFramework("KotlinShared")
+        ext(project).supports(KmpTargetSet.appleMobile)
+        assertEquals(
+            setOf(NativeBuildType.DEBUG, NativeBuildType.RELEASE),
+            project.frameworksByTarget().getValue("iosArm64").map { it.buildType }.toSet(),
+        )
+    }
+
+    @Test
+    fun `given a property that supersets the declaration when declared then intersection never widens past the declaration`(
+        @TempDir dir: Path
+    ) {
+        // property = {DEBUG, RELEASE}, declaration = {DEBUG}: the property can only narrow, so the
+        // effective set stays {DEBUG} (it can never link a build type the module did not declare).
+        val project = projectWith(dir, targets = "iosArm64", buildTypes = "debug,release")
+        ext(project).appleFramework("KotlinShared", buildTypes = debugOnly)
+        ext(project).supports(KmpTargetSet.appleMobile)
+        assertEquals(
+            listOf(NativeBuildType.DEBUG),
+            project.frameworksByTarget().getValue("iosArm64").map { it.buildType },
+        )
+    }
+
+    @Test
+    fun `given the debug property and xcframework when declared then only the debug assemble variant exists`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, targets = "iosArm64,iosSimulatorArm64", buildTypes = "debug")
+        ext(project).appleFramework("KotlinShared", xcframework = true)
+        ext(project).supports(KmpTargetSet.appleMobile)
+        val tasks = project.xcframeworkTaskNames()
+        assertTrue("assembleKotlinSharedDebugXCFramework" in tasks, tasks.toString())
+        assertTrue("assembleKotlinSharedReleaseXCFramework" !in tasks, tasks.toString())
+    }
+
+    @Test
+    fun `given a property disjoint from the declaration when declared then nothing links and the disjoint advisory fires while unattached stays silent`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, targets = "iosArm64", buildTypes = "release")
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared", buildTypes = debugOnly)
+        extension.supports(KmpTargetSet.appleMobile)
+        // The Apple leaf registered and the framework attached to it, but the build types do not
+        // overlap, so no Framework binary links at all.
+        assertTrue(project.frameworksByTarget().isEmpty(), project.frameworksByTarget().toString())
+        assertTrue(extension.frameworkAttachedLeaves().isNotEmpty())
+        assertTrue(extension.frameworkBuildTypesDisjointWarned)
+        assertFalse(extension.frameworkUnattachedWarned)
+    }
+
+    @Test
+    fun `given a disjoint property when the doctor finding input is read then it is true`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, targets = "iosArm64", buildTypes = "release")
+        ext(project).appleFramework("KotlinShared", buildTypes = debugOnly)
+        ext(project).supports(KmpTargetSet.appleMobile)
+        assertTrue(doctor(project).frameworkBuildTypesDisjoint.get())
+    }
+
+    @Test
+    fun `given strict on and a disjoint property when supports runs then the build fails with the disjoint text and leaves no bookkeeping`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, targets = "iosArm64", buildTypes = "release", strict = true)
+        val extension = ext(project)
+        // Pre-mark the active Apple leaf as host-warned so the host-impossible advisory — a cause,
+        // emitted before the framework consequence advisories — does not pre-empt the strict
+        // failure
+        // on a non-Apple CI host (iosArm64 cannot compile on LINUX). This isolates the disjoint
+        // advisory's own strict escalation; the host advisory dedups via this exact set.
+        extension.hostWarned += KmpTarget.Native.Apple.Ios.Arm64
+        extension.appleFramework("KotlinShared", buildTypes = debugOnly)
+        val ex = assertFailsWith<GradleException> { extension.supports(KmpTargetSet.appleMobile) }
+        assertEquals(
+            frameworkBuildTypesDisjointWarning(
+                project.path,
+                "KotlinShared",
+                setOf(NativeBuildType.RELEASE),
+                setOf(NativeBuildType.DEBUG),
+            ),
+            ex.message,
+        )
+        // Recorded AFTER warnOrFail, so a strict failure leaves the module un-warned (sibling
+        // rule).
+        assertFalse(extension.frameworkBuildTypesDisjointWarned)
+    }
+
+    @Test
+    fun `given a jvm-only selection and the debug property when declared then unattached fires and disjoint stays silent`(
+        @TempDir dir: Path
+    ) {
+        // No Apple leaf attaches, so there is no framework to link — the unattached advisory (#107)
+        // owns this state; the disjoint advisory is gated on ≥1 attached leaf and stays silent.
+        val project = projectWith(dir, targets = "jvm", buildTypes = "debug")
+        val extension = ext(project)
+        extension.appleFramework("KotlinShared")
+        extension.supports { jvm }
+        assertTrue(extension.frameworkUnattachedWarned)
+        assertFalse(extension.frameworkBuildTypesDisjointWarned)
+    }
+
+    @Test
+    fun `given a disjoint framework declared AFTER supports when declared then the replay hook fires the disjoint advisory`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, targets = "iosArm64", buildTypes = "release")
+        val extension = ext(project)
+        extension.supports(KmpTargetSet.appleMobile)
+        assertFalse(extension.frameworkBuildTypesDisjointWarned)
+        extension.appleFramework("KotlinShared", buildTypes = debugOnly)
+        assertTrue(extension.frameworkBuildTypesDisjointWarned)
+    }
+
+    @Test
+    fun `given the debug property when the info inputs are read then they show the effective set the declared set and the origin layer`(
+        @TempDir dir: Path
+    ) {
+        val project = projectWith(dir, targets = "iosArm64", buildTypes = "debug")
+        ext(project).appleFramework("KotlinShared")
+        ext(project).supports(KmpTargetSet.appleMobile)
+        val info = info(project)
+        assertEquals(listOf("DEBUG"), info.frameworkBuildTypes.get())
+        assertEquals(listOf("DEBUG", "RELEASE"), info.frameworkBuildTypesDeclared.get())
+        assertContains(info.frameworkBuildTypesOrigin.get(), "gradle.properties")
+    }
+
+    @Test
+    fun `given a typo of the framework build-types key in the committed file when applied then it fails with a did-you-mean`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("kmp-targets.properties").writeText("kmptargets.framework.buildType=debug\n")
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        val ex =
+            assertFailsWith<GradleException> {
+                project.pluginManager.apply("com.rsicarelli.kmptargets")
+            }
+        // pluginManager.apply wraps the plugin's GradleException in a PluginApplicationException,
+        // so
+        // the validateKnownKeys diagnostic is on the cause chain, not the top-level message.
+        val messages =
+            generateSequence(ex as Throwable?) { it.cause }
+                .mapNotNull { it.message }
+                .joinToString("\n")
+        assertContains(messages, "kmptargets.framework.buildType")
+        assertContains(messages, "did you mean 'kmptargets.framework.buildTypes'?")
+    }
+
+    private fun projectWith(
+        dir: Path,
+        targets: String,
+        buildTypes: String? = null,
+        strict: Boolean = false,
+    ): Project {
+        dir.resolve("gradle.properties")
+            .writeText(
+                buildString {
+                    appendLine("kmptargets.targets=$targets")
+                    if (buildTypes != null)
+                        appendLine("kmptargets.framework.buildTypes=$buildTypes")
+                    if (strict) appendLine("kmptargets.strict=true")
+                }
+            )
+        val project = ProjectBuilder.builder().withProjectDir(dir.toFile()).build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply("com.rsicarelli.kmptargets")
+        return project
+    }
+
+    private fun ext(project: Project): KmpTargetsExtension =
+        project.extensions.getByType(KmpTargetsExtension::class.java)
+
+    private fun info(project: Project): KmpTargetsInfoTask =
+        project.tasks.getByName("kmpTargetsInfo") as KmpTargetsInfoTask
+
+    private fun doctor(project: Project): KmpTargetsDoctorTask =
+        project.tasks.getByName("kmpTargetsDoctor") as KmpTargetsDoctorTask
+
+    /** Every [Framework] binary the plugin attached, grouped by the KGP target name. */
+    private fun Project.frameworksByTarget(): Map<String, List<Framework>> =
+        extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .withType(KotlinNativeTarget::class.java)
+            .associate { it.targetName to it.binaries.withType(Framework::class.java).toList() }
+            .filterValues { it.isNotEmpty() }
+
+    private fun Project.xcframeworkTaskNames(): Set<String> =
+        tasks.names.filter { it.endsWith("XCFramework") }.toSet()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormatTest.kt
@@ -247,6 +247,26 @@ class KmpTargetsDoctorFormatTest {
     }
 
     @Test
+    fun `given a build-types-disjoint framework when formatted then it explains the empty overlap and names the declared set as the fix`() {
+        val output =
+            format(
+                selectionIds = listOf("iosArm64"),
+                supportedIds = listOf("iosArm64"),
+                registeredIds = listOf("iosArm64"),
+                frameworkDeclared = true,
+                frameworkBaseName = "KotlinShared",
+                frameworkAttachedIds = listOf("iosArm64"),
+                frameworkBuildTypes = emptyList(),
+                frameworkBuildTypesDeclared = listOf("DEBUG"),
+                frameworkBuildTypesDisjoint = true,
+            )
+        assertContains(output, "[!] framework build types disjoint")
+        assertContains(output, "kmptargets.framework.buildTypes")
+        assertContains(output, "DEBUG")
+        assertContains(output, "Xcode build consuming it fails downstream")
+    }
+
+    @Test
     fun `given identical inputs when formatted twice then the output is identical`() {
         // Config-cache contract: pure function of primitives.
         assertTrue(format() == format())
@@ -273,8 +293,10 @@ class KmpTargetsDoctorFormatTest {
         frameworkBaseName: String = "",
         frameworkAttachedIds: List<String> = emptyList(),
         frameworkBuildTypes: List<String> = emptyList(),
+        frameworkBuildTypesDeclared: List<String> = emptyList(),
         frameworkXcframework: Boolean = false,
         frameworkUnattached: Boolean = false,
+        frameworkBuildTypesDisjoint: Boolean = false,
     ): String =
         formatKmpTargetsDoctor(
             projectPath = projectPath,
@@ -297,7 +319,9 @@ class KmpTargetsDoctorFormatTest {
             frameworkBaseName = frameworkBaseName,
             frameworkAttachedIds = frameworkAttachedIds,
             frameworkBuildTypes = frameworkBuildTypes,
+            frameworkBuildTypesDeclared = frameworkBuildTypesDeclared,
             frameworkXcframework = frameworkXcframework,
             frameworkUnattached = frameworkUnattached,
+            frameworkBuildTypesDisjoint = frameworkBuildTypesDisjoint,
         )
 }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
@@ -275,6 +275,41 @@ class KmpTargetsInfoFormatTest {
         assertFalse("Apple framework" in output, output)
     }
 
+    @Test
+    fun `given a lane that narrowed the build types when formatted then the line shows the effective set the origin and the declared set`() {
+        val output =
+            format(
+                registeredIds = listOf("iosArm64"),
+                frameworkDeclared = true,
+                frameworkBaseName = "KotlinShared",
+                frameworkAttachedIds = listOf("iosArm64"),
+                frameworkBuildTypes = listOf("DEBUG"),
+                frameworkBuildTypesDeclared = listOf("DEBUG", "RELEASE"),
+                frameworkBuildTypesOrigin = "command line (-Pkmptargets.framework.buildTypes)",
+            )
+        assertContains(
+            output,
+            "buildTypes:  DEBUG  (source: command line (-Pkmptargets.framework.buildTypes); " +
+                "declared DEBUG, RELEASE)",
+        )
+    }
+
+    @Test
+    fun `given a lane disjoint from the declaration when formatted then the build types line names the empty overlap`() {
+        val output =
+            format(
+                registeredIds = listOf("iosArm64"),
+                frameworkDeclared = true,
+                frameworkBaseName = "KotlinShared",
+                frameworkAttachedIds = listOf("iosArm64"),
+                frameworkBuildTypes = emptyList(),
+                frameworkBuildTypesDeclared = listOf("DEBUG"),
+                frameworkBuildTypesOrigin = "kmp-targets.properties",
+            )
+        assertContains(output, "buildTypes:  (none — kmp-targets.properties does not overlap")
+        assertContains(output, "nothing links)")
+    }
+
     private fun format(
         selectionIds: List<String> = listOf("jvm"),
         supportedIds: List<String> = listOf("jvm"),
@@ -292,6 +327,8 @@ class KmpTargetsInfoFormatTest {
         frameworkBaseName: String = "",
         frameworkAttachedIds: List<String> = emptyList(),
         frameworkBuildTypes: List<String> = emptyList(),
+        frameworkBuildTypesDeclared: List<String> = emptyList(),
+        frameworkBuildTypesOrigin: String = "",
         frameworkXcframework: Boolean = false,
     ): String =
         formatKmpTargetsInfo(
@@ -314,6 +351,8 @@ class KmpTargetsInfoFormatTest {
             frameworkBaseName = frameworkBaseName,
             frameworkAttachedIds = frameworkAttachedIds,
             frameworkBuildTypes = frameworkBuildTypes,
+            frameworkBuildTypesDeclared = frameworkBuildTypesDeclared,
+            frameworkBuildTypesOrigin = frameworkBuildTypesOrigin,
             frameworkXcframework = frameworkXcframework,
         )
 }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/parser/BuildTypesParserTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/parser/BuildTypesParserTest.kt
@@ -1,0 +1,85 @@
+package com.rsicarelli.kmptargets.parser
+
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure parsing facts of `kmptargets.framework.buildTypes` (#108): a comma-separated,
+ * case-insensitive list over KGP's closed [NativeBuildType] enum, modelled on [parseKmpTargets] but
+ * with no `+`/`-` algebra. Empty input defers (the declared build types win); an unknown token
+ * fails with a did-you-mean. No Gradle here — the resolution/intersection wiring is proven by the
+ * in-process suite.
+ */
+class BuildTypesParserTest {
+
+    private fun ok(raw: String): Set<NativeBuildType> {
+        val result = parseBuildTypes(raw)
+        assertTrue(result is BuildTypesParseResult.Ok, "expected Ok for '$raw', was $result")
+        return result.buildTypes
+    }
+
+    private fun err(raw: String): BuildTypesParseResult.Err {
+        val result = parseBuildTypes(raw)
+        assertTrue(result is BuildTypesParseResult.Err, "expected Err for '$raw', was $result")
+        return result
+    }
+
+    @Test
+    fun `given debug when parsed then it resolves to the DEBUG build type`() {
+        assertEquals(setOf(NativeBuildType.DEBUG), ok("debug"))
+    }
+
+    @Test
+    fun `given release when parsed then it resolves to the RELEASE build type`() {
+        assertEquals(setOf(NativeBuildType.RELEASE), ok("release"))
+    }
+
+    @Test
+    fun `given a comma list when parsed then it resolves to both build types`() {
+        assertEquals(setOf(NativeBuildType.DEBUG, NativeBuildType.RELEASE), ok("debug,release"))
+    }
+
+    @Test
+    fun `given mixed case and whitespace and reversed order when parsed then it is case-insensitive and order-insensitive`() {
+        assertEquals(
+            setOf(NativeBuildType.DEBUG, NativeBuildType.RELEASE),
+            ok("  RELEASE , Debug "),
+        )
+    }
+
+    @Test
+    fun `given a repeated token when parsed then it is de-duplicated`() {
+        assertEquals(setOf(NativeBuildType.DEBUG), ok("debug,DEBUG"))
+    }
+
+    @Test
+    fun `given empty input when parsed then it is Ok with an empty set and a warning`() {
+        val result = parseBuildTypes("")
+        assertTrue(result is BuildTypesParseResult.Ok)
+        assertTrue(result.buildTypes.isEmpty())
+        assertTrue(result.warnings.isNotEmpty(), "empty input should warn, not fail")
+    }
+
+    @Test
+    fun `given only separators when parsed then it is Ok with an empty set`() {
+        assertTrue(ok(" , ").isEmpty())
+    }
+
+    @Test
+    fun `given a near-miss token when parsed then it fails with a did-you-mean suggestion`() {
+        val result = err("relese")
+        assertEquals("relese", result.offendingToken)
+        assertContains(result.message, "did you mean 'release'?")
+    }
+
+    @Test
+    fun `given an unknown token among valid ones when parsed then it fails naming the offending token`() {
+        val result = err("debug,foo")
+        assertEquals("foo", result.offendingToken)
+        assertContains(result.message, "foo")
+        assertContains(result.message, "debug, release")
+    }
+}


### PR DESCRIPTION
## Summary

Build type is **lane-shaped, not module-shaped**: local dev wants DEBUG-only links, the release lane wants RELEASE. This makes Apple-framework build types a global, layered input — `kmptargets.framework.buildTypes`, the build-type twin of `kmptargets.targets` — instead of being fixed per module at `appleFramework(buildTypes = …)`. It implements the issue's **chosen direction (a)** faithfully (framework-scoped), building on the merged #105/#106/#107 machinery.

**Not a deviation** from the issue: `NativeBuildType` is a closed 2-value enum KGP won't extend, so parsing `debug`/`release` is the legitimate `targets`-axis analog (not a mirrored vocabulary like #105's declined spec DSL), and intersection only ever **narrows** — `kmpTargetsInfo` makes the narrowing transparent, so it stays the already-accepted `supports {}`-vs-selection model, not new magic.

## Changes

- **New key `kmptargets.framework.buildTypes`** (`debug`/`release`, comma grammar, case-insensitive) registered in `ConfigKeys.ALL`, resolved through the **exact same** `labeledSources` winner-walk + origin capture as `kmptargets.targets` — so precedence matches per layer and a typo in a dedicated config file fails with a did-you-mean.
- **New `parseBuildTypes`** over KGP's closed `NativeBuildType` enum, modelled on `parseKmpTargets` and reusing `didYouMean` — routes to the real KGP type, nothing mirrored.
- **Effective = `property ∩ appleFramework(buildTypes)`** (the `selection ∩ supported` shape): the property only narrows, never widens; absent → the declared value wins (no silent narrowing of a KGP default). The effective set drives **both** `binaries.framework` **and** the #106 XCFramework assemble variants (`=debug` ⇒ only `linkDebugFramework…` + `assemble…DebugXCFramework`).
- **Disjoint `property ∩ declared` → nothing links** + a **build-types-disjoint advisory** (warn; `kmptargets.strict` fails), a sibling of #107's unattached advisory and mutually exclusive with it (zero vs ≥1 attached leaves).
- **`kmpTargetsInfo` / `kmpTargetsDoctor`** extend #107's framework-facts surface (no parallel surface) to show the effective build types, the winning **origin layer**, the declared set when a lane narrowed it, and the disjoint finding — from the same shared providers.
- **Config-cache safe**: read once at apply time as a primitive `Set<NativeBuildType>` snapshot on the extension (mirrors `globalSelection`); no `Project`/task captured.
- **Docs**: `apple-framework.md` (new "Build types per lane" section), `advisories.md` (8th advisory), `diagnostics.md`, `selection-layers.md`, `why-kmp-targets.md`, README.

## Test plan

- [x] `./gradlew :gradle-plugin:test :gradle-plugin:ktfmtCheck` green locally (full `task ci` not run — no `task`/Kotlin-Native toolchain in the sandbox, matching #105–#107)
- [x] Verified end-to-end on the standalone `samples/hello-world` `core-and-apple`: `kmpTargetsInfo -Pkmptargets.framework.buildTypes=debug` renders `buildTypes: DEBUG (source: command line …; declared DEBUG, RELEASE)`, and only `linkDebugFramework…` / `assemble…DebugXCFramework` tasks exist (no Release variants)
- [x] Added tests (GIVEN-WHEN-THEN): `BuildTypesParserTest` (grammar, case-insensitive, empty→defer, did-you-mean), `FrameworkBuildTypesDisjointAdvisoryTest` (pure predicate + message), `FrameworkBuildTypesInProcessTest` (narrowing, XCFramework narrowing, disjoint + strict + mutual exclusivity with unattached, info effective/origin, typo'd dedicated-file key), `FrameworkBuildTypesEnvPropertyMappingFunctionalTest` (per-layer launcher precedence on the real KGP `Framework.buildType` + junk fails), and info/doctor format cases
- [x] Updated docs/README (user-facing)
- [x] No new public API without explicit intent — the new state is `internal`; the only behavior change is on the existing `appleFramework(...)`

## Related

- Implements #108 (chosen direction (a)), framework-scoped.
- Builds on / extends #105 (`appleFramework`), #106 (`xcframework`), and #107's framework-facts + advisory surface — all merged. The disjoint advisory is the build-type analog of the empty-overlap advisory (#10) and mirrors #107's consequence-channel pattern.
- Selection-sources chain + key registry: #30, #33. Strict mode: #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzfkARHS81TmWzhZUECr8x

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzfkARHS81TmWzhZUECr8x)_