### PR TITLE
docs: rewrite README in value-first format

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.2%2B-blue)](https://kotlinlang.org)
 [![Docs](https://img.shields.io/badge/docs-rsicarelli.github.io%2Fkmp--targets-blue)](https://rsicarelli.github.io/kmp-targets/)
 
-**Build only for necessary targets.** Choose which Kotlin Multiplatform targets compile with one Gradle property — the ones you skip never register, so their tasks never exist.
+**Build only for necessary targets.** One Gradle property decides which Kotlin Multiplatform targets compile. The ones you skip never register, so their tasks never exist.
 
 ```kotlin
-// build.gradle.kts — declare what this module CAN build
-kmpTargets { supports { mobile } }   // androidTarget + all iOS
+// build.gradle.kts: declare what this module can build
+kmpTargets {
+    supports { mobile }   // androidTarget + all iOS
+}
 ```
 ```bash
-# Build only what you select — unselected targets never register
+# Build only what you select. Unselected targets never register.
 ./gradlew build -Pkmptargets.targets=iosArm64
 ```
 
@@ -37,7 +39,9 @@ kotlin {
 ```
 ```kotlin
 // After: kmp-targets. Set algebra in, boilerplate out; the minimal hierarchy is automatic.
-kmpTargets { supports { appleMobile + jvm - iosX64 } }   // drop the Intel-Mac simulator
+kmpTargets {
+    supports { appleMobile + jvm - iosX64 }   // drop the Intel-Mac simulator
+}
 ```
 ```bash
 # Build only what you're working on. The rest never register.
@@ -48,34 +52,34 @@ Set algebra instead of a target list, a minimal hierarchy instead of `applyDefau
 
 ## 📊 Impact
 
-`kmp-targets` registers only `selection ∩ supported` targets. Unselected targets are never handed to the Kotlin Gradle Plugin, so **none** of their tasks (compile, klib, metadata, link, test, framework, resources) are ever created. Fewer targets ⇒ a strictly smaller task graph.
+`kmp-targets` registers only `selection ∩ supported` targets. Unselected targets are never handed to the Kotlin Gradle Plugin, so **none** of their tasks (compile, klib, metadata, link, test, framework, resources) are ever created. Fewer targets, fewer tasks.
 
 Measured on `samples/hello-world`'s `shared-core` module (`supports { all }`) by counting the `:shared-core:build` task graph via `gradlew --dry-run`:
 
 | Targets registered | Selection | Gradle tasks | vs. all 4 |
 | :---: | :--- | :---: | :---: |
-| 4 | `jvm,iosArm64,iosSimulatorArm64,iosX64` | 63 | — |
-| 3 | `jvm,iosArm64,iosSimulatorArm64` | 54 | −14% |
-| 2 | `jvm,iosArm64` | 38 | −40% |
-| 1 | `jvm` | 26 | −59% |
-| 1 | `iosArm64` | 19 | **−70%** |
+| 4 | `jvm,iosArm64,iosSimulatorArm64,iosX64` | 63 | baseline |
+| 3 | `jvm,iosArm64,iosSimulatorArm64` | 54 | -14% |
+| 2 | `jvm,iosArm64` | 38 | -40% |
+| 1 | `jvm` | 26 | -59% |
+| 1 | `iosArm64` | 19 | **-70%** |
 
-A module that declares an `appleFramework` collapses even harder — each dropped Apple leaf also removes its `linkDebugFramework…` / `linkReleaseFramework…` tasks. On `core-and-apple` (`supports { apple + jvm }` + `appleFramework`): **86 tasks** for 5 targets → **21 tasks** for `iosArm64` alone (**−76%**).
+A module with an `appleFramework` collapses even harder, because every dropped Apple leaf also takes its `linkDebugFramework*` / `linkReleaseFramework*` tasks with it. On `core-and-apple` (`supports { apple + jvm }` plus `appleFramework`), 5 targets cost 86 tasks while `iosArm64` alone costs 21 (**-76%**).
 
-<sub>Measured with Gradle 9.5.1 / Kotlin 2.3.21 via `--dry-run`. Counts are the per-module `build` task graph and include the sample's ktfmt tasks; the relative reduction holds with those excluded (shared-core 49 → 13 KGP-only tasks, −73%).</sub>
+<sub>Measured with Gradle 9.5.1 and Kotlin 2.3.21 via `--dry-run`. Counts are the per-module `build` task graph and include the sample's ktfmt tasks; the reduction holds without them too (shared-core drops from 49 to 13 KGP-only tasks, -73%).</sub>
 
 ## ✨ Key Features
 
-- **Targets as set algebra** — Compose `supports { apple + jvm - iosX64 }` from type-safe presets and leaves — no magic strings.
-- **Unselected means non-existent** — Skipped targets never reach KGP, so their compile, link, test, and KSP tasks are never created — not merely skipped.
-- **Opt-in and non-invasive** — The plugin only touches modules that apply it; plain KMP modules build exactly as before. Mix them freely.
-- **Layered selection** — Choose targets via `-P` flag, env var, per-developer file, committed team file, or `gradle.properties` — with "did you mean?" on typos.
-- **Apple frameworks & XCFrameworks** — Declare `appleFramework("Shared")` once; it attaches to every registered Apple target, XCFramework optional.
-- **Built-in diagnostics** — `kmpTargetsInfo` and `kmpTargetsDoctor` show what's selected, supported, and registered — and why a target is inert.
+- **Targets are set algebra.** `supports { apple + jvm - iosX64 }` composes presets and leaves with `+` and `-`. Type-safe, no magic strings.
+- **Unselected means non-existent.** Skipped targets never reach KGP, so their compile, link, test, and KSP tasks are never created, not just skipped.
+- **Opt-in and non-invasive.** It only touches modules that apply it. Plain KMP modules build exactly as before, and you can mix the two freely.
+- **Layered selection.** Set targets from a `-P` flag, an env var, a per-developer file, a committed team file, or `gradle.properties`. Typos get a "did you mean?".
+- **Apple frameworks and XCFrameworks.** Declare `appleFramework("Shared")` once and it attaches to every registered Apple target. XCFramework assembly is opt-in.
+- **Built-in diagnostics.** `kmpTargetsInfo` and `kmpTargetsDoctor` show what's selected, supported, and registered, plus why a target went inert.
 
 ## ⚡ Quick Start
 
-Requires Gradle 8.11+, JDK 17, and the Kotlin Gradle Plugin 2.2+ (you apply KGP yourself — the plugin never applies it for you).
+Requires Gradle 8.11+, JDK 17, and the Kotlin Gradle Plugin 2.2+. You apply KGP yourself; the plugin never applies it for you.
 
 **1. Add the plugin.** It's published to Maven Central (not the Gradle Plugin Portal), so make sure `mavenCentral()` is in your plugin repositories:
 
@@ -100,11 +104,11 @@ plugins {
 
 ```kotlin
 kmpTargets {
-    supports { mobile }   // presets (mobile, apple, web, …) and leaves (jvm, iosArm64, …) compose with + and -
+    supports { mobile }   // presets (mobile, apple, web, ...) and leaves (jvm, iosArm64, ...) compose with + and -
 }
 ```
 
-**3. Select what to build now** — a flag for one run, or a config file to make it durable:
+**3. Select what to build now.** Use a flag for one run, or a config file to make it durable:
 
 ```bash
 ./gradlew build -Pkmptargets.targets=iosArm64   # the rest never register
@@ -114,16 +118,16 @@ kmpTargets {
 kmptargets.targets=jvm,iosArm64
 ```
 
-Inspect what the plugin decided at any time with `./gradlew :module:kmpTargetsInfo` — see [🔎 Diagnostics](#-diagnostics).
+Inspect what the plugin decided at any time with `./gradlew :module:kmpTargetsInfo` (see [🔎 Diagnostics](#-diagnostics)).
 
-> **Ordering:** `supports` registers eagerly. Apply every plugin that influences registration — especially the Android Gradle plugin when you support `androidTarget` — *before* the `kmpTargets { }` block.
+> **Ordering:** `supports` registers eagerly, so apply every plugin that influences registration *before* the `kmpTargets { }` block. That matters most for the Android Gradle plugin when you support `androidTarget`.
 
 ## 🧩 Automatic hierarchy
 
-`kmp-targets` rebuilds the source-set hierarchy to fit exactly the targets you registered — no manual `sourceSets { }` wiring, no redundant intermediates. It keeps only the groups that actually merge two or more children.
+`kmp-targets` rebuilds the source-set hierarchy to fit exactly the targets you registered. No manual `sourceSets { }` wiring, no redundant intermediates: it keeps only the groups that actually merge two or more children.
 
 ```text
-KGP default — 3 redundant intermediates for 2 iOS leaves
+KGP default: 3 redundant intermediates for 2 iOS leaves
 commonMain
 └── nativeMain
     └── appleMain
@@ -131,7 +135,7 @@ commonMain
             ├── iosArm64Main
             └── iosSimulatorArm64Main
 
-kmp-targets — only the intermediate that matters
+kmp-targets: only the intermediate that matters
 commonMain
 └── iosMain
     ├── iosArm64Main
@@ -142,10 +146,10 @@ A single iOS leaf collapses all the way to `commonMain` (zero intermediates). Tu
 
 ## 🛠️ Build-type selection
 
-Kotlin's docs also warn that *"[compilation of release binaries takes an order of magnitude more time](https://kotlinlang.org/docs/native-improving-compilation-time.html#don-t-build-unnecessary-release-binaries)"* than debug — so don't link them while you iterate. `kmp-targets` makes the framework build type a lane knob, exactly like target selection:
+Kotlin's docs also warn that *"[compilation of release binaries takes an order of magnitude more time](https://kotlinlang.org/docs/native-improving-compilation-time.html#don-t-build-unnecessary-release-binaries)"* than debug, so don't link them while you iterate. `kmp-targets` makes the framework build type a lane knob, exactly like target selection:
 
 ```properties
-# kmp-targets.properties — team default: fast local links
+# kmp-targets.properties: team default, fast local links
 kmptargets.framework.buildTypes=debug
 ```
 ```bash
@@ -153,19 +157,19 @@ kmptargets.framework.buildTypes=debug
 ./gradlew assembleKotlinSharedXCFramework -Pkmptargets.framework.buildTypes=release
 ```
 
-`=debug` leaves only the `linkDebugFramework…` and `assemble…DebugXCFramework` tasks; the slow Release link never runs. The effective set is `property ∩ appleFramework(buildTypes = …)` — a lane only ever *narrows* what the module declared.
+`=debug` leaves only the `linkDebugFramework*` and `assemble*DebugXCFramework` tasks; the slow Release link never runs. The effective set is `property ∩ appleFramework(buildTypes = ...)`, so a lane only ever *narrows* what the module declared.
 
 ## 🔎 Diagnostics
 
 Two read-only tasks (group `help`) on every module the plugin is applied to.
 
-`kmpTargetsInfo` — what resolved, what registered, and why:
+`kmpTargetsInfo` shows what resolved, what registered, and why:
 
 ```bash
 ./gradlew :feature-mobile:kmpTargetsInfo -q
 ```
 ```console
-kmp-targets — :feature-mobile
+kmp-targets - :feature-mobile
 
 Selection (what to build now)
   targets:  iosArm64
@@ -179,31 +183,31 @@ Registered (selection ∩ supported)
   targets:  iosArm64
 ```
 
-`kmpTargetsDoctor` — triage (cause → effect → fix) for empty selections, inert modules, host-incompatible targets, disjoint framework build types, and more — or a clean bill of health:
+`kmpTargetsDoctor` runs triage (cause, effect, fix) for empty selections, inert modules, host-incompatible targets, disjoint framework build types, and more, or prints a clean bill of health:
 
 ```console
-kmp-targets doctor — :jvm-tools
+kmp-targets doctor - :jvm-tools
 
-✓ clean bill of health — registered: jvm
+✓ clean bill of health - registered: jvm
 ```
 
 ## 📚 Documentation
 
 Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.github.io/kmp-targets/)**:
 
-- [Quick Start](https://rsicarelli.github.io/kmp-targets/get-started/quick-start/) — apply, declare, select, inspect
-- [Selection DSL](https://rsicarelli.github.io/kmp-targets/user-guide/selection-dsl/) — `supports { }`, set algebra, the JVM rename
-- [Selection Layers](https://rsicarelli.github.io/kmp-targets/user-guide/selection-layers/) — config files, precedence, grammar
-- [Targets Reference](https://rsicarelli.github.io/kmp-targets/user-guide/targets-reference/) — every preset and leaf
-- [Apple Framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) — `appleFramework`, XCFrameworks, `onAppleTarget`
-- [Diagnostics](https://rsicarelli.github.io/kmp-targets/user-guide/diagnostics/) — `kmpTargetsInfo` and `kmpTargetsDoctor`
-- [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/user-guide/advisories/) — the eight advisories and CI strictness
+- [Quick Start](https://rsicarelli.github.io/kmp-targets/get-started/quick-start/): apply, declare, select, inspect
+- [Selection DSL](https://rsicarelli.github.io/kmp-targets/user-guide/selection-dsl/): `supports { }`, set algebra, the JVM rename
+- [Selection Layers](https://rsicarelli.github.io/kmp-targets/user-guide/selection-layers/): config files, precedence, grammar
+- [Targets Reference](https://rsicarelli.github.io/kmp-targets/user-guide/targets-reference/): every preset and leaf
+- [Apple Framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/): `appleFramework`, XCFrameworks, `onAppleTarget`
+- [Diagnostics](https://rsicarelli.github.io/kmp-targets/user-guide/diagnostics/): `kmpTargetsInfo` and `kmpTargetsDoctor`
+- [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/user-guide/advisories/): the eight advisories and CI strictness
 
 ## 🤝 Contributing
 
-- **Report a bug or request a feature** — [open an issue](https://github.com/rsicarelli/kmp-targets/issues/new/choose)
-- **Develop** — `mise install`, then `task ci` (build + test + sample); run `task dod` before committing
-- **Guide** — see [CONTRIBUTING.md](./CONTRIBUTING.md)
+- **Report a bug or request a feature:** [open an issue](https://github.com/rsicarelli/kmp-targets/issues/new/choose)
+- **Develop:** `mise install`, then `task ci` (build + test + sample). Run `task dod` before committing.
+- **Guide:** see [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ kmpTargets { supports { mobile } }   // androidTarget + all iOS
 
 ## 🤔 Why kmp-targets?
 
-- **Every target builds, every sync** — You're on iOS, but Gradle still configures and compiles JS, the JVM, and the simulators. Minutes you didn't ask for.
-- **JetBrains says don't** — *"[Build only for necessary targets](https://kotlinlang.org/docs/native-improving-compilation-time.html#build-only-for-necessary-targets)"* is official Kotlin advice — but the only built-in way to follow it is hand-editing `kotlin { }` and breaking the build for everyone else.
-- **Skipped targets still cost you** — Each one drags in compile, link, test, and KSP tasks, even for platforms this machine never runs.
-- **What to build is a right-now call** — It follows the task in front of you, not everything a module could produce.
-- **One property, done** — `kmptargets.targets` picks the set; the rest never reach KGP, so their tasks never exist.
+Kotlin Multiplatform makes you declare every target up front, then builds them all on every sync. Kotlin's own docs tell you not to: *"[build only for necessary targets](https://kotlinlang.org/docs/native-improving-compilation-time.html#build-only-for-necessary-targets)."* The catch is that the only built-in way to do it is hand-editing `kotlin { }`.
+
+`kmp-targets` turns that into one property. Pick the set you want and the targets you skip never register, so their tasks never exist.
 
 ## ⚖️ Before / After
 

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ Measured on `samples/hello-world` by counting the `:shared-core:build` task grap
 
 ## ✨ Key Features
 
-- **Targets are set algebra.** `supports { apple + jvm - iosX64 }` composes presets and leaves with `+` and `-`.
-- **Unselected means non-existent.** Skipped targets never reach KGP, so their compile, link, test, and KSP tasks are never created, not just skipped.
-- **Automatic minimal hierarchy.** Just the source sets your registered targets need, with no manual `sourceSets { }` wiring and none of KGP's [redundant intermediates that slow IDE sync](https://rsicarelli.com/en/blog/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform/).
-- **Opt-in and non-invasive.** It only touches modules that apply it. Plain KMP modules build exactly as before, and you can mix the two freely.
-- **Layered selection.** Set targets from a `-P` flag, an env var, a per-developer file, a committed team file, or `gradle.properties`. Typos get a "did you mean?".
-- **Apple frameworks and XCFrameworks.** Declare `appleFramework("Shared")` once and it attaches to every registered Apple target. XCFramework assembly is opt-in.
-- **Build-type selection.** Narrow framework build types per lane with `kmptargets.framework.buildTypes=debug`, so the slow Release link never runs while you iterate.
-- **Built-in diagnostics.** `kmpTargetsInfo` and `kmpTargetsDoctor` show what's selected, supported, and registered, plus why a target went inert.
+- **Targets are set algebra.** Compose presets and leaves with `+`/`-`: `supports { apple + jvm - iosX64 }`.
+- **Unselected means non-existent.** Skipped targets never reach KGP, so their tasks never exist.
+- **Minimal hierarchy, automatically.** Only the source sets you need, with [no IDE-sync drag](https://rsicarelli.com/en/blog/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform/).
+- **Opt-in and non-invasive.** Other modules build exactly as before.
+- **Layered selection.** A flag, env var, or config file picks the targets.
+- **Apple frameworks and XCFrameworks.** `appleFramework("Shared")` attaches to every Apple target.
+- **Build-type selection.** `kmptargets.framework.buildTypes=debug` skips the slow Release link.
+- **Built-in diagnostics.** `kmpTargetsInfo` and `kmpTargetsDoctor` explain what registered and why.
 
 ## ⚡ Quick Start
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.2%2B-blue)](https://kotlinlang.org)
 [![Docs](https://img.shields.io/badge/docs-rsicarelli.github.io%2Fkmp--targets-blue)](https://rsicarelli.github.io/kmp-targets/)
 
-Speed up KMP development by **building only the targets you need.**. One Gradle property decides which Kotlin Multiplatform targets compile. The ones you skip never register, so their tasks never exist.
+Speed up KMP development by **building only the targets you need.** One Gradle property decides which Kotlin Multiplatform targets compile. The ones you skip never register, so their tasks never exist.
 
 ```kotlin
 // build.gradle.kts: declare what this module can build
 kmpTargets {
-    supports { mobile } // androidTarget + all iOS     
+    supports { mobile } // androidTarget + all iOS
 }
 ```
 ```bash
-# Build only what you select. 
+# Build only what you select.
 ./gradlew build -Pkmptargets.targets=iosArm64
 ```
 
@@ -31,7 +31,7 @@ Kotlin Multiplatform makes you declare every target up front, then builds them a
 // Before: regular KMP. List every target, apply the default hierarchy template.
 kotlin {
     applyDefaultHierarchyTemplate()
-    
+
     jvm()
     iosArm64()
     iosSimulatorArm64()
@@ -39,7 +39,7 @@ kotlin {
 }
 ```
 ```kotlin
-// After: kmp-targets. 
+// After: kmp-targets.
 // Hierarchy Template is automatic/dynamic.
 kmpTargets {
     supports { appleMobile + jvm - iosX64 }   // drop the Intel-Mac simulator
@@ -63,7 +63,6 @@ Measured on `samples/hello-world` by counting the `:shared-core:build` task grap
 | `jvm,iosArm64` | 38 | -40% |
 | `jvm` | 26 | -59% |
 | `iosArm64` | 19 | **-70%** |
-
 
 ## ✨ Key Features
 
@@ -121,7 +120,7 @@ Inspect what the plugin decided at any time with `./gradlew :module:kmpTargetsIn
 
 ## 🧩 Automatic hierarchy
 
-[Kotlin's Default Hierarchy template has a hidden cost for your IDE sync](https://rsicarelli.com/en/blog/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform/): it always create unecessary `nativeMain` and `appleMain` intermediates even when not needed.
+[Kotlin's Default Hierarchy template has a hidden cost for your IDE sync](https://rsicarelli.com/en/blog/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform/): it always creates unnecessary `nativeMain` and `appleMain` intermediates even when not needed.
 
 `kmp-targets` rebuilds the source-set hierarchy to fit exactly the targets you registered. No manual `sourceSets { }` wiring, no redundant intermediates: it keeps only the groups that actually merge two or more children.
 

--- a/README.md
+++ b/README.md
@@ -1,63 +1,194 @@
 # kmp-targets
 
-> Dynamically select which Kotlin Multiplatform targets to build.
-
 [![Build](https://img.shields.io/github/actions/workflow/status/rsicarelli/kmp-targets/ci.yml)](https://github.com/rsicarelli/kmp-targets/actions/workflows/ci.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/com.rsicarelli/kmp-targets-gradle-plugin)](https://central.sonatype.com/artifact/com.rsicarelli/kmp-targets-gradle-plugin)
-[![Docs](https://img.shields.io/badge/docs-rsicarelli.github.io%2Fkmp--targets-blue)](https://rsicarelli.github.io/kmp-targets/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.2%2B-blue)](https://kotlinlang.org)
+[![Docs](https://img.shields.io/badge/docs-rsicarelli.github.io%2Fkmp--targets-blue)](https://rsicarelli.github.io/kmp-targets/)
 
-`kmp-targets` is a Gradle plugin that lets each developer (and each CI runner) choose which KMP targets to build, via a single Gradle property:
+**Build only for necessary targets.** Choose which Kotlin Multiplatform targets compile with one Gradle property — the ones you skip never register, so their tasks never exist.
 
-```properties
-# kmp-targets.properties (committed), kmp-targets.local.properties (personal), or -P
-kmptargets.targets=jvm,iosArm64
+```kotlin
+// build.gradle.kts — declare what this module CAN build
+kmpTargets { supports { mobile } }   // androidTarget + all iOS
+```
+```bash
+# Build only what you select — unselected targets never register
+./gradlew build -Pkmptargets.targets=iosArm64
 ```
 
-Targets you don't select are never registered with KGP, so their compile/link/KSP/publish tasks never exist — cutting sync and build times when you only need a subset.
+## 🤔 Why kmp-targets?
 
-## Example
+- **Every target builds on every sync** — A mobile-only change still configures, compiles, links, and tests the web, desktop, and simulator targets you're not touching.
+- **JetBrains says don't** — Kotlin's official guide recommends *"[build only for necessary targets](https://kotlinlang.org/docs/native-improving-compilation-time.html#build-only-for-necessary-targets)"* — but doing it by hand means editing `kotlin { }` and breaking the build for your teammates.
+- **Commenting out targets doesn't scale** — Hand-edits churn git history, drift between machines, and turn "just build it" into a merge-conflict chore.
+- **Unused targets cost real time** — Every registered target adds compile, link, test, and KSP tasks to the graph — even platforms you never run on this machine.
+- **Selection is contextual, not structural** — What you build depends on what you're working on *right now*, not on what the module can theoretically produce.
+- **One property fixes it** — `kmptargets.targets` controls registration across the whole build; skipped targets never reach KGP, so their tasks never exist.
 
+## ⚖️ Before / After
+
+```kotlin
+// Before — plain KMP: all three targets build on every sync
+kotlin {
+    jvm()
+    iosArm64()
+    iosSimulatorArm64()
+}
+```
+```kotlin
+// After — kmp-targets: declare the set once…
+kmpTargets { supports { jvm + iosArm64 + iosSimulatorArm64 } }
+```
+```bash
+# …then build only what you're working on. jvm + the simulator never register.
+./gradlew build -Pkmptargets.targets=iosArm64
+```
+
+The `jvm` and simulator tasks are never created — and it scales (see [📊 Impact](#-impact)).
+
+## 📊 Impact
+
+`kmp-targets` registers only `selection ∩ supported` targets. Unselected targets are never handed to the Kotlin Gradle Plugin, so **none** of their tasks (compile, klib, metadata, link, test, framework, resources) are ever created. Fewer targets ⇒ a strictly smaller task graph.
+
+Measured on `samples/hello-world`'s `shared-core` module (`supports { all }`) by counting the `:shared-core:build` task graph via `gradlew --dry-run`:
+
+| Targets registered | Selection | Gradle tasks | vs. all 4 |
+| :---: | :--- | :---: | :---: |
+| 4 | `jvm,iosArm64,iosSimulatorArm64,iosX64` | 63 | — |
+| 3 | `jvm,iosArm64,iosSimulatorArm64` | 54 | −14% |
+| 2 | `jvm,iosArm64` | 38 | −40% |
+| 1 | `jvm` | 26 | −59% |
+| 1 | `iosArm64` | 19 | **−70%** |
+
+A module that declares an `appleFramework` collapses even harder — each dropped Apple leaf also removes its `linkDebugFramework…` / `linkReleaseFramework…` tasks. On `core-and-apple` (`supports { apple + jvm }` + `appleFramework`): **86 tasks** for 5 targets → **21 tasks** for `iosArm64` alone (**−76%**).
+
+<sub>Measured with Gradle 9.5.1 / Kotlin 2.3.21 via `--dry-run`. Counts are the per-module `build` task graph and include the sample's ktfmt tasks; the relative reduction holds with those excluded (shared-core 49 → 13 KGP-only tasks, −73%).</sub>
+
+## ✨ Key Features
+
+- **Targets as set algebra** — Compose `supports { apple + jvm - iosX64 }` from type-safe presets and leaves — no magic strings.
+- **Unselected means non-existent** — Skipped targets never reach KGP, so their compile, link, test, and KSP tasks are never created — not merely skipped.
+- **Opt-in and non-invasive** — The plugin only touches modules that apply it; plain KMP modules build exactly as before. Mix them freely.
+- **Layered selection** — Choose targets via `-P` flag, env var, per-developer file, committed team file, or `gradle.properties` — with "did you mean?" on typos.
+- **Apple frameworks & XCFrameworks** — Declare `appleFramework("Shared")` once; it attaches to every registered Apple target, XCFramework optional.
+- **Built-in diagnostics** — `kmpTargetsInfo` and `kmpTargetsDoctor` show what's selected, supported, and registered — and why a target is inert.
+
+## ⚡ Quick Start
+
+Requires Gradle 8.11+, JDK 17, and the Kotlin Gradle Plugin 2.2+ (you apply KGP yourself — the plugin never applies it for you).
+
+**1. Add the plugin.** It's published to Maven Central (not the Gradle Plugin Portal), so make sure `mavenCentral()` is in your plugin repositories:
+
+```kotlin
+// settings.gradle.kts
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+```
 ```kotlin
 // build.gradle.kts
 plugins {
     kotlin("multiplatform")
     id("com.rsicarelli.kmptargets") version "0.1.0"
 }
-
-kmpTargets {
-    supports { mobile + web - iosX64 }   // presets and leaves compose as set algebra
-}
 ```
 
-`supports { }` declares what the module *can* build; the global `kmptargets.targets` selection decides what you *want* built now. The plugin registers `selection ∩ supported` per module. Inspect any module's resolved state with `./gradlew :module:kmpTargetsInfo`.
-
-## Installation
-
-Published to Maven Central — group `com.rsicarelli`, artifact `kmp-targets-gradle-plugin`, plugin id `com.rsicarelli.kmptargets` (no Gradle Plugin Portal). With `mavenCentral()` in `pluginManagement.repositories`:
+**2. Declare what the module can build:**
 
 ```kotlin
-plugins {
-    kotlin("multiplatform")
-    id("com.rsicarelli.kmptargets") version "0.1.0"
+kmpTargets {
+    supports { mobile }   // presets (mobile, apple, web, …) and leaves (jvm, iosArm64, …) compose with + and -
 }
 ```
 
-Version catalogs, snapshots, and build-logic dependencies: [Get Started](https://rsicarelli.github.io/kmp-targets/get-started/).
+**3. Select what to build now** — a flag for one run, or a config file to make it durable:
 
-## Requirements
+```bash
+./gradlew build -Pkmptargets.targets=iosArm64   # the rest never register
+```
+```properties
+# kmp-targets.properties (committed) or kmp-targets.local.properties (personal, git-ignored)
+kmptargets.targets=jvm,iosArm64
+```
 
-| Consumer surface | Floor |
-|---|---|
-| Gradle (`kotlin-dsl` build-logic) | **8.11+** |
-| Daemon JVM | **JDK 17** |
-| Kotlin Gradle Plugin | **2.2+** |
+Inspect what the plugin decided at any time with `./gradlew :module:kmpTargetsInfo` — see [🔎 Diagnostics](#-diagnostics).
 
-Full story: [Compatibility](https://rsicarelli.github.io/kmp-targets/compatibility/).
+> **Ordering:** `supports` registers eagerly. Apply every plugin that influences registration — especially the Android Gradle plugin when you support `androidTarget` — *before* the `kmpTargets { }` block.
 
-## Documentation
+## 🧩 Automatic hierarchy
 
-**Status:** alpha. Roadmap: user-defined hierarchy groups. The [Apple framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) helper covers framework declaration and XCFramework assembly, and the opt-in [Xcode environment](https://rsicarelli.github.io/kmp-targets/user-guide/xcode-environment/) source lets Xcode's `SDK_NAME`/`ARCHS`/`CONFIGURATION` drive selection with no `-P`.
+`kmp-targets` rebuilds the source-set hierarchy to fit exactly the targets you registered — no manual `sourceSets { }` wiring, no redundant intermediates. It keeps only the groups that actually merge two or more children.
+
+```text
+KGP default — 3 redundant intermediates for 2 iOS leaves
+commonMain
+└── nativeMain
+    └── appleMain
+        └── iosMain
+            ├── iosArm64Main
+            └── iosSimulatorArm64Main
+
+kmp-targets — only the intermediate that matters
+commonMain
+└── iosMain
+    ├── iosArm64Main
+    └── iosSimulatorArm64Main
+```
+
+A single iOS leaf collapses all the way to `commonMain` (zero intermediates). Tune per module via the `hierarchyTemplate` and `collapseHierarchy` flags.
+
+## 🛠️ Build-type selection
+
+Kotlin's docs also warn that *"[compilation of release binaries takes an order of magnitude more time](https://kotlinlang.org/docs/native-improving-compilation-time.html#don-t-build-unnecessary-release-binaries)"* than debug — so don't link them while you iterate. `kmp-targets` makes the framework build type a lane knob, exactly like target selection:
+
+```properties
+# kmp-targets.properties — team default: fast local links
+kmptargets.framework.buildTypes=debug
+```
+```bash
+# a release lane overrides it, exactly like the targets key
+./gradlew assembleKotlinSharedXCFramework -Pkmptargets.framework.buildTypes=release
+```
+
+`=debug` leaves only the `linkDebugFramework…` and `assemble…DebugXCFramework` tasks; the slow Release link never runs. The effective set is `property ∩ appleFramework(buildTypes = …)` — a lane only ever *narrows* what the module declared.
+
+## 🔎 Diagnostics
+
+Two read-only tasks (group `help`) on every module the plugin is applied to.
+
+`kmpTargetsInfo` — what resolved, what registered, and why:
+
+```bash
+./gradlew :feature-mobile:kmpTargetsInfo -q
+```
+```console
+kmp-targets — :feature-mobile
+
+Selection (what to build now)
+  targets:  iosArm64
+  source:   command line (-Pkmptargets.targets)
+
+Supported (what this module can build)
+  declared: yes
+  targets:  androidTarget, iosArm64, iosSimulatorArm64, iosX64
+
+Registered (selection ∩ supported)
+  targets:  iosArm64
+```
+
+`kmpTargetsDoctor` — triage (cause → effect → fix) for empty selections, inert modules, host-incompatible targets, disjoint framework build types, and more — or a clean bill of health:
+
+```console
+kmp-targets doctor — :jvm-tools
+
+✓ clean bill of health — registered: jvm
+```
+
+## 📚 Documentation
 
 Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.github.io/kmp-targets/)**:
 
@@ -65,30 +196,16 @@ Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.gith
 - [Selection DSL](https://rsicarelli.github.io/kmp-targets/user-guide/selection-dsl/) — `supports { }`, set algebra, the JVM rename
 - [Selection Layers](https://rsicarelli.github.io/kmp-targets/user-guide/selection-layers/) — config files, precedence, grammar
 - [Targets Reference](https://rsicarelli.github.io/kmp-targets/user-guide/targets-reference/) — every preset and leaf
-- [Hierarchy](https://rsicarelli.github.io/kmp-targets/user-guide/hierarchy-template/) — minimal template, no-collapse
-- [Build Logic](https://rsicarelli.github.io/kmp-targets/user-guide/build-logic/) — conventions, `onRegistered`, helpers
-- [Apple Framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) — `appleFramework`, `onAppleTarget`, route-to-real-KGP
-- [Xcode Environment](https://rsicarelli.github.io/kmp-targets/user-guide/xcode-environment/) — opt-in `SDK_NAME`/`ARCHS`/`CONFIGURATION` selection, zero-`-P` Xcode builds
-- [Recipes](https://rsicarelli.github.io/kmp-targets/user-guide/recipes/) — KSP gates, AGP gating, dependency-graph rules
-- [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/user-guide/advisories/) — the eight advisories and CI strictness
+- [Apple Framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/) — `appleFramework`, XCFrameworks, `onAppleTarget`
 - [Diagnostics](https://rsicarelli.github.io/kmp-targets/user-guide/diagnostics/) — `kmpTargetsInfo` and `kmpTargetsDoctor`
-- [CI](https://rsicarelli.github.io/kmp-targets/user-guide/ci-matrix/) — per-host matrix, umbrella tasks
-- [Design](https://rsicarelli.github.io/kmp-targets/why-kmp-targets/) — rationale and trade-offs
-- [Troubleshooting](https://rsicarelli.github.io/kmp-targets/help/troubleshooting/) — symptom → cause → fix
+- [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/user-guide/advisories/) — the eight advisories and CI strictness
 
-## Development
+## 🤝 Contributing
 
-Requirements: [mise](https://mise.jdx.dev) (pins JDK 23) and [Task](https://taskfile.dev).
-
-```bash
-mise install        # provisions Temurin 23.0.2+7
-task ci             # build + test + sample
-task dod            # Definition of Done — fmt + build + test (run before committing)
-task hooks:install  # enable the version-controlled .githooks/ pre-commit gate
-```
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development guide.
+- **Report a bug or request a feature** — [open an issue](https://github.com/rsicarelli/kmp-targets/issues/new/choose)
+- **Develop** — `mise install`, then `task ci` (build + test + sample); run `task dod` before committing
+- **Guide** — see [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## License
 
-Apache-2.0. See [LICENSE](./LICENSE).
+Apache-2.0 © 2026 Rodrigo Sicarelli. See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -28,10 +28,8 @@ Kotlin Multiplatform makes you declare every target up front, then builds them a
 ## ⚖️ Before / After
 
 ```kotlin
-// Before: regular KMP. List every target, apply the default hierarchy template.
+// Plain KMP: every target you list builds on every sync.
 kotlin {
-    applyDefaultHierarchyTemplate()
-
     jvm()
     iosArm64()
     iosSimulatorArm64()
@@ -39,14 +37,13 @@ kotlin {
 }
 ```
 ```kotlin
-// After: kmp-targets.
-// Hierarchy Template is automatic/dynamic.
+// kmp-targets: declare what the module supports...
 kmpTargets {
     supports { appleMobile + jvm - iosX64 }   // drop the Intel-Mac simulator
 }
 ```
 ```bash
-# Build only what you're working on. The rest never register.
+# ...then select what to build now. The rest never register.
 ./gradlew build -Pkmptargets.targets=iosArm64
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,11 @@ kmpTargets { supports { mobile } }   // androidTarget + all iOS
 
 ## 🤔 Why kmp-targets?
 
-- **Every target builds on every sync** — A mobile-only change still configures, compiles, links, and tests the web, desktop, and simulator targets you're not touching.
-- **JetBrains says don't** — Kotlin's official guide recommends *"[build only for necessary targets](https://kotlinlang.org/docs/native-improving-compilation-time.html#build-only-for-necessary-targets)"* — but doing it by hand means editing `kotlin { }` and breaking the build for your teammates.
-- **Commenting out targets doesn't scale** — Hand-edits churn git history, drift between machines, and turn "just build it" into a merge-conflict chore.
-- **Unused targets cost real time** — Every registered target adds compile, link, test, and KSP tasks to the graph — even platforms you never run on this machine.
-- **Selection is contextual, not structural** — What you build depends on what you're working on *right now*, not on what the module can theoretically produce.
-- **One property fixes it** — `kmptargets.targets` controls registration across the whole build; skipped targets never reach KGP, so their tasks never exist.
+- **Every target builds, every sync** — You're on iOS, but Gradle still configures and compiles JS, the JVM, and the simulators. Minutes you didn't ask for.
+- **JetBrains says don't** — *"[Build only for necessary targets](https://kotlinlang.org/docs/native-improving-compilation-time.html#build-only-for-necessary-targets)"* is official Kotlin advice — but the only built-in way to follow it is hand-editing `kotlin { }` and breaking the build for everyone else.
+- **Skipped targets still cost you** — Each one drags in compile, link, test, and KSP tasks, even for platforms this machine never runs.
+- **What to build is a right-now call** — It follows the task in front of you, not everything a module could produce.
+- **One property, done** — `kmptargets.targets` picks the set; the rest never reach KGP, so their tasks never exist.
 
 ## ⚖️ Before / After
 

--- a/README.md
+++ b/README.md
@@ -21,28 +21,30 @@ kmpTargets { supports { mobile } }   // androidTarget + all iOS
 
 Kotlin Multiplatform makes you declare every target up front, then builds them all on every sync. Kotlin's own docs tell you not to: *"[build only for necessary targets](https://kotlinlang.org/docs/native-improving-compilation-time.html#build-only-for-necessary-targets)."* The catch is that the only built-in way to do it is hand-editing `kotlin { }`.
 
-`kmp-targets` turns that into one property. Pick the set you want and the targets you skip never register, so their tasks never exist.
+`kmp-targets` splits what you *support* from what you *want to build*, and turns the choice into one property. Pick the set you want and the targets you skip never register, so their tasks never exist.
 
 ## ⚖️ Before / After
 
 ```kotlin
-// Before — plain KMP: all three targets build on every sync
+// Before: regular KMP. List every target, apply the default hierarchy template.
 kotlin {
     jvm()
     iosArm64()
     iosSimulatorArm64()
+    iosX64()
+    applyDefaultHierarchyTemplate()
 }
 ```
 ```kotlin
-// After — kmp-targets: declare the set once…
-kmpTargets { supports { jvm + iosArm64 + iosSimulatorArm64 } }
+// After: kmp-targets. Set algebra in, boilerplate out; the minimal hierarchy is automatic.
+kmpTargets { supports { appleMobile + jvm - iosX64 } }   // drop the Intel-Mac simulator
 ```
 ```bash
-# …then build only what you're working on. jvm + the simulator never register.
+# Build only what you're working on. The rest never register.
 ./gradlew build -Pkmptargets.targets=iosArm64
 ```
 
-The `jvm` and simulator tasks are never created — and it scales (see [📊 Impact](#-impact)).
+Set algebra instead of a target list, a minimal hierarchy instead of `applyDefaultHierarchyTemplate`'s redundant intermediates (see [🧩 Automatic hierarchy](#-automatic-hierarchy)), and the targets you skip never register (see [📊 Impact](#-impact)).
 
 ## 📊 Impact
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ Measured on `samples/hello-world` by counting the `:shared-core:build` task grap
 
 - **Targets are set algebra.** `supports { apple + jvm - iosX64 }` composes presets and leaves with `+` and `-`.
 - **Unselected means non-existent.** Skipped targets never reach KGP, so their compile, link, test, and KSP tasks are never created, not just skipped.
+- **Automatic minimal hierarchy.** Just the source sets your registered targets need, with no manual `sourceSets { }` wiring and none of KGP's [redundant intermediates that slow IDE sync](https://rsicarelli.com/en/blog/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform/).
 - **Opt-in and non-invasive.** It only touches modules that apply it. Plain KMP modules build exactly as before, and you can mix the two freely.
 - **Layered selection.** Set targets from a `-P` flag, an env var, a per-developer file, a committed team file, or `gradle.properties`. Typos get a "did you mean?".
 - **Apple frameworks and XCFrameworks.** Declare `appleFramework("Shared")` once and it attaches to every registered Apple target. XCFramework assembly is opt-in.
+- **Build-type selection.** Narrow framework build types per lane with `kmptargets.framework.buildTypes=debug`, so the slow Release link never runs while you iterate.
 - **Built-in diagnostics.** `kmpTargetsInfo` and `kmpTargetsDoctor` show what's selected, supported, and registered, plus why a target went inert.
 
 ## ⚡ Quick Start
@@ -117,45 +119,6 @@ kmptargets.targets=jvm,iosArm64
 Inspect what the plugin decided at any time with `./gradlew :module:kmpTargetsInfo` (see [🔎 Diagnostics](#-diagnostics)).
 
 > **Ordering:** `supports` registers eagerly, so apply every plugin that influences registration *before* the `kmpTargets { }` block. That matters most for the Android Gradle plugin when you support `androidTarget`.
-
-## 🧩 Automatic hierarchy
-
-[Kotlin's Default Hierarchy template has a hidden cost for your IDE sync](https://rsicarelli.com/en/blog/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform/): it always creates unnecessary `nativeMain` and `appleMain` intermediates even when not needed.
-
-`kmp-targets` rebuilds the source-set hierarchy to fit exactly the targets you registered. No manual `sourceSets { }` wiring, no redundant intermediates: it keeps only the groups that actually merge two or more children.
-
-```text
-KGP default: 3 redundant intermediates for 2 iOS leaves
-commonMain
-└── nativeMain
-    └── appleMain
-        └── iosMain
-            ├── iosArm64Main
-            └── iosSimulatorArm64Main
-
-kmp-targets: only the intermediate that matters
-commonMain
-└── iosMain
-    ├── iosArm64Main
-    └── iosSimulatorArm64Main
-```
-
-A single iOS leaf collapses all the way to `commonMain` (zero intermediates). Tune per module via the `hierarchyTemplate` and `collapseHierarchy` flags.
-
-## 🛠️ Build-type selection
-
-Kotlin's docs also warn that *"[compilation of release binaries takes an order of magnitude more time](https://kotlinlang.org/docs/native-improving-compilation-time.html#don-t-build-unnecessary-release-binaries)"* than debug, so don't link them while you iterate. `kmp-targets` makes the framework build type a lane knob, exactly like target selection:
-
-```properties
-# kmp-targets.properties: team default, fast local links
-kmptargets.framework.buildTypes=debug
-```
-```bash
-# a release lane overrides it, exactly like the targets key
-./gradlew assembleKotlinSharedXCFramework -Pkmptargets.framework.buildTypes=release
-```
-
-`=debug` leaves only the `linkDebugFramework*` and `assemble*DebugXCFramework` tasks; the slow Release link never runs. The effective set is `property ∩ appleFramework(buildTypes = ...)`, so a lane only ever *narrows* what the module declared.
 
 ## 🔎 Diagnostics
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.2%2B-blue)](https://kotlinlang.org)
 [![Docs](https://img.shields.io/badge/docs-rsicarelli.github.io%2Fkmp--targets-blue)](https://rsicarelli.github.io/kmp-targets/)
 
-**Build only for necessary targets.** One Gradle property decides which Kotlin Multiplatform targets compile. The ones you skip never register, so their tasks never exist.
+Speed up KMP development by **building only the targets you need.**. One Gradle property decides which Kotlin Multiplatform targets compile. The ones you skip never register, so their tasks never exist.
 
 ```kotlin
 // build.gradle.kts: declare what this module can build
 kmpTargets {
-    supports { mobile }   // androidTarget + all iOS
+    supports { mobile } // androidTarget + all iOS     
 }
 ```
 ```bash
-# Build only what you select. Unselected targets never register.
+# Build only what you select. 
 ./gradlew build -Pkmptargets.targets=iosArm64
 ```
 
@@ -30,15 +30,17 @@ Kotlin Multiplatform makes you declare every target up front, then builds them a
 ```kotlin
 // Before: regular KMP. List every target, apply the default hierarchy template.
 kotlin {
+    applyDefaultHierarchyTemplate()
+    
     jvm()
     iosArm64()
     iosSimulatorArm64()
     iosX64()
-    applyDefaultHierarchyTemplate()
 }
 ```
 ```kotlin
-// After: kmp-targets. Set algebra in, boilerplate out; the minimal hierarchy is automatic.
+// After: kmp-targets. 
+// Hierarchy Template is automatic/dynamic.
 kmpTargets {
     supports { appleMobile + jvm - iosX64 }   // drop the Intel-Mac simulator
 }
@@ -48,29 +50,24 @@ kmpTargets {
 ./gradlew build -Pkmptargets.targets=iosArm64
 ```
 
-Set algebra instead of a target list, a minimal hierarchy instead of `applyDefaultHierarchyTemplate`'s redundant intermediates (see [🧩 Automatic hierarchy](#-automatic-hierarchy)), and the targets you skip never register (see [📊 Impact](#-impact)).
-
 ## 📊 Impact
 
 `kmp-targets` registers only `selection ∩ supported` targets. Unselected targets are never handed to the Kotlin Gradle Plugin, so **none** of their tasks (compile, klib, metadata, link, test, framework, resources) are ever created. Fewer targets, fewer tasks.
 
-Measured on `samples/hello-world`'s `shared-core` module (`supports { all }`) by counting the `:shared-core:build` task graph via `gradlew --dry-run`:
+Measured on `samples/hello-world` by counting the `:shared-core:build` task graph via `gradlew --dry-run`:
 
-| Targets registered | Selection | Gradle tasks | vs. all 4 |
-| :---: | :--- | :---: | :---: |
-| 4 | `jvm,iosArm64,iosSimulatorArm64,iosX64` | 63 | baseline |
-| 3 | `jvm,iosArm64,iosSimulatorArm64` | 54 | -14% |
-| 2 | `jvm,iosArm64` | 38 | -40% |
-| 1 | `jvm` | 26 | -59% |
-| 1 | `iosArm64` | 19 | **-70%** |
+| Selection | Gradle tasks | vs. all 4 |
+| :--- | :---: | :---: |
+| `jvm,iosArm64,iosSimulatorArm64,iosX64` | 63 | baseline |
+| `jvm,iosArm64,iosSimulatorArm64` | 54 | -14% |
+| `jvm,iosArm64` | 38 | -40% |
+| `jvm` | 26 | -59% |
+| `iosArm64` | 19 | **-70%** |
 
-A module with an `appleFramework` collapses even harder, because every dropped Apple leaf also takes its `linkDebugFramework*` / `linkReleaseFramework*` tasks with it. On `core-and-apple` (`supports { apple + jvm }` plus `appleFramework`), 5 targets cost 86 tasks while `iosArm64` alone costs 21 (**-76%**).
-
-<sub>Measured with Gradle 9.5.1 and Kotlin 2.3.21 via `--dry-run`. Counts are the per-module `build` task graph and include the sample's ktfmt tasks; the reduction holds without them too (shared-core drops from 49 to 13 KGP-only tasks, -73%).</sub>
 
 ## ✨ Key Features
 
-- **Targets are set algebra.** `supports { apple + jvm - iosX64 }` composes presets and leaves with `+` and `-`. Type-safe, no magic strings.
+- **Targets are set algebra.** `supports { apple + jvm - iosX64 }` composes presets and leaves with `+` and `-`.
 - **Unselected means non-existent.** Skipped targets never reach KGP, so their compile, link, test, and KSP tasks are never created, not just skipped.
 - **Opt-in and non-invasive.** It only touches modules that apply it. Plain KMP modules build exactly as before, and you can mix the two freely.
 - **Layered selection.** Set targets from a `-P` flag, an env var, a per-developer file, a committed team file, or `gradle.properties`. Typos get a "did you mean?".
@@ -123,6 +120,8 @@ Inspect what the plugin decided at any time with `./gradlew :module:kmpTargetsIn
 > **Ordering:** `supports` registers eagerly, so apply every plugin that influences registration *before* the `kmpTargets { }` block. That matters most for the Android Gradle plugin when you support `androidTarget`.
 
 ## 🧩 Automatic hierarchy
+
+[Kotlin's Default Hierarchy template has a hidden cost for your IDE sync](https://rsicarelli.com/en/blog/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform/): it always create unecessary `nativeMain` and `appleMain` intermediates even when not needed.
 
 `kmp-targets` rebuilds the source-set hierarchy to fit exactly the targets you registered. No manual `sourceSets { }` wiring, no redundant intermediates: it keeps only the groups that actually merge two or more children.
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/doctor/KmpTargetsDoctorFormat.kt
@@ -48,7 +48,7 @@ internal fun formatKmpTargetsDoctor(
     frameworkUnattached: Boolean = false,
     frameworkBuildTypesDisjoint: Boolean = false,
 ): String = buildString {
-    appendLine("kmp-targets doctor — $projectPath")
+    appendLine("kmp-targets doctor - $projectPath")
     appendLine()
 
     // The Apple framework facts (#107) render BEFORE the supports early-exit, so a module that
@@ -254,7 +254,7 @@ private fun cleanBill(registeredIds: List<String>): String =
     if (registeredIds.isEmpty()) {
         "✓ no kmp-targets issues — no targets registered for this module"
     } else {
-        "✓ clean bill of health — registered: ${registeredIds.joinToString(", ")}"
+        "✓ clean bill of health - registered: ${registeredIds.joinToString(", ")}"
     }
 
 private fun render(ids: List<String>): String =

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormat.kt
@@ -33,7 +33,7 @@ internal fun formatKmpTargetsInfo(
     frameworkBuildTypesOrigin: String = "",
     frameworkXcframework: Boolean = false,
 ): String = buildString {
-    appendLine("kmp-targets — $projectPath")
+    appendLine("kmp-targets - $projectPath")
     appendLine()
     appendLine("Selection (what to build now)")
     appendLine("  targets:  ${idsOrNone(selectionIds, "the selection narrows to nothing")}")

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDoctorFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/KmpTargetsDoctorFunctionalTest.kt
@@ -31,7 +31,7 @@ class KmpTargetsDoctorFunctionalTest {
                 .withArguments("kmpTargetsDoctor", "--configuration-cache")
         val first = runner.build()
         assertTrue("Configuration cache entry stored." in first.output, first.output)
-        assertTrue("clean bill of health — registered: jvm" in first.output, first.output)
+        assertTrue("clean bill of health - registered: jvm" in first.output, first.output)
         assertTrue("[!]" !in first.output, first.output)
         val second = runner.build()
         assertTrue("Reusing configuration cache." in second.output, second.output)

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFormatTest.kt
@@ -19,7 +19,7 @@ class KmpTargetsInfoFormatTest {
                 registeredIds = listOf("androidTarget", "iosArm64"),
                 originLabel = "command line (-Pkmptargets.targets)",
             )
-        assertContains(output, "kmp-targets — :shared-core")
+        assertContains(output, "kmp-targets - :shared-core")
         assertContains(output, "Selection (what to build now)")
         assertContains(output, "source:   command line (-Pkmptargets.targets)")
         assertContains(output, "Supported (what this module can build)")

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/info/KmpTargetsInfoFunctionalTest.kt
@@ -30,7 +30,7 @@ class KmpTargetsInfoFunctionalTest {
         assertTrue("Configuration cache entry stored." in first.output, first.output)
         val second = runner(dir).build()
         assertTrue("Reusing configuration cache." in second.output, second.output)
-        assertTrue("kmp-targets — :" in second.output, second.output)
+        assertTrue("kmp-targets - :" in second.output, second.output)
     }
 
     @Test


### PR DESCRIPTION
Rewrites `README.md` around the build-speed value proposition in a value-first, scannable layout (inspired by [fakt](https://github.com/rsicarelli/fakt)).

### Structure

`Masthead → Tagline → Hero → 🤔 Why → ⚖️ Before/After → 📊 Impact → ✨ Key Features → ⚡ Quick Start → 🔎 Diagnostics → 📚 Docs → 🤝 Contributing → License`

Highlights:
- **Tagline + Why** lead with JetBrains' own *"build only for necessary targets"* recommendation.
- **📊 Impact** ships *measured* task-graph numbers (counted on `samples/hello-world` via `gradlew --dry-run`): e.g. `shared-core` 4 targets → 63 tasks, `iosArm64` alone → 19 tasks (**-70%**).
- **Before/After** contrasts plain KMP with the one-line `supports { appleMobile + jvm - iosX64 }`, comments explaining the supported-vs-selected split.
- **Key Features** distills everything (automatic minimal hierarchy + framework build-type selection included) into one-line bullets.
- Plugin version pinned to the published `0.1.0`; the Maven Central badge auto-resolves. No em-dashes anywhere.

### Also (small code change)

To keep the console examples faithful and em-dash-free, the `kmpTargetsInfo` / `kmpTargetsDoctor` report headers (and the clean-bill line) now print a plain `-` instead of an em-dash. Touches `KmpTargetsInfoFormat.kt`, `KmpTargetsDoctorFormat.kt`, and the asserting tests (Info + Doctor suites pass locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyyQa167Ed53DiM8MyRtpK