### PR TITLE
docs: README refresh — headline, Why, Impact table, Diagnostics, link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Measured on `samples/hello-world` by counting the `:shared-core:build` task grap
 
 See the [compatibility matrix](https://rsicarelli.github.io/kmp-targets/latest/compatibility/) for supported Gradle, JDK, and Kotlin versions.
 
-**1. Add the plugin.** It's published to Maven Central (not the Gradle Plugin Portal), so make sure `mavenCentral()` is in your plugin repositories:
+**1. Add the plugin:**
 
 ```kotlin
 // settings.gradle.kts

--- a/README.md
+++ b/README.md
@@ -31,28 +31,6 @@ Kotlin Multiplatform declares every target up front and compiles the whole set o
 
 `kmp-targets` separates what a module *supports* from what you *build now*. Skip a target and it never registers, so its tasks never exist. Less to build, download, and sync, including on CI, where you prove every target compiles but build one per check.
 
-## ⚖️ Before / After
-
-```kotlin
-// Plain KMP: every target you list builds on every sync.
-kotlin {
-    jvm()
-    iosArm64()
-    iosSimulatorArm64()
-    iosX64()
-}
-```
-```kotlin
-// kmp-targets: declare what the module supports...
-kmpTargets {
-    supports { appleMobile + jvm - iosX64 }   // drop the Intel-Mac simulator
-}
-```
-```bash
-# ...then select what to build now. The rest never register.
-./gradlew build -Pkmptargets.targets=iosArm64
-```
-
 ## 📊 Impact
 
 `kmp-targets` registers only `selection ∩ supported` targets. Unselected targets are never handed to the Kotlin Gradle Plugin, so **none** of their tasks (compile, klib, metadata, link, test, framework, resources) are ever created. Fewer targets, fewer tasks.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Measured on `samples/hello-world` by counting the `:shared-core:build` task grap
 
 ## ⚡ Quick Start
 
-Requires Gradle 8.11+, JDK 17, and the Kotlin Gradle Plugin 2.2+. You apply KGP yourself; the plugin never applies it for you.
+See the [compatibility matrix](https://rsicarelli.github.io/kmp-targets/latest/compatibility/) for supported Gradle, JDK, and Kotlin versions.
 
 **1. Add the plugin.** It's published to Maven Central (not the Gradle Plugin Portal), so make sure `mavenCentral()` is in your plugin repositories:
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Measured on `samples/hello-world` by counting the `:shared-core:build` task grap
 
 ## ✨ Key Features
 
-- **Targets are set algebra.** Compose presets and leaves with `+`/`-`: `supports { apple + jvm - iosX64 }`.
 - **Unselected means non-existent.** Skipped targets never reach KGP, so their tasks never exist.
-- **Minimal hierarchy, automatically.** Only the source sets you need, with [no IDE-sync drag](https://rsicarelli.com/en/blog/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform/).
-- **Opt-in and non-invasive.** Other modules build exactly as before.
 - **Layered selection.** A flag, env var, or config file picks the targets.
+- **Targets are set algebra.** Compose presets and leaves with `+`/`-`: `supports { apple + jvm - iosX64 }`.
+- **Opt-in and non-invasive.** Other modules build exactly as before.
+- **Minimal hierarchy, automatically.** Only the source sets you need, with [no IDE-sync drag](https://rsicarelli.com/en/blog/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform/).
+- **Built-in diagnostics.** `kmpTargetsInfo` and `kmpTargetsDoctor` explain what registered and why.
 - **Apple frameworks and XCFrameworks.** `appleFramework("Shared")` attaches to every Apple target.
 - **Build-type selection.** `kmptargets.framework.buildTypes=debug` skips the slow Release link.
-- **Built-in diagnostics.** `kmpTargetsInfo` and `kmpTargetsDoctor` explain what registered and why.
 
 ## ⚡ Quick Start
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.2%2B-blue)](https://kotlinlang.org)
 [![Docs](https://img.shields.io/badge/docs-rsicarelli.github.io%2Fkmp--targets-blue)](https://rsicarelli.github.io/kmp-targets/)
 
-KMP makes you declare every target up front, then builds them all on every sync, even the ones you're not touching. kmp-targets hands that choice back to you. Pick what to build, and the targets you skip never register, so their tasks never exist.
+KMP makes you declare every target up front, then builds them all on every sync, even the ones you're not touching. **`kmp-targets`** hands that choice back to you. Pick what to build, and the targets you skip never register, so their tasks never exist.
 
 ```kotlin
 // declare what this module can build
@@ -33,7 +33,7 @@ Kotlin Multiplatform declares every target up front and compiles the whole set o
 
 ## 📊 Impact
 
-`kmp-targets` registers only `selection ∩ supported` targets. Unselected targets are never handed to the Kotlin Gradle Plugin, so **none** of their tasks (compile, klib, metadata, link, test, framework, resources) are ever created. Fewer targets, fewer tasks.
+`kmp-targets` registers only `selection ∩ supported` targets. Unselected targets are never handed to the Kotlin Gradle Plugin, so **none** of their tasks (compile, klib, metadata, link, test, framework, resources) are ever created. **Fewer targets, fewer tasks.**
 
 Measured on `samples/hello-world` by counting the `:shared-core:build` task graph via `gradlew --dry-run`, for selections from all four supported targets (`jvm`, `iosArm64`, `iosSimulatorArm64`, `iosX64`) down to one:
 
@@ -112,7 +112,7 @@ The [Diagnostics docs](https://rsicarelli.github.io/kmp-targets/latest/user-guid
 
 ## 📚 Documentation
 
-Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.github.io/kmp-targets/)**:
+Everything lives at [rsicarelli.github.io/kmp-targets](https://rsicarelli.github.io/kmp-targets/):
 
 - [Quick Start](https://rsicarelli.github.io/kmp-targets/latest/get-started/quick-start/): apply, declare, select, inspect
 - [Selection DSL](https://rsicarelli.github.io/kmp-targets/latest/user-guide/selection-dsl/): `supports { }`, set algebra, the JVM rename

--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ kmptargets.targets=iosArm64
 
 ## 🤔 Why kmp-targets?
 
-Kotlin Multiplatform makes you declare every target up front, then builds them all on every sync. Kotlin's own docs tell you not to: *"[build only for necessary targets](https://kotlinlang.org/docs/native-improving-compilation-time.html#build-only-for-necessary-targets)."* The catch is that the only built-in way to do it is hand-editing `kotlin { }`.
+Kotlin Multiplatform makes you declare every target up front, then builds them all on every sync. With two or three targets that's fine. But codebases grow, and every target you add brings its own tasks to compile, link, test, and publish, and more for the IDE to sync. Kotlin's own docs tell you to avoid it: *"[build only for necessary targets](https://kotlinlang.org/docs/native-improving-compilation-time.html#build-only-for-necessary-targets)."* The only built-in way is hand-editing `kotlin { }`.
 
-`kmp-targets` splits what you *support* from what you *want to build*, and turns the choice into one property. Pick the set you want and the targets you skip never register, so their tasks never exist.
+In practice, you don't work on Android, iOS, web, and desktop at the same time. You pick a platform, iterate, then switch and verify somewhere else. On the iOS simulator today? You don't need the physical-device tasks in your graph. Heading to a real device next? Switch back and they're there. Most of the day a subset is all you need, yet plain KMP builds the whole matrix anyway.
+
+`kmp-targets` splits what a module *supports* from what you *build right now*. Skip a target and it never registers, so none of its tasks get created, and the saving cascades: fewer targets, fewer tasks for Gradle to configure and watch, fewer downloads, a lighter IDE sync. CI works the same way. You still prove every target compiles, but one job rarely needs both device and simulator, so you pick one per check and CI gets shorter too.
+
+It comes out of three years on a 300+ module KMP codebase, where keeping the build set small is what kept iteration fast.
 
 ## ⚖️ Before / After
 

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ Kotlin Multiplatform declares every target up front and compiles the whole set o
 
 `kmp-targets` registers only `selection ∩ supported` targets. Unselected targets are never handed to the Kotlin Gradle Plugin, so **none** of their tasks (compile, klib, metadata, link, test, framework, resources) are ever created. Fewer targets, fewer tasks.
 
-Measured on `samples/hello-world` by counting the `:shared-core:build` task graph via `gradlew --dry-run`:
+Measured on `samples/hello-world` by counting the `:shared-core:build` task graph via `gradlew --dry-run`, for selections from all four supported targets (`jvm`, `iosArm64`, `iosSimulatorArm64`, `iosX64`) down to one:
 
-| Selection | Gradle tasks | vs. all 4 |
+| # targets | savings | total tasks |
 | :--- | :---: | :---: |
-| `jvm,iosArm64,iosSimulatorArm64,iosX64` | 63 | baseline |
-| `jvm,iosArm64,iosSimulatorArm64` | 54 | -14% |
-| `jvm,iosArm64` | 38 | -40% |
-| `jvm` | 26 | -59% |
-| `iosArm64` | 19 | **-70%** |
+| 4 | baseline | 63 |
+| 3 | 14% | 54 |
+| 2 | 40% | 38 |
+| 1 (`jvm`) | 59% | 26 |
+| 1 (`iosArm64`) | **70%** | 19 |
 
 ## ✨ Key Features
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,11 @@ kmptargets.targets=iosArm64
 
 ## 🤔 Why kmp-targets?
 
-Kotlin Multiplatform makes you declare every target up front, then builds them all on every sync. With two or three targets that's fine. But codebases grow, and every target you add brings its own tasks to compile, link, test, and publish, and more for the IDE to sync. Kotlin's own docs tell you to avoid it: *"[build only for necessary targets](https://kotlinlang.org/docs/native-improving-compilation-time.html#build-only-for-necessary-targets)."* The only built-in way is hand-editing `kotlin { }`.
+**You verify one platform at a time, so why build them all?**
 
-In practice, you don't work on Android, iOS, web, and desktop at the same time. You pick a platform, iterate, then switch and verify somewhere else. On the iOS simulator today? You don't need the physical-device tasks in your graph. Heading to a real device next? Switch back and they're there. Most of the day a subset is all you need, yet plain KMP builds the whole matrix anyway.
+Kotlin Multiplatform declares every target up front and compiles the whole set on every sync. Each target you add is more compile, link, test, publish, and IDE-sync work, on every change.
 
-`kmp-targets` splits what a module *supports* from what you *build right now*. Skip a target and it never registers, so none of its tasks get created, and the saving cascades: fewer targets, fewer tasks for Gradle to configure and watch, fewer downloads, a lighter IDE sync. CI works the same way. You still prove every target compiles, but one job rarely needs both device and simulator, so you pick one per check and CI gets shorter too.
-
-It comes out of three years on a 300+ module KMP codebase, where keeping the build set small is what kept iteration fast.
+`kmp-targets` separates what a module *supports* from what you *build now*. Skip a target and it never registers, so its tasks never exist. Less to build, download, and sync, including on CI, where you prove every target compiles but build one per check.
 
 ## ⚖️ Before / After
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Measured on `samples/hello-world` by counting the `:shared-core:build` task grap
 
 - **Unselected means non-existent.** Skipped targets never reach KGP, so their tasks never exist.
 - **Layered selection.** A flag, env var, or config file picks the targets.
-- **Targets are set algebra.** Compose presets and leaves with `+`/`-`: `supports { apple + jvm - iosX64 }`.
+- **Targets are set algebra.** Add and drop presets and leaves: `apple + jvm - iosX64`.
 - **Opt-in and non-invasive.** Other modules build exactly as before.
 - **Minimal hierarchy, automatically.** Only the source sets you need, with [no IDE-sync drag](https://rsicarelli.com/en/blog/the-hidden-cost-of-default-hierarchy-templates-in-kotlin-multiplatform/).
 - **Built-in diagnostics.** `kmpTargetsInfo` and `kmpTargetsDoctor` explain what registered and why.
@@ -108,19 +108,19 @@ Every module the plugin applies to gets two read-only tasks (group `help`):
 - **`kmpTargetsInfo`** shows what resolved, what registered, and why.
 - **`kmpTargetsDoctor`** runs triage with cause, effect, and fix for the usual snags: empty selections, inert modules, host-incompatible targets, disjoint framework build types, and more.
 
-The [Diagnostics docs](https://rsicarelli.github.io/kmp-targets/user-guide/diagnostics/) walk through both, with recipes for the trickier setups. The first migration can be heavy lifting depending on what your project does, but it pays off once it clicks. Stuck? [Open an issue](https://github.com/rsicarelli/kmp-targets/issues/new/choose) and we'll help you wire it up.
+The [Diagnostics docs](https://rsicarelli.github.io/kmp-targets/latest/user-guide/diagnostics/) walk through both, with recipes for the trickier setups. The first migration can be heavy lifting depending on what your project does, but it pays off once it clicks. Stuck? [Open an issue](https://github.com/rsicarelli/kmp-targets/issues/new/choose) and we'll help you wire it up.
 
 ## 📚 Documentation
 
 Everything lives at **[rsicarelli.github.io/kmp-targets](https://rsicarelli.github.io/kmp-targets/)**:
 
-- [Quick Start](https://rsicarelli.github.io/kmp-targets/get-started/quick-start/): apply, declare, select, inspect
-- [Selection DSL](https://rsicarelli.github.io/kmp-targets/user-guide/selection-dsl/): `supports { }`, set algebra, the JVM rename
-- [Selection Layers](https://rsicarelli.github.io/kmp-targets/user-guide/selection-layers/): config files, precedence, grammar
-- [Targets Reference](https://rsicarelli.github.io/kmp-targets/user-guide/targets-reference/): every preset and leaf
-- [Apple Framework](https://rsicarelli.github.io/kmp-targets/user-guide/apple-framework/): `appleFramework`, XCFrameworks, `onAppleTarget`
-- [Diagnostics](https://rsicarelli.github.io/kmp-targets/user-guide/diagnostics/): `kmpTargetsInfo` and `kmpTargetsDoctor`
-- [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/user-guide/advisories/): the eight advisories and CI strictness
+- [Quick Start](https://rsicarelli.github.io/kmp-targets/latest/get-started/quick-start/): apply, declare, select, inspect
+- [Selection DSL](https://rsicarelli.github.io/kmp-targets/latest/user-guide/selection-dsl/): `supports { }`, set algebra, the JVM rename
+- [Selection Layers](https://rsicarelli.github.io/kmp-targets/latest/user-guide/selection-layers/): config files, precedence, grammar
+- [Targets Reference](https://rsicarelli.github.io/kmp-targets/latest/user-guide/targets-reference/): every preset and leaf
+- [Apple Framework](https://rsicarelli.github.io/kmp-targets/latest/user-guide/apple-framework/): `appleFramework`, XCFrameworks, `onAppleTarget`
+- [Diagnostics](https://rsicarelli.github.io/kmp-targets/latest/user-guide/diagnostics/): `kmpTargetsInfo` and `kmpTargetsDoctor`
+- [Advisories & Strict Mode](https://rsicarelli.github.io/kmp-targets/latest/user-guide/advisories/): the eight advisories and CI strictness
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.2%2B-blue)](https://kotlinlang.org)
 [![Docs](https://img.shields.io/badge/docs-rsicarelli.github.io%2Fkmp--targets-blue)](https://rsicarelli.github.io/kmp-targets/)
 
-Speed up KMP development by **building only the targets you need.** One Gradle property decides which Kotlin Multiplatform targets compile. The ones you skip never register, so their tasks never exist.
+KMP makes you declare every target up front, then builds them all on every sync, even the ones you're not touching. kmp-targets hands that choice back to you. Pick what to build, and the targets you skip never register, so their tasks never exist.
 
 ```kotlin
-// build.gradle.kts: declare what this module can build
+// declare what this module can build
 kmpTargets {
     supports { mobile } // androidTarget + all iOS
 }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ kmpTargets {
 # Build only what you select.
 ./gradlew build -Pkmptargets.targets=iosArm64
 ```
+```properties
+# ...or set it once as a local preference (kmp-targets.local.properties)
+kmptargets.targets=iosArm64
+```
 
 ## 🤔 Why kmp-targets?
 

--- a/README.md
+++ b/README.md
@@ -99,39 +99,16 @@ kmptargets.targets=jvm,iosArm64
 
 Inspect what the plugin decided at any time with `./gradlew :module:kmpTargetsInfo` (see [🔎 Diagnostics](#-diagnostics)).
 
-> **Ordering:** `supports` registers eagerly, so apply every plugin that influences registration *before* the `kmpTargets { }` block. That matters most for the Android Gradle plugin when you support `androidTarget`.
-
 ## 🔎 Diagnostics
 
-Two read-only tasks (group `help`) on every module the plugin is applied to.
+Dropping `kmp-targets` into an existing module isn't always a one-liner. Real projects carry KSP processors, custom or legacy source-set hierarchies, and `expect`/`actual` spread across targets, and predicting how a smaller target set lands on all of that is hard. So the plugin gives you tooling to see what it decided, instead of guessing.
 
-`kmpTargetsInfo` shows what resolved, what registered, and why:
+Every module the plugin applies to gets two read-only tasks (group `help`):
 
-```bash
-./gradlew :feature-mobile:kmpTargetsInfo -q
-```
-```console
-kmp-targets - :feature-mobile
+- **`kmpTargetsInfo`** shows what resolved, what registered, and why.
+- **`kmpTargetsDoctor`** runs triage with cause, effect, and fix for the usual snags: empty selections, inert modules, host-incompatible targets, disjoint framework build types, and more.
 
-Selection (what to build now)
-  targets:  iosArm64
-  source:   command line (-Pkmptargets.targets)
-
-Supported (what this module can build)
-  declared: yes
-  targets:  androidTarget, iosArm64, iosSimulatorArm64, iosX64
-
-Registered (selection ∩ supported)
-  targets:  iosArm64
-```
-
-`kmpTargetsDoctor` runs triage (cause, effect, fix) for empty selections, inert modules, host-incompatible targets, disjoint framework build types, and more, or prints a clean bill of health:
-
-```console
-kmp-targets doctor - :jvm-tools
-
-✓ clean bill of health - registered: jvm
-```
+The [Diagnostics docs](https://rsicarelli.github.io/kmp-targets/user-guide/diagnostics/) walk through both, with recipes for the trickier setups. The first migration can be heavy lifting depending on what your project does, but it pays off once it clicks. Stuck? [Open an issue](https://github.com/rsicarelli/kmp-targets/issues/new/choose) and we'll help you wire it up.
 
 ## 📚 Documentation
 


### PR DESCRIPTION
A pass over `README.md` to make the pitch land faster, read well on mobile, and fix broken links.

## Top of the readme
- Rewrote the headline to lead with the KMP pain (declare-all, build-all on every sync) instead of a generic "speed up development" line, and stopped pinning selection to a single Gradle property since a flag, env var, or file all work.
- Added a local-preferences snippet to the intro so it shows both the one-off `-P` flag and the durable `kmp-targets.local.properties` way.
- Reworked **Why** into a scannable bold hook plus two short paragraphs: the per-sync cost of building every target, then the support-vs-build split with the CI angle.

## Structure & content
- Removed the **Before / After** section. Its command and `supports { }` block were already shown in the intro, Key Features, and Quick Start.
- Made the **Impact** table mobile-friendly: reordered to `# targets | savings | total tasks` and replaced the long comma-separated selections with target counts, so the savings column no longer scrolls off small screens.
- Ordered **Key Features** by priority (the payoff first, the Apple/build-type specifics last).
- Trimmed **Quick Start**: linked the compatibility matrix instead of inlining versions, and cut step 1 down to "Add the plugin".
- Reframed **Diagnostics** around adoption help. It's honest that wiring a real project (KSP, custom hierarchies, expect/actual) can take work, while making clear the two read-only tasks and the docs are there to guide it, and that issues are welcome. Stopped pasting console output and dropped the eager-registration Ordering callout.

## Fixes
- Fixed every deep docs link. They were missing the `/latest/` path segment the live site uses, so the whole Documentation section (and the Diagnostics link) 404'd. Verified against the published Diagnostics page.
- Trimmed the set-algebra example to `apple + jvm - iosX64` (no inline `supports { }` block).
- Tidied emphasis marks: bold the first `kmp-targets` mention, bold the Impact takeaway, drop a decorative bold on the docs-home link.

Note: the GitHub About text is repo metadata, not a file, so it isn't part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUjcWyf1FK3TBX8HB8puKg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUjcWyf1FK3TBX8HB8puKg)_