### PR TITLE
chore(deps): stop Dependabot bumping Kotlin and Compose

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,13 @@ updates:
       junit:
         patterns:
           - "org.junit*"
+    ignore:
+      # Kotlin is upgraded deliberately (toolchain + sample DSL migration), never as an automated
+      # bump — Kotlin 2.4.0 removed the built-in ABI-validation DSL the abi-builtin sample uses (#92).
+      - dependency-name: "org.jetbrains.kotlin*"
+      # Compose is upgraded deliberately in lockstep with the Kotlin / Compose-compiler toolchain.
+      - dependency-name: "org.jetbrains.compose*"
+      - dependency-name: "androidx.compose*"
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
Adds Dependabot `ignore` rules to the Gradle ecosystem so Kotlin and Compose are no longer auto-bumped:

- `org.jetbrains.kotlin*`
- `org.jetbrains.compose*`
- `androidx.compose*`

**Why:** Kotlin upgrades are deliberate (toolchain + sample DSL migration), not automated bumps — Kotlin 2.4.0 removed the experimental built-in ABI-validation DSL that `samples/abi-builtin` relies on, which broke #92 (now closed). Compose is upgraded in lockstep with the Kotlin / Compose-compiler toolchain for the same reason. (Compose isn't a dependency yet — this rule is preemptive.)

Dependabot reads `dependabot.yml` from the default branch, so this only takes effect once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)