### PR TITLE
docs: show XCFramework assembly with target + build-type selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,22 @@ KMP makes you declare every target up front, then builds them all on every sync,
 // declare what this module can build
 kmpTargets {
     supports { mobile } // androidTarget + all iOS
+    appleFramework("Shared", xcframework = true) // assemble Shared.xcframework
 }
 ```
 ```bash
 # Build only what you select.
 ./gradlew build -Pkmptargets.targets=iosArm64
+
+# Assemble a debug-only XCFramework (skip the slow Release link).
+./gradlew assembleSharedXCFramework \
+    -Pkmptargets.targets=iosArm64 \
+    -Pkmptargets.framework.buildTypes=debug
 ```
 ```properties
 # ...or set it once as a local preference (kmp-targets.local.properties)
 kmptargets.targets=iosArm64
+kmptargets.framework.buildTypes=debug
 ```
 
 ## 🤔 Why kmp-targets?


### PR DESCRIPTION
Adds an XCFramework example to the intro snippet so the value prop covers Apple framework output too: pick a target and a single build type, assemble just that.

```bash
# Assemble a debug-only XCFramework (skip the slow Release link).
./gradlew assembleSharedXCFramework \
    -Pkmptargets.targets=iosArm64 \
    -Pkmptargets.framework.buildTypes=debug
```

The declare block now opts the framework into XCFramework assembly so the command is actually runnable, and the local-preferences block gains the matching key.

### Verified against source (flag/task names)
- **Build-type flag is `kmptargets.framework.buildTypes`** (values `debug`/`release`), not `kmptargets.buildtype` — see `ConfigKeys.FRAMEWORK_BUILD_TYPES`.
- **Task is `assembleSharedXCFramework`**, not `assembleXCFramework`. KGP registers `assemble<BaseName>XCFramework` (plus per-build-type `assemble<BaseName><BuildType>XCFramework`); confirmed by the tests asserting `assembleKotlinSharedXCFramework` for base name `KotlinShared`, so base name `Shared` gives `assembleSharedXCFramework`.
- **XCFramework assembly is opt-in** via `appleFramework(..., xcframework = true)` (`KmpTargetsExtension.appleFramework`), so the declare block needs it for the task to exist.

One judgment call worth a look: I added `appleFramework("Shared", xcframework = true)` to the intro's declare block to ground the command. Happy to drop it back to a bare `supports { mobile }` and let the task name stand on its own if you'd rather keep the intro leaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUjcWyf1FK3TBX8HB8puKg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUjcWyf1FK3TBX8HB8puKg)_