### PR TITLE
docs: IDE workflow recipe — fast Sync on one platform, switch without killing Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Everything lives at [rsicarelli.github.io/kmp-targets](https://rsicarelli.github
 - [Quick Start](https://rsicarelli.github.io/kmp-targets/latest/get-started/quick-start/): apply, declare, select, inspect
 - [Selection DSL](https://rsicarelli.github.io/kmp-targets/latest/user-guide/selection-dsl/): `supports { }`, set algebra, the JVM rename
 - [Selection Layers](https://rsicarelli.github.io/kmp-targets/latest/user-guide/selection-layers/): config files, precedence, grammar
+- [IDE Workflow](https://rsicarelli.github.io/kmp-targets/latest/user-guide/ide-workflow/): fast Sync on one platform, switch without killing Gradle
 - [Targets Reference](https://rsicarelli.github.io/kmp-targets/latest/user-guide/targets-reference/): every preset and leaf
 - [Apple Framework](https://rsicarelli.github.io/kmp-targets/latest/user-guide/apple-framework/): `appleFramework`, XCFrameworks, `onAppleTarget`
 - [Diagnostics](https://rsicarelli.github.io/kmp-targets/latest/user-guide/diagnostics/): `kmpTargetsInfo` and `kmpTargetsDoctor`

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -19,6 +19,7 @@ Start with [`kmpTargetsInfo`](../user-guide/diagnostics.md#kmptargetsinfo): it p
 | Selection ignored / surprising value wins | a higher-precedence source is set — often a stale `kmp-targets.local.properties` or an env var | `kmpTargetsInfo` names the winning source; check the [precedence chain](../user-guide/selection-layers.md) |
 | A module builds nothing | empty overlap: selection ∩ supported = ∅ | widen the selection or the module's `supports { }`; the [empty-overlap advisory](../user-guide/advisories.md#empty-overlap) names the module |
 | Every sync re-configures after changing selection | each distinct value is its own configuration-cache entry — only the first build of a value misses | expected; alternating between known values hits the cache ([the trade-off](../why-kmp-targets.md#the-configuration-cache-trade-off)) |
+| Changed selection but the IDE still shows the old targets | reaching for `gradlew stop`? not needed | the config files are tracked cache inputs — edit `kmp-targets.local.properties` and Sync; the edit alone refreshes ([IDE Workflow](../user-guide/ide-workflow.md)) |
 
 ## Registration
 

--- a/docs/user-guide/ide-workflow.md
+++ b/docs/user-guide/ide-workflow.md
@@ -1,0 +1,57 @@
+# IDE Workflow
+
+Big KMP build, slow Sync? You only work one platform at a time, so let the IDE index only that one.
+
+This is the everyday loop: pick the platform you're touching, Sync, get fast indexing and correct IntelliSense for it. Switch platforms by editing one line and re-syncing — **no `gradlew stop`, no daemon kill.**
+
+## The recipe
+
+**1. Pin your platform** in `kmp-targets.local.properties` (git-ignored, per-developer — it's *your* machine's preference, not the team's):
+
+```properties
+# kmp-targets.local.properties
+kmptargets.targets=iosArm64
+```
+
+**2. Sync** (the Gradle elephant / "Reload All Gradle Projects"). Only `iosArm64` registers, so only its source sets index and only its tasks exist.
+
+**3. Switch platforms** when you move to another. Edit the same line:
+
+```properties
+kmptargets.targets=jvm
+```
+
+…and Sync again. That's the whole loop.
+
+!!! tip "Working on Android?"
+    Use `kmptargets.targets=android,jvm` — co-selecting `jvm` keeps Android consumers resolving against the jvm-fallback variant. See [the asymmetric case](recipes.md#the-asymmetric-case-android-and-the-jvm-fallback).
+
+## Why no daemon kill
+
+`kmp-targets.local.properties` (and `kmp-targets.properties`) are **tracked configuration-cache inputs**. Editing one invalidates the cache, so the next Sync re-configures with the new target set — automatically. Leaving them untouched keeps the cache hit.
+
+If you've used homegrown target-switching before and got used to running `gradlew stop` after every flip, you don't need it here. That ritual is the symptom of an *untracked* property read; this plugin tracks the file, so the edit alone is enough.
+
+!!! note "What you can't avoid"
+    Switching the registered target set is a real re-configuration + re-import — inherently slower than a no-op Sync. The win is the **result**: a smaller model (fewer targets) indexes faster. You skip the *extra* daemon-restart tax, not the Sync itself. And because [each value is its own cache entry](../why-kmp-targets.md#the-configuration-cache-trade-off), flipping *back* to a platform you've already used is a cache hit.
+
+## Confirm what indexed
+
+Not sure which targets the IDE actually got? Ask the plugin:
+
+```bash
+./gradlew :app:kmpTargetsInfo
+```
+
+It prints the resolved selection, the winning source (so a stale `kmp-targets.local.properties` is obvious), and the registered intersection. Full tour: [Diagnostics](diagnostics.md).
+
+## Terminal & CI use the same key
+
+The IDE preference and a one-off terminal run share one vocabulary — `kmptargets.targets`:
+
+```bash
+# one build, no file edit, beats the file:
+./gradlew :app:assemble -Pkmptargets.targets=iosArm64
+```
+
+A Makefile/Taskfile target, a CI matrix job, and your IDE all speak the same string. Precedence (CLI beats env beats your local file beats the committed file): [Selection Layers](selection-layers.md).

--- a/docs/user-guide/selection-layers.md
+++ b/docs/user-guide/selection-layers.md
@@ -37,7 +37,7 @@ kmptargets.hierarchyTemplate=true
 # kmptargets.framework.buildTypes=debug  # see "Apple Framework"
 ```
 
-`kmp-targets.local.properties` (git-ignored) is optional: absent it's ignored; present, its keys override the committed file's. Both files accept only known `kmptargets.*` keys — an unknown key fails the build with a "did you mean …?" suggestion. Both are tracked configuration-cache inputs: editing one invalidates the cache, leaving them untouched keeps cache hits.
+`kmp-targets.local.properties` (git-ignored) is optional: absent it's ignored; present, its keys override the committed file's. Both files accept only known `kmptargets.*` keys — an unknown key fails the build with a "did you mean …?" suggestion. Both are tracked configuration-cache inputs: editing one invalidates the cache, leaving them untouched keeps cache hits — so switching your local platform is just an edit and a Sync, [no daemon kill](ide-workflow.md).
 
 ## Selection grammar
 

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/ConfigCacheSelectionRefreshFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/kmptargets/ConfigCacheSelectionRefreshFunctionalTest.kt
@@ -1,0 +1,64 @@
+package com.rsicarelli.kmptargets
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * The "do I have to kill Gradle to switch targets?" proof.
+ *
+ * Two builds against the SAME project dir (so they share the on-disk configuration cache, exactly
+ * like an IDE re-sync against a live daemon). Between them, only `kmp-targets.local.properties` is
+ * edited. If the file is a tracked config-cache input, the second build must INVALIDATE the cache
+ * and register the new target — no `gradlew stop`, no `--no-configuration-cache`.
+ */
+class ConfigCacheSelectionRefreshFunctionalTest {
+
+    @Test
+    fun `given a cached build when the local properties selection is edited then the next run invalidates the cache and registers the new target`(
+        @TempDir dir: Path
+    ) {
+        writeFixture(dir)
+
+        // Build 1: select jvm, store the configuration cache.
+        dir.resolve("kmp-targets.local.properties").writeText("kmptargets.targets=jvm\n")
+        val first = runner(dir).build()
+        assertTrue("Configuration cache entry stored." in first.output, first.output)
+
+        // Build 2: edit ONLY the file (no daemon restart, no -P). Must NOT reuse the cache, and the
+        // newly selected target must now be the registered one.
+        dir.resolve("kmp-targets.local.properties").writeText("kmptargets.targets=iosArm64\n")
+        val second = runner(dir).build()
+        assertFalse("Reusing configuration cache." in second.output, second.output)
+        assertTrue("Registered (selection ∩ supported)" in second.output, second.output)
+        assertTrue("iosArm64" in second.output, second.output)
+    }
+
+    private fun writeFixture(dir: Path) {
+        dir.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture\"\n")
+        dir.resolve("build.gradle.kts")
+            .writeText(
+                """
+                plugins {
+                    id("org.jetbrains.kotlin.multiplatform")
+                    id("com.rsicarelli.kmptargets")
+                }
+
+                repositories { mavenCentral() }
+
+                kmpTargets { supports { jvm + iosArm64 } }
+                """
+                    .trimIndent()
+            )
+    }
+
+    private fun runner(dir: Path): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(dir.toFile())
+            .withPluginClasspath()
+            .withArguments("kmpTargetsInfo", "--configuration-cache")
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
   - 'User Guide':
       - 'Selection DSL': user-guide/selection-dsl.md
       - 'Selection Layers': user-guide/selection-layers.md
+      - 'IDE Workflow': user-guide/ide-workflow.md
       - 'Targets Reference': user-guide/targets-reference.md
       - 'Hierarchy': user-guide/hierarchy-template.md
       - 'Build Logic': user-guide/build-logic.md


### PR DESCRIPTION
## Why

A KotlinConf BR thread surfaced a real devx gap: on a 300+ module build, IDE Sync is slow, and the workflow for "work on one platform at a time" was unclear — including a belief that switching targets needs a `gradlew stop` (daemon kill).

This PR settles the question and documents the answer.

## Proof first

`ConfigCacheSelectionRefreshFunctionalTest` (already on the branch, `a75b6c8`) proves it: two builds against the same project dir (shared on-disk config cache, like an IDE re-sync), editing **only** `kmp-targets.local.properties` between them. The second build **invalidates** the cache and registers the new target — **no `gradlew stop`**.

So the dedicated config files are tracked configuration-cache inputs (as designed). The "kill Gradle" ritual is the symptom of an *untracked* property read; this plugin doesn't have that.

> Caveat: this proves the Gradle layer (the same config-cache mechanism the IDE sync rides), not a literal IntelliJ sync. IDE-side model caching is the one thing left to verify by hand.

## What's in here

- **New page** `docs/user-guide/ide-workflow.md` — the "what do I do?" recipe: pin platform in `kmp-targets.local.properties` → Sync → switch by editing one line. Explains why no daemon kill, and the cost you *can't* avoid (the re-sync itself; the win is the smaller model).
- Wired into mkdocs nav + README docs list.
- Cross-links from **Selection Layers** and a **Troubleshooting** row ("reaching for `gradlew stop`? not needed").

## Checks

- `mkdocs build --strict` passes (no broken links).
- Docs-only + the existing proof test.

## Not in this PR (deferred, per `.claude/CLAUDE.md`)

- a `kmpUse` Gradle task to write the local config
- a visual IDE plugin (target picker)

Each is its own scope — happy to open follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfaEoME3zeus3ZemRyJHgT

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfaEoME3zeus3ZemRyJHgT)_