### PR TITLE
chore: re-anchor version to 0.0.0-SNAPSHOT to publish first release as 0.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.rsicarelli
-version=0.1.0-SNAPSHOT
+version=0.0.0-SNAPSHOT
 
 POM_NAME=KMP Targets
 POM_DESCRIPTION=Dynamically select which Kotlin Multiplatform targets to build via the kmptargets.targets Gradle property.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ ksp = "2.3.9"
 # The plugin's own published version — single declaration point for the standalone samples
 # (they import this catalog and consume the plugin via `alias(libs.plugins.kmpTargets)`).
 # Kept in lockstep with `version=` in gradle.properties by .github/scripts/bump-version.main.kts.
-kmpTargets = "0.1.0-SNAPSHOT"
+kmpTargets = "0.0.0-SNAPSHOT"
 
 [libraries]
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
## Why

The first release should be `0.1.0`, but the release pipeline can't currently emit it. `bump-version.main.kts` strips `-SNAPSHOT` and then, for a **stable** release of a non-pre-release base, always does a "normal bump" (`bump-version.main.kts:108-112`). From `0.1.0-SNAPSHOT` that yields:

| bump | stable result |
|------|---------------|
| patch | `0.1.1` |
| minor | `0.2.0` |
| major | `1.0.0` |

There is no input that lands on `0.1.0` — the script assumes the committed version is the *last released* one and bumps past it, which doesn't fit a first release.

## What this does

Re-anchors the base version to `0.0.0-SNAPSHOT` (two files, kept in lockstep as the bump script does):

- `gradle.properties` → `version=0.0.0-SNAPSHOT`
- `gradle/libs.versions.toml` → `kmpTargets = "0.0.0-SNAPSHOT"`

With this base, **Publish Release** with **`minor` / `stable`** computes `0.0.0` → **`0.1.0`** (publishes the artifact, tags `v0.1.0`), and the post-publish `prepare-next-release` step advances `main` to `0.2.0` as the next dev version.

The catalog is updated alongside `gradle.properties` so the `hello-world` sample — which shares the root catalog via `from(files("../../gradle/libs.versions.toml"))` — resolves the `0.0.0-SNAPSHOT` plugin bundle during the release workflow's sample-validation step. All other CI-built samples (`isolated-projects`, `abi-builtin`, `abi-bcv`, `xcode-env`) also share the root catalog, so they stay consistent automatically.

## Release steps after merge

1. Confirm the `GPG_SIGNING_KEY` / `GPG_SIGNING_PASSWORD` secrets point at the current signing key.
2. Dispatch **Publish Release** from `main` with **bump = minor**, **release type = stable**.

## Heads-ups

- Merging triggers `continuous-deploy`, which publishes a harmless `0.0.0-SNAPSHOT` to the snapshots repo. Add `[skip ci]` to the merge commit to avoid it (only if branch protection doesn't require status checks).
- After release, `main`'s committed version is `0.2.0` (no `-SNAPSHOT`) — the script's normal post-release state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyBJQCKiomjkqJCb6jQDdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyBJQCKiomjkqJCb6jQDdt)_