### PR TITLE
feat(#109): opt-in Xcode-environment selection source (SDK_NAME/ARCHS/CONFIGURATION)

### DIFF
--- a/.github/workflows/sample-matrix.yml
+++ b/.github/workflows/sample-matrix.yml
@@ -9,6 +9,9 @@
 # its only selectable shape). Registration is host-blind by design — selecting iosArm64 on
 # Linux/Windows registers it with an advisory and KGP disables its compile tasks there.
 #
+# The macOS lane additionally validates the opt-in Xcode-environment source (#109) over the
+# standalone samples/xcode-env build — the only host that can link the framework Xcode would embed.
+#
 # Gradle comes from the committed wrapper (9.5.1) — no `gradle-version` override — and the JDK
 # matches .mise.toml (Temurin 23), so CI and local toolchains stay aligned.
 
@@ -74,3 +77,20 @@ jobs:
 
       - name: Build sample with host-appropriate selection
         run: ./gradlew -p samples/hello-world build "-Pkmptargets.targets=${{ matrix.targets }}"
+
+      # macOS only: the opt-in Xcode-environment source (#109). Exporting Xcode's real
+      # SDK_NAME/ARCHS/CONFIGURATION — exactly what Xcode sets before invoking Gradle for
+      # embedAndSign — exercises the zero-`-P` path end to end: with `kmptargets.xcodeEnv=true`
+      # committed in the sample, selection narrows to the one simulator leaf (asserted by
+      # verifyXcodeEnvNarrowed) and the framework links on a real Apple toolchain. No .xcodeproj
+      # needed; the env contract is KGP's own.
+      - name: Validate Xcode-environment selection (macOS)
+        if: runner.os == 'macOS'
+        env:
+          SDK_NAME: iphonesimulator
+          ARCHS: arm64
+          CONFIGURATION: Debug
+        run: |
+          ./gradlew -p samples/xcode-env :kmpTargetsInfo -q
+          ./gradlew -p samples/xcode-env verifyXcodeEnvNarrowed
+          ./gradlew -p samples/xcode-env linkDebugFrameworkIosSimulatorArm64

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Full story: [Compatibility](https://rsicarelli.github.io/kmp-targets/compatibili
 
 ## Documentation
 
-**Status:** alpha. Roadmap: user-defined hierarchy groups. The [Apple framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) helper now covers framework declaration and XCFramework assembly.
+**Status:** alpha. Roadmap: user-defined hierarchy groups. The [Apple framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) helper covers framework declaration and XCFramework assembly, and the opt-in [Xcode environment](https://rsicarelli.github.io/kmp-targets/user-guide/xcode-environment/) source lets Xcode's `SDK_NAME`/`ARCHS`/`CONFIGURATION` drive selection with no `-P`.
 
 Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.github.io/kmp-targets/)**:
 
@@ -68,6 +68,7 @@ Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.gith
 - [Hierarchy](https://rsicarelli.github.io/kmp-targets/user-guide/hierarchy-template/) — minimal template, no-collapse
 - [Build Logic](https://rsicarelli.github.io/kmp-targets/user-guide/build-logic/) — conventions, `onRegistered`, helpers
 - [Apple Framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) — `appleFramework`, `onAppleTarget`, route-to-real-KGP
+- [Xcode Environment](https://rsicarelli.github.io/kmp-targets/user-guide/xcode-environment/) — opt-in `SDK_NAME`/`ARCHS`/`CONFIGURATION` selection, zero-`-P` Xcode builds
 - [Recipes](https://rsicarelli.github.io/kmp-targets/user-guide/recipes/) — KSP gates, AGP gating, dependency-graph rules
 - [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/user-guide/advisories/) — the eight advisories and CI strictness
 - [Diagnostics](https://rsicarelli.github.io/kmp-targets/user-guide/diagnostics/) — `kmpTargetsInfo` and `kmpTargetsDoctor`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,6 +59,12 @@ tasks:
     cmds:
       - "{{.GRADLE}} -p samples/abi-builtin checkKotlinAbi -Pkmptargets.targets=jvm"
 
+  sample:xcode-env:
+    desc: "Opt-in Xcode-environment selection (#109): kmpTargetsInfo over the committed fallback — set SDK_NAME/ARCHS/CONFIGURATION to see the narrowing (depends on publish-local)"
+    deps: [publish-local]
+    cmds:
+      - "{{.GRADLE}} -p samples/xcode-env kmpTargetsInfo"
+
   ci:
     desc: Full local CI dry-run (check + publish-local + samples)
     cmds:
@@ -68,6 +74,7 @@ tasks:
       - task: sample:isolated
       - task: sample:abi-bcv
       - task: sample:abi-builtin
+      - task: sample:xcode-env
 
   dod:
     desc: Definition of Done — fmt + build + test (run before committing)
@@ -106,6 +113,7 @@ tasks:
       - rm -rf samples/isolated-projects/build samples/isolated-projects/.gradle samples/isolated-projects/*/build
       - rm -rf samples/abi-bcv/build samples/abi-bcv/.gradle
       - rm -rf samples/abi-builtin/build samples/abi-builtin/.gradle
+      - rm -rf samples/xcode-env/build samples/xcode-env/.gradle
 
   fmt:
     desc: Format Kotlin sources with ktfmt (kotlinlang style) across the main build and both samples
@@ -115,6 +123,7 @@ tasks:
       - "{{.GRADLE}} -p samples/isolated-projects ktfmtFormat"
       - "{{.GRADLE}} -p samples/abi-bcv ktfmtFormat"
       - "{{.GRADLE}} -p samples/abi-builtin ktfmtFormat"
+      - "{{.GRADLE}} -p samples/xcode-env ktfmtFormat"
 
   fmt:check:
     desc: Verify Kotlin sources are ktfmt-formatted across the main build and both samples (run by `task check`)
@@ -124,3 +133,4 @@ tasks:
       - "{{.GRADLE}} -p samples/isolated-projects ktfmtCheck"
       - "{{.GRADLE}} -p samples/abi-bcv ktfmtCheck"
       - "{{.GRADLE}} -p samples/abi-builtin ktfmtCheck"
+      - "{{.GRADLE}} -p samples/xcode-env ktfmtCheck"

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ kmpTargets {
 
 The plugin registers `selection ∩ supported` per module: the module declares what it *can* build, the global selection decides what you *want* right now.
 
-**Status:** alpha. Roadmap: user-defined hierarchy groups, XCFramework helpers.
+**Status:** alpha. Roadmap: user-defined hierarchy groups. Apple support now covers the [framework helper](user-guide/apple-framework.md), XCFramework assembly, and the opt-in [Xcode environment](user-guide/xcode-environment.md) selection source.
 
 ## Documentation
 

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -1,6 +1,6 @@
 # Samples
 
-Four standalone sample builds consume the plugin as an external project would: shared root version catalog, plugin resolved by version (mavenLocal in the dev loop, Maven Central for consumers).
+Five standalone sample builds consume the plugin as an external project would: shared root version catalog, plugin resolved by version (mavenLocal in the dev loop, Maven Central for consumers).
 
 ## hello-world — the multi-module showcase
 
@@ -40,6 +40,16 @@ Two single-module libraries that support `jvm + linuxX64 + js` and commit ABI du
 ./gradlew -p samples/abi-bcv     apiCheck                                   # full selection (recommended lane) → clean
 ```
 
+## xcode-env — Xcode drives selection
+
+[`samples/xcode-env`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/xcode-env) is a single-module library shipping an iOS/macOS framework with `kmptargets.xcodeEnv=true` committed. With no Xcode env it builds the committed fallback; when Xcode's `SDK_NAME`/`ARCHS`/`CONFIGURATION` are present they narrow selection to the one leaf being built — no `-P`. Its `verifyXcodeEnvNarrowed` task pins the narrowing; the [Xcode Environment](../user-guide/xcode-environment.md) guide explains the mapping.
+
+```bash
+./gradlew -p samples/xcode-env kmpTargetsInfo                                   # committed fallback
+SDK_NAME=iphonesimulator ARCHS=arm64 CONFIGURATION=Debug \
+  ./gradlew -p samples/xcode-env verifyXcodeEnvNarrowed                         # narrows to iosSimulatorArm64
+```
+
 ## CI runs them
 
-[`ci.yml`](https://github.com/rsicarelli/kmp-targets/blob/main/.github/workflows/ci.yml) builds the samples on every push; [`sample-matrix.yml`](https://github.com/rsicarelli/kmp-targets/blob/main/.github/workflows/sample-matrix.yml) builds hello-world per host with host-appropriate selections — the [CI matrix](../user-guide/ci-matrix.md) pattern.
+[`ci.yml`](https://github.com/rsicarelli/kmp-targets/blob/main/.github/workflows/ci.yml) builds the samples on every push; [`sample-matrix.yml`](https://github.com/rsicarelli/kmp-targets/blob/main/.github/workflows/sample-matrix.yml) builds hello-world per host with host-appropriate selections — the [CI matrix](../user-guide/ci-matrix.md) pattern — and on macOS links the `xcode-env` framework from the real Xcode environment.

--- a/docs/user-guide/apple-framework.md
+++ b/docs/user-guide/apple-framework.md
@@ -100,4 +100,6 @@ extensions.configure<KmpTargetsExtension> {
 
 ## Out of scope
 
-Per-module build-type property variants, mapping Xcode's `CONFIGURATION` env var, and custom (non-DEBUG/RELEASE) build types are out of scope (KGP's enum is closed). Multiple frameworks per module (and aggregating several into one XCFramework), and non-Apple binaries (`sharedLib`/`staticLib`/`executable`) are deliberate follow-ups.
+Per-module build-type property variants and custom (non-DEBUG/RELEASE) build types are out of scope (KGP's enum is closed). Multiple frameworks per module (and aggregating several into one XCFramework), and non-Apple binaries (`sharedLib`/`staticLib`/`executable`) are deliberate follow-ups.
+
+Letting Xcode's own `SDK_NAME`/`ARCHS`/`CONFIGURATION` drive selection — so the Xcode build phase needs no `-P` — is the opt-in [Xcode Environment](xcode-environment.md) source.

--- a/docs/user-guide/selection-layers.md
+++ b/docs/user-guide/selection-layers.md
@@ -23,6 +23,8 @@ When no source provides a value, two **fallbacks** (not overrides — anything a
 
 The rarer `-Dorg.gradle.project.kmptargets.targets` and `~/.gradle/gradle.properties` forms resolve at the `gradle.properties` layer, below the dedicated files. Why the dedicated files outrank `gradle.properties`: [Design](../why-kmp-targets.md#selection-model).
 
+With the opt-in [`kmptargets.xcodeEnv`](xcode-environment.md) flag on, an extra layer sits between **2** and **3** — Xcode's own `SDK_NAME`/`ARCHS` when it invokes Gradle — so an Xcode build needs no `-P`. The flag off, it does not exist.
+
 ## The config files
 
 ```properties

--- a/docs/user-guide/xcode-environment.md
+++ b/docs/user-guide/xcode-environment.md
@@ -1,0 +1,59 @@
+# Xcode Environment
+
+When Xcode invokes Gradle for `embedAndSign…AppleFrameworkForXcode`, it exports `SDK_NAME`, `ARCHS`, and `CONFIGURATION` — KGP already reads them to drive the embed task. Yet the consumer's Xcode build phase still has to pass `-Pkmptargets.targets=…` so the right leaf registers. The env vars already carry the answer.
+
+The opt-in **`kmptargets.xcodeEnv`** flag closes that gap: with it on, Xcode's environment becomes a *declared* selection layer, so the Xcode build phase needs **no `-P`**.
+
+```properties
+# kmp-targets.properties — committed, team-shared
+kmptargets.xcodeEnv=true
+```
+
+This is explicit by design. The committed flag is the act you review; the env is then a declared input, not ambient magic. With the flag off, the Xcode variables are **never read** (no configuration-cache inputs added).
+
+## What it maps
+
+`SDK_NAME` (matched by prefix; it carries a version suffix like `iphonesimulator18.0`) plus a single `ARCHS` value resolve to one leaf:
+
+| `SDK_NAME` | `arm64` | `x86_64` | other arch |
+|---|---|---|---|
+| `iphoneos` | `iosArm64` | — | — |
+| `iphonesimulator` | `iosSimulatorArm64` | `iosX64` | — |
+| `appletvos` | `tvosArm64` | — | — |
+| `appletvsimulator` | `tvosSimulatorArm64` | `tvosX64` | — |
+| `watchos` | `watchosDeviceArm64` | — | `arm64_32` → `watchosArm64`, `armv7k` → `watchosArm32` |
+| `watchsimulator` | `watchosSimulatorArm64` | `watchosX64` | — |
+| `macosx` | `macosArm64` | `macosX64` | — |
+
+`CONFIGURATION` feeds [`kmptargets.framework.buildTypes`](apple-framework.md#build-types-per-lane): `Debug`/`Release` map case-insensitively. A **custom** configuration (`Staging`, `QA`, …) is not a build type, so — mirroring KGP — the `KOTLIN_FRAMEWORK_BUILD_TYPE` env var is consulted as the fallback.
+
+An **unknown** SDK, an unrecognized or **multi-architecture** `ARCHS` (a fat build like `arm64 x86_64`), or a custom configuration with no fallback all resolve to nothing and **fall through to the next layer** — they never fail the build. `IS_MACCATALYST` is not consulted.
+
+## Precedence
+
+The Xcode-environment source slots **below** the per-invocation overrides and **above** the dedicated files, so a CI lane or a manual run can still override it, while inside an Xcode build the active SDK/arch wins over any committed default:
+
+1. `-Pkmptargets.targets=…` / `-Pkmptargets.framework.buildTypes=…` (CLI)
+2. `ORG_GRADLE_PROJECT_…` environment
+3. **Xcode environment** (`SDK_NAME`/`ARCHS` → selection, `CONFIGURATION` → build types) — when `kmptargets.xcodeEnv=true`
+4. `kmp-targets.local.properties` → `kmp-targets.properties` → `gradle.properties` → `local.properties`
+
+[`kmpTargetsInfo`](diagnostics.md#kmptargetsinfo) names the winning origin — `Xcode environment (SDK_NAME/ARCHS)` for the selection, `Xcode environment (CONFIGURATION)` for the build types — so a build driven by Xcode is never opaque.
+
+## The payoff
+
+The consumer's Xcode "Run Script" build phase drops the `-P` entirely:
+
+```bash
+# Before — the run-script had to re-derive and pass the selection:
+./gradlew :shared:embedAndSignAppleFrameworkForXcode -Pkmptargets.targets=iosSimulatorArm64
+
+# After (kmptargets.xcodeEnv=true) — Xcode's own SDK_NAME/ARCHS/CONFIGURATION drive it:
+./gradlew :shared:embedAndSignAppleFrameworkForXcode
+```
+
+`embedAndSign…` stays KGP's task and contract — the plugin only maps the env Xcode already sets onto the selection. Outside Xcode (no env), selection falls through to the committed `kmp-targets.properties`, so a plain `./gradlew` build is unchanged and fully reproducible. See the runnable [`samples/xcode-env`](https://github.com/rsicarelli/kmp-targets/tree/main/samples/xcode-env) build.
+
+## Out of scope
+
+Owning `embedAndSign` (KGP's task), generating the Xcode run-script phase, multi-architecture fat-simulator handling, and `IS_MACCATALYST` are deliberately not covered.

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/KmpTargetsPlugin.kt
@@ -26,6 +26,8 @@ import com.rsicarelli.kmptargets.source.EnvironmentVariableSource
 import com.rsicarelli.kmptargets.source.GradlePropertySource
 import com.rsicarelli.kmptargets.source.LocalPropertyValueSource
 import com.rsicarelli.kmptargets.source.SelectionSource
+import com.rsicarelli.kmptargets.source.XcodeBuildTypesSource
+import com.rsicarelli.kmptargets.source.XcodeTargetsSource
 import com.rsicarelli.kmptargets.source.composeSelectionSources
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -56,6 +58,38 @@ public class KmpTargetsPlugin : Plugin<Project> {
         validateKnownKeys(personal, ConfigKeys.LOCAL_FILE)
         validateKnownKeys(committed, ConfigKeys.COMMITTED_FILE)
 
+        // Opt-in Xcode-environment source (#109): when `kmptargets.xcodeEnv=true`, Xcode's own
+        // SDK_NAME/ARCHS/CONFIGURATION env vars become a *declared* selection layer (slot 3 — below
+        // CLI -P/env, above the dedicated files), so an `embedAndSign…AppleFrameworkForXcode` build
+        // needs no -P. The flag is read once here as a primitive through the standard chain (so it
+        // is
+        // never itself Xcode-derived — no chicken-and-egg). When OFF the env-var sources are not
+        // even
+        // constructed, so `providers.environmentVariable(...)` is never called and NO config-cache
+        // inputs are added; when ON each variable is read lazily via a provider, so invalidation is
+        // correct per variable.
+        val xcodeEnvEnabled: Boolean = xcodeEnvEnabled(target, personal, committed)
+        val xcodeTargetsSource: Pair<String, SelectionSource>? =
+            if (xcodeEnvEnabled) {
+                OriginLabels.xcodeEnvironment("SDK_NAME/ARCHS") to
+                    XcodeTargetsSource(
+                        target.providers.environmentVariable("SDK_NAME"),
+                        target.providers.environmentVariable("ARCHS"),
+                    )
+            } else {
+                null
+            }
+        val xcodeBuildTypesSource: Pair<String, SelectionSource>? =
+            if (xcodeEnvEnabled) {
+                OriginLabels.xcodeEnvironment("CONFIGURATION") to
+                    XcodeBuildTypesSource(
+                        target.providers.environmentVariable("CONFIGURATION"),
+                        target.providers.environmentVariable("KOTLIN_FRAMEWORK_BUILD_TYPE"),
+                    )
+            } else {
+                null
+            }
+
         // Global selection: what the user wants to build now. A blank/absent property means "not
         // overriding" → defer to `defaultSelection`. A non-blank property that
         // resolves to an empty set via minus operators (e.g. `jvm,-jvm`) is an explicit "build
@@ -65,10 +99,10 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // `composeSelectionSources` semantics (lower layers stay unread once one wins) while also
         // capturing WHICH layer won, for `kmpTargetsInfo`'s origin report (issue #33).
         val winner: Pair<String, String>? =
-            labeledSources(target, ConfigKeys.TARGETS, personal, committed).firstNotNullOfOrNull {
-                (label, source) ->
-                source.read()?.let { value -> label to value }
-            }
+            labeledSources(target, ConfigKeys.TARGETS, personal, committed, xcodeTargetsSource)
+                .firstNotNullOfOrNull { (label, source) ->
+                    source.read()?.let { value -> label to value }
+                }
         val raw: String? = winner?.second
         if (raw != null && raw.isNotBlank()) {
             ext.globalSelection = parseOrThrow(raw, ConfigKeys.TARGETS)
@@ -84,7 +118,13 @@ public class KmpTargetsPlugin : Plugin<Project> {
         // property only ever narrows, never widens). Read once here as a primitive set of KGP's own
         // enum, so no `Project` is captured.
         val buildTypesWinner: Pair<String, String>? =
-            labeledSources(target, ConfigKeys.FRAMEWORK_BUILD_TYPES, personal, committed)
+            labeledSources(
+                    target,
+                    ConfigKeys.FRAMEWORK_BUILD_TYPES,
+                    personal,
+                    committed,
+                    xcodeBuildTypesSource,
+                )
                 .firstNotNullOfOrNull { (label, source) ->
                     source.read()?.let { value -> label to value }
                 }
@@ -743,12 +783,18 @@ public class KmpTargetsPlugin : Plugin<Project> {
         key: String,
         personal: Map<String, String>?,
         committed: Map<String, String>?,
+        xcodeEnv: Pair<String, SelectionSource>? = null,
     ): List<Pair<String, SelectionSource>> {
         val cli: String? = target.gradle.startParameter.projectProperties[key]
-        return listOf(
+        // `xcodeEnv` slots in below CLI -P/env and above the dedicated files (#109), and is null
+        // for
+        // every key it does not serve and whenever the opt-in flag is off — `listOfNotNull` then
+        // leaves the existing chain byte-identical.
+        return listOfNotNull(
             OriginLabels.cli(key) to SelectionSource { cli },
             OriginLabels.environmentVariable(key) to
                 EnvironmentVariableSource(target.providers, ConfigKeys.ENV_PREFIX + key),
+            xcodeEnv,
             ConfigKeys.LOCAL_FILE to SelectionSource { personal?.get(key) },
             ConfigKeys.COMMITTED_FILE to SelectionSource { committed?.get(key) },
             OriginLabels.gradleProperties(key) to GradlePropertySource(target.providers, key),
@@ -826,6 +872,23 @@ public class KmpTargetsPlugin : Plugin<Project> {
         committed: Map<String, String>?,
     ): Boolean =
         configSources(target, ConfigKeys.UMBRELLA_TASKS, personal, committed)
+            .read()
+            ?.trim()
+            ?.lowercase()
+            ?.toBooleanStrictOrNull() ?: false
+
+    /**
+     * Reads the global `kmptargets.xcodeEnv` flag (#109) through the standard [configSources] chain
+     * (so the flag is never itself Xcode-derived). Opt-in: unset — or anything other than
+     * `true`/`false` (case-insensitive, per `toBooleanStrictOrNull`) — means OFF, so no Xcode-env
+     * source is composed and the Xcode env vars are never read.
+     */
+    private fun xcodeEnvEnabled(
+        target: Project,
+        personal: Map<String, String>?,
+        committed: Map<String, String>?,
+    ): Boolean =
+        configSources(target, ConfigKeys.XCODE_ENV, personal, committed)
             .read()
             ?.trim()
             ?.lowercase()

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/OriginLabels.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/OriginLabels.kt
@@ -23,6 +23,14 @@ internal object OriginLabels {
         "environment variable ${ConfigKeys.ENV_PREFIX}$key"
 
     /**
+     * The opt-in Xcode-environment source (issue #109), naming the env vars it read —
+     * `SDK_NAME/ARCHS` for the selection, `CONFIGURATION` for the framework build types — so the
+     * origin is explicit in `kmpTargetsInfo` even though the values came from Xcode's ambient
+     * environment.
+     */
+    fun xcodeEnvironment(vars: String): String = "Xcode environment ($vars)"
+
+    /**
      * The fused `providers.gradleProperty` layer. CLI and env are caught by the dedicated layers
      * above it, but this provider cannot tell the remaining origins apart — root
      * `gradle.properties`, `-Dorg.gradle.project.<key>`, and `~/.gradle/gradle.properties` all

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/ConfigKeys.kt
@@ -42,6 +42,16 @@ internal object ConfigKeys {
      */
     const val FRAMEWORK_BUILD_TYPES: String = "kmptargets.framework.buildTypes"
 
+    /**
+     * Global opt-in letting Xcode's own build environment drive selection (`true`/`false`, default
+     * off — issue #109). When on, an Xcode-environment source is slotted into the precedence chain
+     * (below CLI `-P`/env, above the dedicated files) for both [TARGETS] (from `SDK_NAME`+`ARCHS`)
+     * and [FRAMEWORK_BUILD_TYPES] (from `CONFIGURATION`), so an
+     * `embedAndSign…AppleFrameworkForXcode` build needs no `-P`. The committed flag is the explicit
+     * act; with it off the Xcode env vars are never read.
+     */
+    const val XCODE_ENV: String = "kmptargets.xcodeEnv"
+
     /** Every key the dedicated config files may legally contain (unknown keys fail the build). */
     val ALL: Set<String> =
         setOf(
@@ -51,6 +61,7 @@ internal object ConfigKeys {
             STRICT,
             UMBRELLA_TASKS,
             FRAMEWORK_BUILD_TYPES,
+            XCODE_ENV,
         )
 
     /** Committed, team-shared config file at the root of the build. */

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/XcodeEnvironmentMapping.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/XcodeEnvironmentMapping.kt
@@ -1,0 +1,106 @@
+package com.rsicarelli.kmptargets.source
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+
+/**
+ * Pure (no Gradle types) translation of Xcode's build-environment variables into kmp-targets'
+ * vocabulary, for the opt-in Xcode-environment selection source (#109). When Xcode invokes Gradle
+ * for `embedAndSign…AppleFrameworkForXcode` it exports `SDK_NAME` / `ARCHS` / `CONFIGURATION`; KGP
+ * already reads them to drive the embed task, but its `XcodeEnvironment` / `AppleSdk` mapping is
+ * `internal`, so the env-var contract is the only stable surface to map against. These functions
+ * mirror that contract over Apple's own SDK/arch naming — a stable OS-level vocabulary, not KGP's
+ * evolving API — and are unit-tested table-by-table.
+ *
+ * Both functions are total and **never throw**: an unrecognized SDK, an unrecognized or multi-value
+ * `ARCHS`, or a custom build configuration with no fallback all resolve to `null`, so the selection
+ * chain simply falls through to the next layer rather than failing the build.
+ */
+
+/**
+ * Maps an `SDK_NAME` prefix plus a single `ARCHS` value to the registered KGP leaf, or `null` when
+ * the pair is unknown/ambiguous (so the source defers to the next chain layer).
+ *
+ * `SDK_NAME` carries a version suffix (`iphonesimulator18.0`), so the platform is matched by
+ * prefix. A multi-architecture `ARCHS` (a space-separated fat build, e.g. `"arm64 x86_64"`) is
+ * deliberately **out of scope** (issue #109) and yields `null`; `IS_MACCATALYST` is likewise not
+ * consulted.
+ */
+internal fun xcodeTargetLeaf(sdkName: String?, archs: String?): KmpTarget? {
+    val sdk = sdkName?.trim()?.lowercase()?.takeIf { it.isNotEmpty() } ?: return null
+    val arch =
+        archs
+            ?.trim()
+            ?.split(Regex("\\s+"))
+            ?.filter { it.isNotEmpty() }
+            ?.singleOrNull() // multi-arch fat builds are out of scope → fall through
+            ?.lowercase() ?: return null
+    // Simulator prefixes are checked before their device counterparts; none is a prefix of another,
+    // so the order is for readability, not correctness.
+    return when {
+        sdk.startsWith("iphonesimulator") ->
+            when (arch) {
+                "arm64" -> KmpTarget.Native.Apple.Ios.SimulatorArm64
+                "x86_64" -> KmpTarget.Native.Apple.Ios.X64
+                else -> null
+            }
+        sdk.startsWith("iphoneos") ->
+            when (arch) {
+                "arm64" -> KmpTarget.Native.Apple.Ios.Arm64
+                else -> null
+            }
+        sdk.startsWith("appletvsimulator") ->
+            when (arch) {
+                "arm64" -> KmpTarget.Native.Apple.Tvos.SimulatorArm64
+                "x86_64" -> KmpTarget.Native.Apple.Tvos.X64
+                else -> null
+            }
+        sdk.startsWith("appletvos") ->
+            when (arch) {
+                "arm64" -> KmpTarget.Native.Apple.Tvos.Arm64
+                else -> null
+            }
+        sdk.startsWith("watchsimulator") ->
+            when (arch) {
+                "arm64" -> KmpTarget.Native.Apple.Watchos.SimulatorArm64
+                "x86_64" -> KmpTarget.Native.Apple.Watchos.X64
+                else -> null
+            }
+        sdk.startsWith("watchos") ->
+            when (arch) {
+                "arm64" -> KmpTarget.Native.Apple.Watchos.DeviceArm64
+                "arm64_32" -> KmpTarget.Native.Apple.Watchos.Arm64
+                "armv7k" -> KmpTarget.Native.Apple.Watchos.Arm32
+                else -> null
+            }
+        sdk.startsWith("macosx") ->
+            when (arch) {
+                "arm64" -> KmpTarget.Native.Apple.Macos.Arm64
+                "x86_64" -> KmpTarget.Native.Apple.Macos.X64
+                else -> null
+            }
+        else -> null
+    }
+}
+
+/**
+ * Maps Xcode's `CONFIGURATION` to a KGP [NativeBuildType], or `null` when neither it nor the
+ * [kotlinFrameworkBuildType] fallback names a known build type.
+ *
+ * `Debug` / `Release` map directly (case-insensitive). A **custom** configuration (`Staging`, `QA`,
+ * …) is not a build type, so — mirroring KGP's own behavior — the `KOTLIN_FRAMEWORK_BUILD_TYPE`
+ * value (which a consumer sets in their Xcode build settings precisely to disambiguate custom
+ * configurations) is consulted next; if that is also absent or unrecognized, the result is `null`.
+ */
+internal fun xcodeBuildType(
+    configuration: String?,
+    kotlinFrameworkBuildType: String?,
+): NativeBuildType? {
+    fun match(value: String?): NativeBuildType? =
+        when (value?.trim()?.lowercase()?.takeIf { it.isNotEmpty() }) {
+            "debug" -> NativeBuildType.DEBUG
+            "release" -> NativeBuildType.RELEASE
+            else -> null
+        }
+    return match(configuration) ?: match(kotlinFrameworkBuildType)
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/XcodeEnvironmentSource.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/source/XcodeEnvironmentSource.kt
@@ -1,0 +1,37 @@
+package com.rsicarelli.kmptargets.source
+
+import org.gradle.api.provider.Provider
+
+/**
+ * [SelectionSource] for the `kmptargets.targets` key, fed by Xcode's `SDK_NAME` + `ARCHS` (#109).
+ * Emits the matched leaf's [id][com.rsicarelli.kmptargets.model.KmpTarget.id] — a token the
+ * standard `parseKmpTargets` already accepts — or `null` (defer to the next layer) when the pair is
+ * unknown/ambiguous.
+ *
+ * The env providers are captured at construction and read lazily, so each variable is tracked as
+ * its own configuration-cache input. The source is only constructed when the opt-in flag is on, so
+ * when the feature is off these variables are never read and add no config-cache inputs.
+ */
+internal class XcodeTargetsSource(
+    private val sdkName: Provider<String>,
+    private val archs: Provider<String>,
+) : SelectionSource {
+
+    override fun read(): String? = xcodeTargetLeaf(sdkName.orNull, archs.orNull)?.id
+}
+
+/**
+ * [SelectionSource] for the `kmptargets.framework.buildTypes` key, fed by Xcode's `CONFIGURATION`
+ * (with `KOTLIN_FRAMEWORK_BUILD_TYPE` as the custom-configuration fallback) (#109). Emits a
+ * lower-cased `debug` / `release` token so it re-enters #108's existing `parseBuildTypes` path with
+ * nothing duplicated, or `null` to defer to the next layer. Same lazy, per-variable config-cache
+ * contract as [XcodeTargetsSource].
+ */
+internal class XcodeBuildTypesSource(
+    private val configuration: Provider<String>,
+    private val kotlinFrameworkBuildType: Provider<String>,
+) : SelectionSource {
+
+    override fun read(): String? =
+        xcodeBuildType(configuration.orNull, kotlinFrameworkBuildType.orNull)?.name?.lowercase()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/XcodeEnvSelectionFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/XcodeEnvSelectionFunctionalTest.kt
@@ -1,0 +1,165 @@
+package com.rsicarelli.kmptargets
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Functional (TestKit) proof of the opt-in Xcode-environment selection source (#109) through
+ * Gradle's *launcher* paths: with `kmptargets.xcodeEnv=true` committed, Xcode's real `SDK_NAME` /
+ * `ARCHS` / `CONFIGURATION` env vars drive selection (no `-P`); an explicit `-P` still wins; an
+ * unknown SDK falls through without failing the chain; and with the flag off the env is never read.
+ * The per-layer precedence machinery itself is the shared `labeledSources` chain (proven for the
+ * targets/build-types keys by [EnvPropertyMappingFunctionalTest] /
+ * [FrameworkBuildTypesEnvPropertyMappingFunctionalTest]); this pins that the Xcode-env source rides
+ * it at the right slot and maps Xcode's vocabulary correctly.
+ */
+class XcodeEnvSelectionFunctionalTest {
+
+    @Test
+    fun `given the flag on and an Xcode simulator env when the build runs then selection resolves to the simulator leaf`(
+        @TempDir dir: Path
+    ) {
+        // The committed file selects jvm; the Xcode env (above the dedicated files) overrides it to
+        // exactly the leaf Xcode is building — the zero-P win.
+        writeSelectionFixture(dir, xcodeEnv = true, committedTargets = "jvm")
+        val result =
+            runner(dir)
+                .withEnvironment(mapOf("SDK_NAME" to "iphonesimulator18.0", "ARCHS" to "arm64"))
+                .build()
+        assertTrue("SELECTION=iosSimulatorArm64" in result.output, result.output)
+    }
+
+    @Test
+    fun `given an explicit -P targets over the Xcode env when the build runs then the -P wins`(
+        @TempDir dir: Path
+    ) {
+        // SDK_NAME/ARCHS would map to iosArm64, but the CLI layer outranks the Xcode-env source.
+        writeSelectionFixture(dir, xcodeEnv = true, committedTargets = "android")
+        val result =
+            runner(dir)
+                .withArguments("printSelection", "-q", "-Pkmptargets.targets=jvm")
+                .withEnvironment(mapOf("SDK_NAME" to "iphoneos18.0", "ARCHS" to "arm64"))
+                .build()
+        assertTrue("SELECTION=jvm" in result.output, result.output)
+    }
+
+    @Test
+    fun `given the flag on and an unknown Xcode sdk when the build runs then it falls through to the committed file`(
+        @TempDir dir: Path
+    ) {
+        writeSelectionFixture(dir, xcodeEnv = true, committedTargets = "jvm")
+        val result =
+            runner(dir)
+                .withEnvironment(mapOf("SDK_NAME" to "driverkit24.0", "ARCHS" to "arm64"))
+                .build()
+        assertTrue("SELECTION=jvm" in result.output, result.output)
+    }
+
+    @Test
+    fun `given the flag off and an Xcode env set when the build runs then the env is never read`(
+        @TempDir dir: Path
+    ) {
+        writeSelectionFixture(dir, xcodeEnv = false, committedTargets = "jvm")
+        val result =
+            runner(dir)
+                .withEnvironment(mapOf("SDK_NAME" to "iphonesimulator18.0", "ARCHS" to "arm64"))
+                .build()
+        assertTrue("SELECTION=jvm" in result.output, result.output)
+    }
+
+    @Test
+    fun `given the flag on and a Release CONFIGURATION when the build configures then the framework narrows to RELEASE`(
+        @TempDir dir: Path
+    ) {
+        writeFrameworkFixture(dir)
+        val result =
+            runner(dir)
+                .withArguments("assertBuildTypes", "-q")
+                .withEnvironment(mapOf("CONFIGURATION" to "Release"))
+                .build()
+        assertTrue("BUILDTYPES=RELEASE" in result.output, result.output)
+    }
+
+    @Test
+    fun `given a custom CONFIGURATION with a KOTLIN_FRAMEWORK_BUILD_TYPE fallback when the build configures then the framework narrows to it`(
+        @TempDir dir: Path
+    ) {
+        writeFrameworkFixture(dir)
+        val result =
+            runner(dir)
+                .withArguments("assertBuildTypes", "-q")
+                .withEnvironment(
+                    mapOf("CONFIGURATION" to "Staging", "KOTLIN_FRAMEWORK_BUILD_TYPE" to "release")
+                )
+                .build()
+        assertTrue("BUILDTYPES=RELEASE" in result.output, result.output)
+    }
+
+    private fun writeSelectionFixture(dir: Path, xcodeEnv: Boolean, committedTargets: String) {
+        dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
+        dir.resolve("kmp-targets.properties")
+            .writeText(
+                buildString {
+                    if (xcodeEnv) appendLine("kmptargets.xcodeEnv=true")
+                    appendLine("kmptargets.targets=$committedTargets")
+                }
+            )
+        dir.resolve("build.gradle.kts")
+            .writeText(
+                """
+                plugins { id("com.rsicarelli.kmptargets") }
+
+                val selection = kmpTargets.resolvedSelection().members.map { it.id }.sorted()
+                tasks.register("printSelection") {
+                    doLast { println("SELECTION=" + selection.joinToString(",")) }
+                }
+                """
+                    .trimIndent()
+            )
+    }
+
+    private fun writeFrameworkFixture(dir: Path) {
+        dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
+        // The flag is committed; an Apple leaf is committed so the framework attaches.
+        // CONFIGURATION
+        // then narrows the default DEBUG+RELEASE declaration through the same #108 intersection.
+        dir.resolve("kmp-targets.properties")
+            .writeText("kmptargets.xcodeEnv=true\nkmptargets.targets=iosSimulatorArm64\n")
+        dir.resolve("build.gradle.kts")
+            .writeText(
+                """
+                import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+                import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
+                plugins {
+                    kotlin("multiplatform")
+                    id("com.rsicarelli.kmptargets")
+                }
+
+                kmpTargets {
+                    supports { appleMobile }
+                    appleFramework("KotlinShared")
+                }
+
+                val buildTypes =
+                    kotlin.targets.withType(KotlinNativeTarget::class.java)
+                        .flatMap { it.binaries.withType(Framework::class.java) }
+                        .map { it.buildType.name }
+                        .toSortedSet()
+                println("BUILDTYPES=" + buildTypes.joinToString(","))
+                tasks.register("assertBuildTypes")
+                """
+                    .trimIndent()
+            )
+    }
+
+    private fun runner(dir: Path): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(dir.toFile())
+            .withPluginClasspath()
+            .withArguments("printSelection", "-q")
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFunctionalTest.kt
@@ -62,6 +62,22 @@ class KmpTargetsInfoFunctionalTest {
     }
 
     @Test
+    fun `given the Xcode-env flag on and an Xcode sdk when kmpTargetsInfo runs then the output names the Xcode-environment source`(
+        @TempDir dir: Path
+    ) {
+        dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
+        dir.resolve("kmp-targets.properties")
+            .writeText("kmptargets.xcodeEnv=true\nkmptargets.targets=jvm\n")
+        dir.resolve("build.gradle.kts").writeText("plugins { id(\"com.rsicarelli.kmptargets\") }\n")
+        val result =
+            runner(dir, "kmpTargetsInfo", "-q")
+                .withEnvironment(mapOf("SDK_NAME" to "iphonesimulator18.0", "ARCHS" to "arm64"))
+                .build()
+        assertTrue("iosSimulatorArm64" in result.output, result.output)
+        assertTrue("source:   Xcode environment (SDK_NAME/ARCHS)" in result.output, result.output)
+    }
+
+    @Test
     fun `given a build that never requests the info task when run with configuration cache then the entry stores cleanly`(
         @TempDir dir: Path
     ) {

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/source/XcodeEnvironmentMappingTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/source/XcodeEnvironmentMappingTest.kt
@@ -1,0 +1,132 @@
+package com.rsicarelli.kmptargets.source
+
+import com.rsicarelli.kmptargets.model.KmpTarget
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.junit.jupiter.api.Test
+
+/**
+ * Table-pinned unit tests for the pure `SDK_NAME`+`ARCHS` → leaf and `CONFIGURATION` → build-type
+ * mappings behind the opt-in Xcode-environment source (#109). The env-var contract is the only
+ * stable surface KGP exposes, so this table IS the spec — any drift fails here, not in a build.
+ */
+class XcodeEnvironmentMappingTest {
+
+    @Test
+    fun `given an iphoneos device sdk with arm64 when mapped then it is iosArm64`() {
+        assertEquals(KmpTarget.Native.Apple.Ios.Arm64, xcodeTargetLeaf("iphoneos18.0", "arm64"))
+    }
+
+    @Test
+    fun `given an iphonesimulator sdk with arm64 when mapped then it is iosSimulatorArm64`() {
+        assertEquals(
+            KmpTarget.Native.Apple.Ios.SimulatorArm64,
+            xcodeTargetLeaf("iphonesimulator18.0", "arm64"),
+        )
+    }
+
+    @Test
+    fun `given an iphonesimulator sdk with x86_64 when mapped then it is iosX64`() {
+        assertEquals(
+            KmpTarget.Native.Apple.Ios.X64,
+            xcodeTargetLeaf("iphonesimulator18.0", "x86_64"),
+        )
+    }
+
+    @Test
+    fun `given the tvos device and simulator sdks when mapped then they are the tvos leaves`() {
+        assertEquals(KmpTarget.Native.Apple.Tvos.Arm64, xcodeTargetLeaf("appletvos18.0", "arm64"))
+        assertEquals(
+            KmpTarget.Native.Apple.Tvos.SimulatorArm64,
+            xcodeTargetLeaf("appletvsimulator18.0", "arm64"),
+        )
+        assertEquals(
+            KmpTarget.Native.Apple.Tvos.X64,
+            xcodeTargetLeaf("appletvsimulator18.0", "x86_64"),
+        )
+    }
+
+    @Test
+    fun `given the watchos device archs when mapped then each is its distinct watch leaf`() {
+        assertEquals(
+            KmpTarget.Native.Apple.Watchos.DeviceArm64,
+            xcodeTargetLeaf("watchos11.0", "arm64"),
+        )
+        assertEquals(
+            KmpTarget.Native.Apple.Watchos.Arm64,
+            xcodeTargetLeaf("watchos11.0", "arm64_32"),
+        )
+        assertEquals(KmpTarget.Native.Apple.Watchos.Arm32, xcodeTargetLeaf("watchos11.0", "armv7k"))
+    }
+
+    @Test
+    fun `given the watchsimulator sdk when mapped then it is the watch simulator leaves`() {
+        assertEquals(
+            KmpTarget.Native.Apple.Watchos.SimulatorArm64,
+            xcodeTargetLeaf("watchsimulator11.0", "arm64"),
+        )
+        assertEquals(
+            KmpTarget.Native.Apple.Watchos.X64,
+            xcodeTargetLeaf("watchsimulator11.0", "x86_64"),
+        )
+    }
+
+    @Test
+    fun `given the macosx sdk when mapped then it is the macos leaves`() {
+        assertEquals(KmpTarget.Native.Apple.Macos.Arm64, xcodeTargetLeaf("macosx15.0", "arm64"))
+        assertEquals(KmpTarget.Native.Apple.Macos.X64, xcodeTargetLeaf("macosx15.0", "x86_64"))
+    }
+
+    @Test
+    fun `given a recognized sdk in a different case when mapped then the match is case-insensitive`() {
+        assertEquals(
+            KmpTarget.Native.Apple.Ios.SimulatorArm64,
+            xcodeTargetLeaf("iPhoneSimulator18.0", "ARM64"),
+        )
+    }
+
+    @Test
+    fun `given an unknown sdk when mapped then it falls through to null`() {
+        assertNull(xcodeTargetLeaf("driverkit24.0", "arm64"))
+        assertNull(xcodeTargetLeaf("", "arm64"))
+        assertNull(xcodeTargetLeaf(null, "arm64"))
+    }
+
+    @Test
+    fun `given a known sdk with an unrecognized arch when mapped then it falls through to null`() {
+        assertNull(xcodeTargetLeaf("iphoneos18.0", "i386"))
+        assertNull(xcodeTargetLeaf("iphonesimulator18.0", null))
+        assertNull(xcodeTargetLeaf("iphonesimulator18.0", "  "))
+    }
+
+    @Test
+    fun `given a multi-arch fat ARCHS when mapped then it is out of scope and falls through to null`() {
+        assertNull(xcodeTargetLeaf("iphonesimulator18.0", "arm64 x86_64"))
+    }
+
+    @Test
+    fun `given Debug or Release CONFIGURATION when mapped then it is the matching build type`() {
+        assertEquals(NativeBuildType.DEBUG, xcodeBuildType("Debug", null))
+        assertEquals(NativeBuildType.RELEASE, xcodeBuildType("Release", null))
+    }
+
+    @Test
+    fun `given a CONFIGURATION in a different case when mapped then the match is case-insensitive`() {
+        assertEquals(NativeBuildType.DEBUG, xcodeBuildType("DEBUG", null))
+        assertEquals(NativeBuildType.RELEASE, xcodeBuildType(" release ", null))
+    }
+
+    @Test
+    fun `given a custom CONFIGURATION with a KOTLIN_FRAMEWORK_BUILD_TYPE fallback when mapped then the fallback wins`() {
+        assertEquals(NativeBuildType.RELEASE, xcodeBuildType("Staging", "release"))
+        assertEquals(NativeBuildType.DEBUG, xcodeBuildType("QA", "DEBUG"))
+    }
+
+    @Test
+    fun `given a custom CONFIGURATION with no usable fallback when mapped then it falls through to null`() {
+        assertNull(xcodeBuildType("Staging", null))
+        assertNull(xcodeBuildType("Staging", "preview"))
+        assertNull(xcodeBuildType(null, null))
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - 'Hierarchy': user-guide/hierarchy-template.md
       - 'Build Logic': user-guide/build-logic.md
       - 'Apple Framework': user-guide/apple-framework.md
+      - 'Xcode Environment': user-guide/xcode-environment.md
       - 'Recipes': user-guide/recipes.md
       - 'Advisories & Strict Mode': user-guide/advisories.md
       - 'Diagnostics': user-guide/diagnostics.md

--- a/samples/xcode-env/README.md
+++ b/samples/xcode-env/README.md
@@ -19,9 +19,9 @@ Precedence (highest first): CLI `-P` → `ORG_GRADLE_PROJECT_` env → **Xcode e
 
 | Invocation | Active selection | Why |
 |---|---|---|
-| `./gradlew build` (no Xcode env) | `jvm, iosArm64, iosSimulatorArm64` | committed fallback in `kmp-targets.properties` |
+| `./gradlew build` (no Xcode env) | `iosArm64, iosSimulatorArm64` | committed fallback in `kmp-targets.properties` |
 | Xcode build, `SDK_NAME=iphonesimulator ARCHS=arm64` | `iosSimulatorArm64` | Xcode env overrides the file with the one leaf Xcode is building |
-| anything with `-Pkmptargets.targets=jvm` | `jvm` | explicit `-P` still wins over the Xcode env |
+| anything with `-Pkmptargets.targets=iosArm64` | `iosArm64` | explicit `-P` still wins over the Xcode env |
 
 `CONFIGURATION=Debug|Release` narrows the framework's build types through the same `#108` intersection;
 a custom configuration honors `KOTLIN_FRAMEWORK_BUILD_TYPE`. An unknown SDK falls through to the

--- a/samples/xcode-env/README.md
+++ b/samples/xcode-env/README.md
@@ -1,0 +1,45 @@
+# Sample: opt-in Xcode-environment selection (`kmptargets.xcodeEnv`)
+
+A standalone library shipping an iOS/macOS framework (`XcodeEnvShared`) that lets **Xcode's own build
+environment drive selection** — issue #109. The single committed line
+
+```properties
+# kmp-targets.properties
+kmptargets.xcodeEnv=true
+```
+
+turns Xcode's `SDK_NAME` / `ARCHS` / `CONFIGURATION` env vars into a *declared* selection layer, so the
+consumer's Xcode build phase that calls `embedAndSign…AppleFrameworkForXcode` needs **no
+`-Pkmptargets.targets=…`**.
+
+## How it resolves
+
+Precedence (highest first): CLI `-P` → `ORG_GRADLE_PROJECT_` env → **Xcode environment** → this file →
+`gradle.properties` → `local.properties`.
+
+| Invocation | Active selection | Why |
+|---|---|---|
+| `./gradlew build` (no Xcode env) | `jvm, iosArm64, iosSimulatorArm64` | committed fallback in `kmp-targets.properties` |
+| Xcode build, `SDK_NAME=iphonesimulator ARCHS=arm64` | `iosSimulatorArm64` | Xcode env overrides the file with the one leaf Xcode is building |
+| anything with `-Pkmptargets.targets=jvm` | `jvm` | explicit `-P` still wins over the Xcode env |
+
+`CONFIGURATION=Debug|Release` narrows the framework's build types through the same `#108` intersection;
+a custom configuration honors `KOTLIN_FRAMEWORK_BUILD_TYPE`. An unknown SDK falls through to the
+committed fallback (it never fails the build).
+
+## Try it
+
+```bash
+task publish-local
+
+# Committed fallback (no Xcode env):
+./gradlew -p samples/xcode-env kmpTargetsInfo
+
+# Simulate Xcode (macOS host) — narrows to one leaf, then links the framework:
+SDK_NAME=iphonesimulator ARCHS=arm64 CONFIGURATION=Debug \
+  ./gradlew -p samples/xcode-env verifyXcodeEnvNarrowed linkDebugFrameworkIosSimulatorArm64
+```
+
+The `verifyXcodeEnvNarrowed` task asserts the narrowing (the macOS CI lane runs exactly this); `inspect`
+the resolved origin any time with `kmpTargetsInfo`, which prints `source: Xcode environment
+(SDK_NAME/ARCHS)`.

--- a/samples/xcode-env/build.gradle.kts
+++ b/samples/xcode-env/build.gradle.kts
@@ -16,12 +16,11 @@ plugins {
 ktfmt { kotlinLangStyle() }
 
 kmpTargets {
-    // Supported = every Apple leaf ∪ jvm. The active selection (committed fallback, or the Xcode
-    // env
-    // when present) is intersected with this, so an Xcode simulator build registers
-    // iosSimulatorArm64
-    // alone while a plain build registers the committed jvm + iOS set.
-    supports { apple + jvm }
+    // An iOS/macOS framework module supports the Apple platforms. The active selection (committed
+    // fallback, or the Xcode env when present) is intersected with this, so an Xcode simulator
+    // build
+    // registers iosSimulatorArm64 alone while a plain build registers the committed iOS set.
+    supports { apple }
 
     // Declare the framework once; the plugin attaches it to every registered Apple leaf. The
     // configure block is the real KGP `Framework`. With no `buildTypes` arg it defaults to

--- a/samples/xcode-env/build.gradle.kts
+++ b/samples/xcode-env/build.gradle.kts
@@ -1,0 +1,57 @@
+// Sample: kmp-targets × the opt-in Xcode-environment selection source (#109).
+//
+// A standalone, single-module library that ships an iOS/macOS framework. It commits
+// `kmptargets.xcodeEnv=true`, so when Xcode invokes Gradle for embedAndSign…AppleFrameworkForXcode
+// its own SDK_NAME/ARCHS/CONFIGURATION env vars drive selection — the consumer's Xcode build phase
+// needs NO `-Pkmptargets.targets=…`. Outside Xcode (no env), selection is the committed fallback in
+// kmp-targets.properties. The macOS CI lane (sample-matrix.yml) exercises the real path: it sets
+// the
+// Xcode env, asserts the narrowing via `verifyXcodeEnvNarrowed`, and links the framework.
+plugins {
+    kotlin("multiplatform") version libs.versions.kotlin.get()
+    alias(libs.plugins.kmpTargets)
+    id("com.ncorti.ktfmt.gradle") version libs.versions.ktfmt.get()
+}
+
+ktfmt { kotlinLangStyle() }
+
+kmpTargets {
+    // Supported = every Apple leaf ∪ jvm. The active selection (committed fallback, or the Xcode
+    // env
+    // when present) is intersected with this, so an Xcode simulator build registers
+    // iosSimulatorArm64
+    // alone while a plain build registers the committed jvm + iOS set.
+    supports { apple + jvm }
+
+    // Declare the framework once; the plugin attaches it to every registered Apple leaf. The
+    // configure block is the real KGP `Framework`. With no `buildTypes` arg it defaults to
+    // DEBUG+RELEASE; Xcode's CONFIGURATION (via #108's intersection) narrows it at build time.
+    appleFramework("XcodeEnvShared") { isStatic = false }
+}
+
+// CI assertion (macOS lane, not wired into `check`): when Xcode's simulator env is present the
+// selection must have narrowed to exactly iosSimulatorArm64; otherwise it just reports the
+// committed
+// fallback. Config-cache safe — a List<String> and the SDK_NAME string are captured at
+// configuration
+// time; the action references only those primitives (no Project capture).
+val observedTargets = kotlin.targets.names.filter { it != "metadata" }.sorted()
+val sdkName = providers.environmentVariable("SDK_NAME")
+
+tasks.register("verifyXcodeEnvNarrowed") {
+    val observed = observedTargets
+    val sdk = sdkName.orNull
+    doLast {
+        if (sdk != null && sdk.startsWith("iphonesimulator")) {
+            check(observed == listOf("iosSimulatorArm64")) {
+                "Xcode-env narrowing regressed: SDK_NAME=$sdk must narrow selection to " +
+                    "[iosSimulatorArm64], but registered $observed"
+            }
+            logger.lifecycle("Xcode-env narrowed selection to $observed (SDK_NAME=$sdk)")
+        } else {
+            logger.lifecycle(
+                "No Xcode simulator env (SDK_NAME=$sdk); selection is the committed fallback: $observed"
+            )
+        }
+    }
+}

--- a/samples/xcode-env/gradle.properties
+++ b/samples/xcode-env/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.caching=true
+# The Xcode-environment source reads SDK_NAME/ARCHS/CONFIGURATION through providers, so the feature
+# is configuration-cache safe; with the flag off (or no Xcode env) nothing extra is read.
+org.gradle.configuration-cache=true

--- a/samples/xcode-env/kmp-targets.properties
+++ b/samples/xcode-env/kmp-targets.properties
@@ -8,4 +8,4 @@ kmptargets.xcodeEnv=true
 # Ubuntu CI smoke). When Xcode IS driving the build, its active SDK_NAME/ARCHS overrides this to
 # exactly the one leaf being built — e.g. SDK_NAME=iphonesimulator ARCHS=arm64 narrows to
 # iosSimulatorArm64. CONFIGURATION=Debug|Release narrows the framework's build types the same way.
-kmptargets.targets=jvm,iosArm64,iosSimulatorArm64
+kmptargets.targets=iosArm64,iosSimulatorArm64

--- a/samples/xcode-env/kmp-targets.properties
+++ b/samples/xcode-env/kmp-targets.properties
@@ -1,0 +1,11 @@
+# Opt-in: let Xcode's own build environment drive selection (issue #109). This committed flag is the
+# explicit act — it turns Xcode's SDK_NAME/ARCHS/CONFIGURATION into a *declared* selection layer
+# (slot 3: below CLI -P and ORG_GRADLE_PROJECT_ env, above this file), so an
+# embedAndSign…AppleFrameworkForXcode build needs no -P. A typo here fails the build (did-you-mean).
+kmptargets.xcodeEnv=true
+
+# The committed fallback used when there is NO Xcode env (plain `./gradlew build`, local dev, the
+# Ubuntu CI smoke). When Xcode IS driving the build, its active SDK_NAME/ARCHS overrides this to
+# exactly the one leaf being built — e.g. SDK_NAME=iphonesimulator ARCHS=arm64 narrows to
+# iosSimulatorArm64. CONFIGURATION=Debug|Release narrows the framework's build types the same way.
+kmptargets.targets=jvm,iosArm64,iosSimulatorArm64

--- a/samples/xcode-env/settings.gradle.kts
+++ b/samples/xcode-env/settings.gradle.kts
@@ -1,0 +1,25 @@
+pluginManagement {
+    repositories {
+        // The plugin under test comes from ~/.m2/repository after `task publish-local`.
+        mavenLocal()
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        google()
+    }
+
+    // Share the main repo's version catalog so Kotlin/kmp-targets versions stay in lockstep with
+    // the
+    // plugin under test; the `0.1.0-SNAPSHOT` a consumer would type stays visible in
+    // build.gradle.kts.
+    versionCatalogs { create("libs") { from(files("../../gradle/libs.versions.toml")) } }
+}
+
+rootProject.name = "xcode-env"

--- a/samples/xcode-env/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
+++ b/samples/xcode-env/src/commonMain/kotlin/com/rsicarelli/kmptargets/sample/Greeting.kt
@@ -1,0 +1,6 @@
+package com.rsicarelli.kmptargets.sample
+
+/** A tiny public surface so the XcodeEnvShared framework exports something non-trivial. */
+public class Greeting {
+    public fun greet(): String = "Hello from the kmp-targets Xcode-environment sample"
+}


### PR DESCRIPTION
## Summary

When Xcode invokes Gradle for `embedAndSign…AppleFrameworkForXcode` it exports `SDK_NAME`/`ARCHS`/`CONFIGURATION`; KGP already reads them, yet the consumer's Xcode build phase still has to pass `-Pkmptargets.targets=…`. The opt-in, registry-validated **`kmptargets.xcodeEnv=true`** flag closes that gap — with it on, Xcode's env becomes a *declared* selection layer, so the Xcode build phase needs **no `-P`**.

This was issue #109's **leaning (a)**, not a commitment. It was earned, not assumed: the #105 reshaping rejected a mirror of KGP's *evolving* `Framework` API when a real type existed to route to. Neither holds here — the mapping is over Apple's **stable** SDK/arch naming, KGP's `XcodeEnvironment`/`AppleSdk` are `internal` (no real thing to route to), and the committed flag keeps selection explicit and reviewable. Direction confirmed with the owner before implementation.

## Changes

- **Pure mapping** (`source/XcodeEnvironmentMapping.kt`, no Gradle types, table-pinned): `SDK_NAME` prefix + a single `ARCHS` → KGP leaf across **iOS/tvOS/watchOS/macOS**; multi-arch fat `ARCHS` and `IS_MACCATALYST` fall through to `null` (never failing the chain). `CONFIGURATION` → `NativeBuildType`, honoring KGP's `KOTLIN_FRAMEWORK_BUILD_TYPE` fallback for custom configurations.
- **Two `SelectionSource`s** (`source/XcodeEnvironmentSource.kt`) slot into the shared `labeledSources` chain at **slot 3** — below CLI `-P`/env, above the dedicated files — for `kmptargets.targets` and (reusing **#108**'s `parseBuildTypes`) `kmptargets.framework.buildTypes`. Origin surfaced in `kmpTargetsInfo` as `Xcode environment (SDK_NAME/ARCHS)` / `(CONFIGURATION)`.
- **`kmptargets.xcodeEnv`** registered in `ConfigKeys.ALL` (a typo fails with did-you-mean). Flag read once at apply time as a primitive through the standard chain (never itself Xcode-derived).
- **Config-cache safe:** env read via `providers.environmentVariable` (per-variable invalidation); when the flag is **off** the sources are never constructed, so no env vars are read and **no inputs are added**. An explicit `-P` still wins; the **#107** unattached-framework advisory is origin-agnostic and reused unchanged.
- **Sample** `samples/xcode-env/` (standalone) + a **macOS** `sample-matrix.yml` step that sets the real `SDK_NAME`/`ARCHS`/`CONFIGURATION`, asserts the narrowing via `verifyXcodeEnvNarrowed`, and runs `linkDebugFrameworkIosSimulatorArm64` on a real Apple toolchain.
- **Docs:** new `user-guide/xcode-environment.md` (nav-wired) + `selection-layers`/`apple-framework` cross-refs + README/`docs/index` roadmap.

## Test plan

- [x] `./gradlew :gradle-plugin:test ktfmtCheck` green locally (config-cache stored/reused)
- [x] Added tests — table-pinned mapping unit tests (`XcodeEnvironmentMappingTest`); functional precedence / fall-through / **flag-off-reads-nothing** / `CONFIGURATION`→buildTypes (`XcodeEnvSelectionFunctionalTest`); `kmpTargetsInfo` Xcode-origin test
- [x] Verified end-to-end on Linux: no env → committed fallback; `SDK_NAME=iphonesimulator ARCHS=arm64` → narrows to `iosSimulatorArm64`; `kmpTargetsInfo` shows both Xcode origins (the real Apple link is gated on the macOS CI lane)
- [x] Updated docs/README (user-facing)
- [x] No new **public** API — both new sources are `internal`; the mapping is `internal`

## Related

- Implements #109 (the seed's leaning (a), earned). Reuses #108's `kmptargets.framework.buildTypes` parser for the `CONFIGURATION` half; #107's advisory is origin-agnostic and untouched.
- Selection-sources chain + key registry: #30, #33. Built on the Apple framework helper (#105/#106).
- `embedAndSign` stays KGP's task and contract — out of scope, as is `IS_MACCATALYST` and multi-arch fat-simulator handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xfyU7xM31RJgsSY9qKZNL

---
_Generated by [Claude Code](https://claude.ai/code/session_017xfyU7xM31RJgsSY9qKZNL)_